### PR TITLE
ROU-2475: Added fix for labels inside .rating

### DIFF
--- a/src/scss/04-patterns/05-numbers/_rating.scss
+++ b/src/scss/04-patterns/05-numbers/_rating.scss
@@ -159,6 +159,21 @@
 	}
 }
 
+// Responsive -------------------------------------------------------------------------
+///
+.ios {
+	.rating {
+		.rating-item {
+			//Fix for preventing FastClick issues on iOS
+			// Check here for details: https://github.com/ftlabs/fastclick/issues/60 */
+			& > * {
+				display: block;
+				pointer-events: none;
+			}
+		}
+	}
+}
+
 // IsRTL -------------------------------------------------------------------------
 ///
 .is-rtl {


### PR DESCRIPTION
### What was happening

When using a iOS device, on a native App only, the rating-item is only selectable when tapping twice.

### What was done

`.ios .rating .rating-item > * {
    display: block;
    pointer-events: none;
}`

Added css to affect labels inside the rating element. Solution found here:
https://stackoverflow.com/questions/7358781/tapping-on-label-in-mobile-safari

### Test Steps

1. Open app on ios device
2. Click on ratng-inputs
3. A feedback message appears with the correct current value.

### Checklist

-   [x] tested locally
-   [x] documented the code
-   [x] clean all warnings and errors of eslint
-   [x] requires changes in OutSystems (if so, provide a module with changes)
-   [ ] requires new sample page in OutSystems (if so, provide a module with changes)
