### PR TITLE
Sidebar direction bug

### DIFF
--- a/src/scripts/OSUIFramework/Pattern/Sidebar/Sidebar.ts
+++ b/src/scripts/OSUIFramework/Pattern/Sidebar/Sidebar.ts
@@ -138,7 +138,11 @@ namespace OSUIFramework.Patterns.Sidebar {
 			}
 
 			// Set the direction class
-			Helper.Style.AddClass(this._selfElem, Enum.CssClass.Direction + this._configs.Direction);
+			if (this._direction !== '') {
+				Helper.Style.AddClass(this._selfElem, Enum.CssClass.Direction + this._configs.Direction);
+			} else {
+				Helper.Style.AddClass(this._selfElem, Enum.CssClass.Direction + GlobalEnum.Direction.Right);
+			}
 
 			if (this._width !== '') {
 				Helper.Style.SetStyleAttribute(this._selfElem, Enum.CssProperty.Width, this._configs.Width);


### PR DESCRIPTION
This PR is for fixing an issue when the Direction is set to empty on page load, to make sure the default class is still placed, which is the is-right one.


### Screenshots

(prefer animated gif)

### Checklist

-   [ ] tested locally
-   [ ] documented the code
-   [ ] clean all warnings and errors of eslint
-   [ ] requires changes in OutSystems (if so, provide a module with changes)
-   [ ] requires new sample page in OutSystems (if so, provide a module with changes)
