### PR TITLE
Tooltip Position Issues

### DIFF
--- a/src/scripts/OSUIFramework/Pattern/Tooltip/scss/_tooltip.scss
+++ b/src/scripts/OSUIFramework/Pattern/Tooltip/scss/_tooltip.scss
@@ -114,6 +114,7 @@ $osui-tooltip-arrow-size: 8px;
 		position: absolute;
 		top: 100%;
 		transition: opacity 0.25s;
+		z-index: 1;
 
 		// Service Studio Preview
 		& {
@@ -254,7 +255,7 @@ $osui-tooltip-arrow-size: 8px;
 			.osui-tooltip_balloon {
 				left: initial;
 				right: calc(-1 * var(--space-s));
-				transform: translateX(-100%);
+				transform: translateX(100%);
 
 				&:before {
 					border-color: transparent transparent transparent var(--color-neutral-9);


### PR DESCRIPTION
This PR is for fix a position issues at the Tooltip

### What was happening

- There was an issue related with the z-index;
- There also was an issue related with the horizontal position that was prevent Tooltip to assume the left position since the implementation logic was "saying" that tooltip doesn't fit at the left side (it was too big) - This was happening because ballon position (when it's closed) was outside the screen at the left side!

### What was done

- Set the z-index;
- Place the ballon into the correct position when it's closed;

### Checklist

-   [x] tested locally
-   [x] documented the code
-   [x] clean all warnings and errors of eslint
-   [ ] requires changes in OutSystems (if so, provide a module with changes)
-   [ ] requires new sample page in OutSystems (if so, provide a module with changes)
