### PR TITLE
ROU-2588 - Accordion Item and Text in BottomBar doesn't centralise at iPhone

### DIFF
--- a/src/scss/03-widgets/_btn.scss
+++ b/src/scss/03-widgets/_btn.scss
@@ -175,8 +175,7 @@
 
 	.bottom-bar {
 		.btn {
-			border-radius: 0;
-			height: 100%;
+			padding-bottom: var(--space-none);
 		}
 	}
 }

--- a/src/scss/04-patterns/02-content/_accordion.scss
+++ b/src/scss/04-patterns/02-content/_accordion.scss
@@ -5,12 +5,12 @@
 
 ///
 [data-block*='AccordionItem'] {
-	&:first-child .section-expandable {
+	&:first-of-type .section-expandable {
 		border-radius: var(--border-radius-soft) var(--border-radius-soft) var(--border-radius-none)
 			var(--border-radius-none);
 	}
 
-	&:last-child .section-expandable {
+	&:last-of-type .section-expandable {
 		border-bottom-width: var(--border-size-s);
 		border-radius: var(--border-radius-none) var(--border-radius-none) var(--border-radius-soft)
 			var(--border-radius-soft);


### PR DESCRIPTION
This PR is for solve a fix into:
- Accordion Item border issue when used inside a list without disableVirtualization=True;
- BottomBar button (.btn) vertical align issue at IOS devices;

### Checklist

-   [x] tested locally
-   [x] documented the code
-   [x] clean all warnings and errors of eslint
-   [ ] requires changes in OutSystems (if so, provide a module with changes)
-   [ ] requires new sample page in OutSystems (if so, provide a module with changes)
