### PR TITLE
Add small state to textarea

### DIFF
--- a/src/scss/03-widgets/_inputs-and-textareas.scss
+++ b/src/scss/03-widgets/_inputs-and-textareas.scss
@@ -102,7 +102,7 @@
 			height: 48px;
 		}
 
-		&[data-textarea] {
+		&[data-textarea]:not(.input-small) {
 			font-size: var(--font-size-base);
 			height: auto;
 		}


### PR DESCRIPTION
This PR is for fix the issue on textareas when having input-small class.

[Sample page](url)

### What was happening
- Missing style for the small state on textareas

### What was done
- Added a not condition to [data-textarea]

### Checklist

-   [X] tested locally
-   [ ] documented the code
-   [ ] clean all warnings and errors of eslint
-   [ ] requires changes in OutSystems (if so, provide a module with changes)
-   [ ] requires new sample page in OutSystems (if so, provide a module with changes)
