### PR TITLE
Rating - Fixed removal of bind(this)

### DIFF
--- a/src/scripts/OSUIFramework/Pattern/Rating/Rating.ts
+++ b/src/scripts/OSUIFramework/Pattern/Rating/Rating.ts
@@ -10,6 +10,9 @@ namespace OSUIFramework.Patterns.Rating {
 		private _decimalValue: number;
 		// Store current disable values
 		private _disabled: boolean;
+		// Store the click event with bind(this)
+		// eslint-disable-next-line @typescript-eslint/no-explicit-any
+		private _eventOnRatingClick: any;
 		// Store if the rating value is half
 		private _isHalfValue: boolean;
 		// Store the callback to be used on the OnSelect event
@@ -33,6 +36,7 @@ namespace OSUIFramework.Patterns.Rating {
 			this._disabled = !this.configs.IsEdit;
 			this._ratingInputName = 'rating-' + this.uniqueId;
 			this._ratingHasEventAdded = false;
+			this._eventOnRatingClick = this._ratingOnClick.bind(this);
 		}
 
 		// Medthod that will iterate on the RatingScale, to crate an item for each one
@@ -57,13 +61,13 @@ namespace OSUIFramework.Patterns.Rating {
 			// Check if a event was already added
 			if (this._ratingHasEventAdded) {
 				// If true, remove event
-				this._selfElem.removeEventListener(GlobalEnum.HTMLEvent.Click, this._ratingOnClick.bind(this));
+				this._selfElem.removeEventListener(GlobalEnum.HTMLEvent.Click, this._eventOnRatingClick);
 
 				// And set variable as false
 				this._ratingHasEventAdded = false;
 			} else if (this.configs.IsEdit) {
 				// Otherwise, if there is no event already added and the param IsEdit is true, add new event
-				this._selfElem.addEventListener(GlobalEnum.HTMLEvent.Click, this._ratingOnClick.bind(this));
+				this._selfElem.addEventListener(GlobalEnum.HTMLEvent.Click, this._eventOnRatingClick);
 				// And set variable as true
 				this._ratingHasEventAdded = true;
 			}
@@ -199,7 +203,7 @@ namespace OSUIFramework.Patterns.Rating {
 
 			// remove event listener if any was added
 			if (this._ratingHasEventAdded) {
-				this._selfElem.removeEventListener(GlobalEnum.HTMLEvent.Click, this._ratingOnClick.bind(this));
+				this._selfElem.removeEventListener(GlobalEnum.HTMLEvent.Click, this._eventOnRatingClick);
 			}
 
 			// Remove html from the fieldset


### PR DESCRIPTION
This PR is for fizing the removal of Rating event listeners

### What was happening
Due to the usage of method.bind(this) when adding the listeners, they were not being properly removed on the OnDestroy and IsEdit parameterChange.

### What was done
Followed same approach as more recent patterns, by assigning a variable on the constructor o the method.bind(this). This variable is used to add/remove events.

### Checklist

-   [x ] tested locally
-   [ x] documented the code
-   [x ] clean all warnings and errors of eslint
-   [ ] requires changes in OutSystems (if so, provide a module with changes)
-   [ ] requires new sample page in OutSystems (if so, provide a module with changes)
