### PR TITLE
ROU-2503: Drowpdown styles are broken

### DIFF
--- a/src/scss/03-widgets/_dropdown.scss
+++ b/src/scss/03-widgets/_dropdown.scss
@@ -8,24 +8,6 @@
 	cursor: initial;
 	position: relative;
 
-	&.dropdown-container:after {
-		border: var(--border-size-m) solid var(--color-neutral-7);
-		border-right-width: var(--border-size-none);
-		border-top-width: var(--border-size-none);
-		bottom: 0;
-		box-sizing: border-box;
-		content: '';
-		height: 8px;
-		left: auto;
-		pointer-events: none;
-		position: absolute;
-		right: 16px;
-		top: 15px;
-		transform: rotate(-45deg) translateY(0) translateX(0);
-		transition: all 300ms ease-in-out;
-		width: 8px;
-	}
-
 	& > div,
 	& > select {
 		&.dropdown {
@@ -76,37 +58,6 @@
 			color: var(--color-neutral-6);
 			opacity: 1;
 			pointer-events: none;
-		}
-	}
-
-	// Is expanded
-	&.dropdown-expanded {
-		&.dropdown {
-			&-container:after {
-				border-color: var(--color-primary);
-				transform: rotate(135deg) translateY(-3px) translateX(3px);
-			}
-
-			// Is expanded Down
-			&-expanded-down {
-				& div.dropdown-list {
-					margin-top: var(--space-xs);
-					top: 100% !important;
-				}
-			}
-
-			// Is expanded Up
-			&-expanded-up {
-				& div.dropdown-list {
-					bottom: 100% !important;
-					margin-bottom: var(--space-xs);
-					top: auto !important;
-				}
-			}
-		}
-
-		& > div.dropdown-display {
-			border: var(--border-size-s) solid var(--color-primary);
 		}
 	}
 
@@ -176,6 +127,55 @@
 		& > select.dropdown-display {
 			border: var(--border-size-s) solid var(--color-error);
 		}
+	}
+}
+
+.dropdown-container:after {
+	border: var(--border-size-m) solid var(--color-neutral-7);
+	border-right-width: var(--border-size-none);
+	border-top-width: var(--border-size-none);
+	bottom: 0;
+	box-sizing: border-box;
+	content: '';
+	height: 8px;
+	left: auto;
+	pointer-events: none;
+	position: absolute;
+	right: 16px;
+	top: 15px;
+	transform: rotate(-45deg) translateY(0) translateX(0);
+	transition: all 300ms ease-in-out;
+	width: 8px;
+}
+
+// Is expanded
+.dropdown-expanded {
+	&.dropdown {
+		&-container:after {
+			border-color: var(--color-primary);
+			transform: rotate(135deg) translateY(-3px) translateX(3px);
+		}
+
+		// Is expanded Down
+		&-expanded-down {
+			& div.dropdown-list {
+				margin-top: var(--space-xs);
+				top: 100% !important;
+			}
+		}
+
+		// Is expanded Up
+		&-expanded-up {
+			& div.dropdown-list {
+				bottom: 100% !important;
+				margin-bottom: var(--space-xs);
+				top: auto !important;
+			}
+		}
+	}
+
+	& > div.dropdown-display {
+		border: var(--border-size-s) solid var(--color-primary);
 	}
 }
 


### PR DESCRIPTION
Please check the JIRA issue for more information.

### What was happening
- The new SCSS has a sector with more specificity has the OutSystems UI Theme.

### What was done

- Remove the specificity of the CSS selector

### Test Steps

1. Get the ROU-2503 branch
2. Go to Architecture Dashboard app on dev environment 
3. Replace the old OutsystemsUI CSS file by the new version using CSS URL Replacer 

### Screenshots
![DropdownCSSFixed](https://user-images.githubusercontent.com/25321845/134530579-bd2d12f3-0c7d-429a-8d0a-b6511ad7a211.gif)

### Checklist

-   [x] tested locally
-   [x] documented the code
-   [x] clean all warnings and errors of eslint
-   [ ] requires changes in OutSystems (if so, provide a module with changes)
-   [ ] requires new sample page in OutSystems (if so, provide a module with changes)
