### PR TITLE
ROU-2547

### DIFF
--- a/src/scss/00-abstract/_setup-border-vars.scss
+++ b/src/scss/00-abstract/_setup-border-vars.scss
@@ -14,7 +14,7 @@ $osui-border-radius-types: 'none' 0, 'soft' 4px, 'rounded' 100px, 'circle' 100%;
 /// Border Radius BoxSides
 $osui-border-radius-box-sides: (
 	'top' 'left' 'right',
-	'right' 'top' 'bottom',
+	'top' 'right' 'left',
 	'bottom' 'left' 'right',
-	'left' 'top' 'bottom'
+	'bottom' 'right' 'left'
 );

--- a/src/scss/00-abstract/_setup-global-vars.scss
+++ b/src/scss/00-abstract/_setup-global-vars.scss
@@ -30,6 +30,8 @@ $osui-devices: 'phone', 'tablet', 'desktop';
 /* ---------------------------------------------------------------------------- */
 /// Box Sides
 $osui-box-sides: 'top', 'right', 'bottom', 'left';
+$osui-box-x-sides: 'right', 'bottom';
+$osui-box-y-sides: 'top', 'bottom';
 
 /// Box Corners
 $osui-box-corners: 'top-left', 'top-right', 'bottom-right', 'bottom-left';


### PR DESCRIPTION
This PR is for fixing the syntax for the css dynamically created to generate border-radius utility-classes

### What was happening
The CSS class ."border-radius-left-soft", its properties' names have the order switched. Should be border-bottom-left-radius and border-top-left-radius instead, causing invalid CSS.

### What was done
Changed the global $osui-border-radius-box-sides var to have correct combinations, only starting with 'top' or 'bottom'

### Checklist

-   [ ] tested locally
-   [ ] documented the code
-   [ ] clean all warnings and errors of eslint
-   [ ] requires changes in OutSystems (if so, provide a module with changes)
-   [ ] requires new sample page in OutSystems (if so, provide a module with changes)
