### PR TITLE
Add not validation to css selector for input-small

### DIFF
--- a/src/scss/03-widgets/_inputs-and-textareas.scss
+++ b/src/scss/03-widgets/_inputs-and-textareas.scss
@@ -97,7 +97,7 @@
 .tablet,
 .phone {
 	.form-control {
-		&[data-input] {
+		&[data-input]:not(.input-small) {
 			font-size: var(--font-size-base);
 			height: 48px;
 		}


### PR DESCRIPTION
This PR is for fix the issue on inputs when having input-small class.

### What was happening
- Missing style for the small state on inputs

### What was done
- Added a not condition to [data-input]

### Checklist

-   [X] tested locally
-   [ ] documented the code
-   [ ] clean all warnings and errors of eslint
-   [ ] requires changes in OutSystems (if so, provide a module with changes)
-   [ ] requires new sample page in OutSystems (if so, provide a module with changes)
