### PR TITLE
A missing selector was added to remove td header on layout native

### DIFF
--- a/src/scss/03-widgets/_table.scss
+++ b/src/scss/03-widgets/_table.scss
@@ -172,6 +172,11 @@
 				vertical-align: inherit;
 				width: auto !important;
 			}
+			
+			td:before {
+				display: none;
+			}
+			
 		}
 	}
 }


### PR DESCRIPTION
Added a missing selector for phone and tablet when using pagination. 

td:before {
     display: none;
}
