### PR TITLE
Added fix for preview

### DIFF
--- a/src/scss/02-layout/_menu.scss
+++ b/src/scss/02-layout/_menu.scss
@@ -9,24 +9,8 @@
 
 	// Service Studio Preview
 	& {
-		-servicestudio-align-items: center;
 		-servicestudio-background-color: var(--header-color);
 		-servicestudio-height: auto !important;
-	}
-}
-
-/* Menu ServiceStudio Preview */
-///
-body {
-	.app-menu-content {
-		// Service Studio Preview
-		& {
-			-servicestudio-align-items: flex-start;
-			-servicestudio-height: 100% !important;
-			-servicestudio-left: 0 !important;
-			-servicestudio-position: relative !important;
-			-servicestudio-width: 100% !important;
-		}
 	}
 }
 
@@ -69,6 +53,67 @@ body {
 	}
 }
 
+///
+.layout-top {
+	.header-content {
+		// Service Studio Preview
+		& {
+			-servicestudio-align-items: center;
+			-servicestudio-flex-direction: row;
+		}
+	}
+}
+
+///
+.layout-side {
+	.aside-navigation {
+		// Service Studio Preview
+		& {
+			-servicestudio-background-color: var(--color-neutral-0);
+			-servicestudio-height: 100%;
+			-servicestudio-position: fixed;
+			-servicestudio-width: var(--side-menu-size);
+			-servicestudio-z-index: 105;
+		}
+
+		& > div {
+			// Service Studio Preview
+			& {
+				-servicestudio-height: 100%;
+			}
+		}
+	}
+
+	.header {
+		.app-menu-content {
+			// Service Studio Preview
+			& {
+				-servicestudio-flex-direction: row;
+				-servicestudio-position: static;
+				-servicestudio-width: 100%;
+			}
+		}
+
+		.app-menu-links {
+			// Service Studio Preview
+			& {
+				-servicestudio-align-items: center;
+				-servicestudio-flex-direction: row;
+			}
+		}
+	}
+
+	.header-navigation {
+		& > div {
+			// Service Studio Preview
+			& {
+				-servicestudio-height: 100%;
+				-servicestudio-width: 100%;
+			}
+		}
+	}
+}
+
 // Responsive --------------------------------------------------------------------
 ///
 .desktop {
@@ -107,6 +152,16 @@ body {
 	.menu-visible .app-menu-content {
 		transform: translateX(var(--side-menu-size)) translateZ(0);
 		transition: transform 330ms ease-out;
+	}
+
+	.layout-side {
+		.header .app-menu-content,
+		.aside-navigation {
+			// Service Studio Preview
+			& {
+				-servicestudio-display: none;
+			}
+		}
 	}
 }
 

--- a/src/scss/08-servicestudio-preview/_servicestudiopreview.scss
+++ b/src/scss/08-servicestudio-preview/_servicestudiopreview.scss
@@ -78,7 +78,6 @@ html[data-uieditorversion^='1'] {
 
 	body.phone .layout .app-menu-content,
 	body.tablet .layout .app-menu-content,
-	.layout-side .header .app-menu-content,
 	body:not(.phone):not(.tablet) .layout-side .menu-icon {
 		-servicestudio-display: none;
 	}


### PR DESCRIPTION
This PR is for fixing the preview on Service Studio (legacy and Hybrid) for SideMenu layout (desktop, phone & tablet views)


### What was happening
Menu on Header placeholder was invisible on Hybrid version
Whole layout was messed up on Legacy IDE


### Checklist

-   [ ] tested locally
-   [ ] documented the code
-   [ ] clean all warnings and errors of eslint
-   [ ] requires changes in OutSystems (if so, provide a module with changes)
-   [ ] requires new sample page in OutSystems (if so, provide a module with changes)
