### PR TITLE
ROU-2294: Toggle is-rtl class on iOS doesn't work well

### DIFF
--- a/src/scss/01-foundations/_resets.scss
+++ b/src/scss/01-foundations/_resets.scss
@@ -39,6 +39,8 @@ html {
 ///
 body {
 	background-color: var(--color-background-body);
+	/// iOS devices loses the direction default value when toggle the RTL on the body element. Added the default property of direction to prevent the issue.
+	direction: ltr;
 	font-size: var(--font-size-s);
 	line-height: 1.5;
 	margin: 0;


### PR DESCRIPTION
Fixed an issue on iOS devices, adding the default property of direction to "ltr" on the body element. This issue is caused when toggle the is-rtl class to the body, the iOS devices lose the default value of direction on the body element.