### PR TITLE
Add disable styles for button group when is placed on header content

### DIFF
--- a/src/scss/03-widgets/_button-group.scss
+++ b/src/scss/03-widgets/_button-group.scss
@@ -73,6 +73,14 @@
 				border-bottom: var(--border-size-m) solid var(--color-primary);
 				color: var(--color-neutral-10);
 			}
+
+			&[disabled] {
+				color: var(--color-neutral-6);
+
+				&.button-group-selected-item {
+					border-bottom: var(--border-size-m) solid var(--color-neutral-6);
+				}
+			}
 		}
 	}
 }


### PR DESCRIPTION
This PR is for fixing the disabled styles of ButtonGroup

### What was happening
- Missing disabled styles for ButtonGroup when it's placed on header content

### What was done
- Added disable styles for ButtonGroup when is placed on header content

-   [X] tested locally
-   [ ] documented the code
-   [ ] clean all warnings and errors of eslint
-   [ ] requires changes in OutSystems (if so, provide a module with changes)
-   [ ] requires new sample page in OutSystems (if so, provide a module with changes)
