### PR TITLE
Fixed submenu hover on sidemenu deskotp

### DIFF
--- a/src/scss/10-deprecated/_submenu-deprecated.scss
+++ b/src/scss/10-deprecated/_submenu-deprecated.scss
@@ -282,7 +282,7 @@
 				border-bottom: var(--border-size-m) solid transparent;
 
 				&:hover {
-					border-bottom: var(--border-size-m) solid var(--color-primary);
+					border-bottom: var(--border-size-m) solid transparent;
 				}
 			}
 		}


### PR DESCRIPTION
This PR is for fixing the submenu hover on desktop, inside layout-side

### What was happening
layout shift when hovering the submenu-items, due to change on border size.

### What was done
Added rules for hover and noon-hover styles, to make sure border-size is always the same.
Changed only on deprecated version of submenu.

### Checklist

-   [ ] tested locally
-   [ ] documented the code
-   [ ] clean all warnings and errors of eslint
-   [ ] requires changes in OutSystems (if so, provide a module with changes)
-   [ ] requires new sample page in OutSystems (if so, provide a module with changes)
