### PR TITLE
Added previously deleted rule for responsive tables.

### DIFF
--- a/src/scss/03-widgets/_table.scss
+++ b/src/scss/03-widgets/_table.scss
@@ -172,11 +172,10 @@
 				vertical-align: inherit;
 				width: auto !important;
 			}
-			
+
 			td:before {
 				display: none;
 			}
-			
 		}
 	}
 }
@@ -185,14 +184,14 @@
 .phone {
 	.layout-native {
 		.table {
-			display: block;
-			overflow: auto;
-			position: relative;
-		}
+			:not(.table-responsive) {
+				display: block;
+				overflow: auto;
+				position: relative;
 
-		.table:not(.table-responsive) {
-			td:before {
-				display: none;
+				td:before {
+					display: none;
+				}
 			}
 		}
 	}


### PR DESCRIPTION
This PR is for adding an old rule to render responsive tables.

### What was happening
Responsive tables were being misrendered in Native apps.
![image](https://user-images.githubusercontent.com/7048430/132548774-d7266100-d0cd-49de-bc83-f958d99079c3.png)


### What was done
A previously deleted rule was brought back to the code.

### Screenshots

![image](https://user-images.githubusercontent.com/7048430/132549086-489068d9-90eb-4f8b-b0be-d07360556716.png)
with the "old" rule



### Checklist

-   [x] tested locally
-   [ ] documented the code
-   [x] clean all warnings and errors of eslint
-   [ ] requires changes in OutSystems (if so, provide a module with changes)
-   [ ] requires new sample page in OutSystems (if so, provide a module with changes)
