### PR TITLE
Section Group - title disappears and section name is not fixed (iOS)

### DIFF
--- a/src/scss/02-layout/_header-layout-native.scss
+++ b/src/scss/02-layout/_header-layout-native.scss
@@ -10,8 +10,8 @@
 	}
 
 	.header {
-		position: sticky;
 		position: -webkit-sticky; //Fix for older iPhones
+		position: sticky;
 		top: 0;
 
 		&-top {
@@ -53,8 +53,8 @@
 
 	.content-bottom {
 		bottom: 0;
-		position: sticky;
 		position: -webkit-sticky; //Fix for older iPhones
+		position: sticky;
 		z-index: 100;
 	}
 

--- a/src/scss/02-layout/_header.scss
+++ b/src/scss/02-layout/_header.scss
@@ -46,8 +46,8 @@
 .fixed-header {
 	.header {
 		left: 0;
-		position: sticky;
 		position: -webkit-sticky; //Fix for older iPhones
+		position: sticky;
 		right: 0;
 		top: 0;
 	}

--- a/src/scss/04-patterns/02-content/_section.scss
+++ b/src/scss/04-patterns/02-content/_section.scss
@@ -24,6 +24,7 @@
 	&-group {
 		&.is--sticky {
 			.section-title {
+				position: -webkit-sticky; //Fix for older iPhones
 				position: sticky;
 				top: calc(var(--section-top-position) + var(--os-safe-area-top));
 				z-index: 90;

--- a/src/scss/04-patterns/04-navigation/_section-index.scss
+++ b/src/scss/04-patterns/04-navigation/_section-index.scss
@@ -10,8 +10,8 @@
 	flex-direction: column;
 
 	&.is--sticky {
-		position: sticky;
 		position: -webkit-sticky; //Fix for older iPhones
+		position: sticky;
 		top: var(--top-position);
 	}
 

--- a/src/scss/05-useful/_positioning.scss
+++ b/src/scss/05-useful/_positioning.scss
@@ -15,6 +15,6 @@
 
 ///
 .sticky {
-	position: sticky;
 	position: -webkit-sticky; //Fix for older iPhones
+	position: sticky;
 }


### PR DESCRIPTION
This PR is for fixing Section Group's sticky position on older iPhones (iOS 12)

### What was happening

- It was reported that on and iPhone 6 with iOS 12.4 the Section Group component. 

### What was done

- The vendor prefix `webkit` was added to all `position:sticky` rules to add this fix on older iPhones.

### Test Steps

1. Open a page with Section Group on an iPhone with iOS 12 or lower.

### Screenshots

![Screen Recording 2021-09-03 at 11 32 04](https://user-images.githubusercontent.com/7048430/131994343-8ddacd8a-8a5b-4fde-bd00-3f01aeec7113.gif)

### Checklist

-   [x] tested locally
-   [x] documented the code
-   [x] clean all warnings and errors of eslint
-   [ ] requires changes in OutSystems (if so, provide a module with changes)
-   [ ] requires new sample page in OutSystems (if so, provide a module with changes)
