### PR TITLE
Update value after destroy

### DIFF
--- a/src/scripts/Providers/NoUiSlider/RangeSlider/RangeSlider.ts
+++ b/src/scripts/Providers/NoUiSlider/RangeSlider/RangeSlider.ts
@@ -290,7 +290,7 @@ namespace Providers.RangeSlider {
 		// Method to remove and destroy RangeSlider instance
 		public updateRangeSlider(): void {
 			if (typeof this._provider === 'object') {
-				// Get value so the the Range Slider kees the same value as before is destroyed
+				// Get value so the the Range Slider keeps the same value as before is destroyed
 				this._configs.InitialValue = this.getValue();
 				this._provider.destroy();
 				this._createProviderRangeSlider();


### PR DESCRIPTION
This PR is for fixing the issue found on testing.

### What was happening
InitialValue wasn't kept on destroy/update method
Too many PipsSteps would break the browser

### What was done
On updateRangeSlider method, now the InitialValue is equal to getValue(), before calling destroy().
Now the PipsSteps are limited to the MaxValue.


### Checklist

-   [ ] tested locally
-   [ ] documented the code
-   [ ] clean all warnings and errors of eslint
-   [ ] requires changes in OutSystems (if so, provide a module with changes)
-   [ ] requires new sample page in OutSystems (if so, provide a module with changes)
