### PR TITLE
Update app menu selector

### DIFF
--- a/src/scss/02-layout/_menu-layout-side.scss
+++ b/src/scss/02-layout/_menu-layout-side.scss
@@ -47,7 +47,7 @@
 ///
 .desktop {
 	.layout-side {
-		.app-menu-content {
+		&:not(.layout-native) .app-menu-content {
 			left: 0;
 		}
 


### PR DESCRIPTION
This PR is for fixing the visibility of the menu when used on a layout native

### What was happening
- The overlay behavior applied on layout native, appears always open:

### What was done
- Remove the specificity of the selector, by adding a :not condition

### Checklist

-   [X] tested locally
-   [ ] documented the code
-   [ ] clean all warnings and errors of eslint
-   [ ] requires changes in OutSystems (if so, provide a module with changes)
-   [ ] requires new sample page in OutSystems (if so, provide a module with changes)
