### PR TITLE
Fix rating ss preview

### DIFF
--- a/src/scripts/OSUIFramework/Pattern/Rating/scss/_rating.scss
+++ b/src/scripts/OSUIFramework/Pattern/Rating/scss/_rating.scss
@@ -140,6 +140,20 @@
 		opacity: 1;
 	}
 
+	.icon-states {
+		// Service Studio Preview
+		& {
+			-servicestudio-display: flex;
+		}
+
+		span {
+			// Service Studio Preview
+			& {
+				-servicestudio-display: flex;
+			}
+		}
+	}
+
 	--rating-size: 16px;
 }
 
@@ -148,16 +162,6 @@
 	.rating {
 		span.wcag-hide-text {
 			position: absolute;
-		}
-	}
-}
-
-///
-.icon-states {
-	div[data-block*='Rating'] span {
-		// Service Studio Preview
-		& {
-			-servicestudio-display: flex;
 		}
 	}
 }


### PR DESCRIPTION
This PR is for fixing the preview of the Rating inside Service Studio

### What was happening

When inside a block, the stars appeared on top of each other.

### What was done

Added display-flex to the span inside the .icon-states div, for service studio only.

### Test Steps

1. Open service studio
2. Add rating inside a webblock


### Checklist

-   [x ] tested locally
-   [x ] documented the code
-   [x ] clean all warnings and errors of eslint
-   [ ] requires changes in OutSystems (if so, provide a module with changes)
-   [ ] requires new sample page in OutSystems (if so, provide a module with changes)
