### PR TITLE
Fix a textarea validation message position issue.

### DIFF
--- a/src/scss/03-widgets/_form.scss
+++ b/src/scss/03-widgets/_form.scss
@@ -5,6 +5,12 @@
 
 ///
 .form {
+	&.OSFillParent {
+		.form-control[class*='ThemeGrid_Width'].not-valid + span.validation-message {
+			left: 22px;
+		}
+	}
+
 	label {
 		margin-bottom: var(--space-s);
 	}
@@ -21,18 +27,18 @@
 		position: relative;
 
 		&.validation-message {
-			display: block;
-			margin: -20px 0 2px;
-			position: relative;
+			bottom: -32px;
+			left: 0;
+			position: absolute;
+			white-space: nowrap;
+			width: 100%;
 		}
 	}
 
 	textarea[data-textarea] {
 		& + span {
 			&.validation-message {
-				margin: -20px 0 0;
-				min-height: 20px;
-				top: -4px;
+				bottom: 7px;
 			}
 		}
 	}
@@ -65,6 +71,12 @@
 span.validation-message {
 	color: var(--color-error);
 	font-size: var(--font-size-xs);
+	margin-left: var(--space-none);
+}
+
+///
+.form-control[class*='ThemeGrid_Width'].not-valid + span.validation-message {
+	left: 10px;
 }
 
 // Responsive --------------------------------------------------------------------


### PR DESCRIPTION
This PR is to fix the validation message position, and also used this task to improve the validation message behaviour, since it was with position absolute and when the validation text is bigger it could be cropped since it was also added as a one line only.

### Screenshots

<img width="856" alt="Screenshot 2021-09-27 at 16 51 06" src="https://user-images.githubusercontent.com/5339917/134942395-f39ef13d-02e9-40f7-b0fa-f901d298bc5a.png">
### Checklist

-   [x] tested locally
-   [x] documented the code
-   [x] clean all warnings and errors of eslint
-   [ ] requires changes in OutSystems (if so, provide a module with changes)
-   [ ] requires new sample page in OutSystems (if so, provide a module with changes)
