### PR TITLE
Reviewed position of floating content when has margin applied

### DIFF
--- a/src/scss/04-patterns/02-content/_floating-content.scss
+++ b/src/scss/04-patterns/02-content/_floating-content.scss
@@ -153,6 +153,23 @@
 
 	&-margin {
 		margin: var(--space-l);
+
+		&.floating-content {
+			&-center {
+				left: calc(50% - var(--space-l));
+				top: calc(50% - var(--space-l));
+			}
+
+			&-left,
+			&-right {
+				top: calc(50% - var(--space-l));
+			}
+			&-top,
+			&-bottom,
+			&-center {
+				left: calc(50% - var(--space-l));
+			}
+		}
 	}
 }
 
@@ -265,7 +282,7 @@
 				&,
 				&-left,
 				&-right {
-					bottom: calc(var(--footer-height) + var(--os-safe-area-bottom));
+					bottom: calc(var(--bottom-bar-size) + var(--os-safe-area-bottom));
 				}
 			}
 		}

--- a/src/scss/os-ui-new.scss
+++ b/src/scss/os-ui-new.scss
@@ -223,6 +223,7 @@
 @import '04-patterns/02-content/card-sectioned';
 @import '04-patterns/02-content/chat-message';
 @import '../scripts/OSUIFramework/Pattern/FlipContent/scss/flipcontent';
+@import '04-patterns/02-content/floating-content';
 @import '04-patterns/02-content/list-item-content';
 @import '04-patterns/02-content/section';
 @import '04-patterns/02-content/tag';


### PR DESCRIPTION
This PR is for fixing positions on FloatingCOntent when has the margin behavior applied.

### What was happening
- The calculations of the positioning of FloatingContent doesn't count the margin values;

### What was done
- Added the css to compiled CSS (missing this on dist version);
- Fixing the positions of FloatingContent to have the margin in calculations

### Checklist

-   [X] tested locally
-   [ ] documented the code
-   [ ] clean all warnings and errors of eslint
-   [ ] requires changes in OutSystems (if so, provide a module with changes)
-   [ ] requires new sample page in OutSystems (if so, provide a module with changes)
