### PR TITLE
Fixed Table preview

### DIFF
--- a/src/scss/03-widgets/_table.scss
+++ b/src/scss/03-widgets/_table.scss
@@ -117,12 +117,22 @@
 
 		thead {
 			display: none;
+
+			// Service Studio Preview
+			& {
+				-servicestudio-display: table-header-group;
+			}
 		}
 	}
 
 	tr,
 	td {
 		display: block;
+
+		// Service Studio Preview
+		& {
+			-servicestudio-display: table-row;
+		}
 	}
 
 	tr {
@@ -188,6 +198,11 @@
 				display: block;
 				overflow: auto;
 				position: relative;
+
+				// Service Studio Preview
+				& {
+					-servicestudio-display: table;
+				}
 
 				td:before {
 					display: none;


### PR DESCRIPTION
This PR is for fixing the tables preview on Service Studio, when using the phone view on Reactive Apps and on Native Apps.


### What was happening

![image](https://user-images.githubusercontent.com/32780808/138069502-839c02eb-622b-4e54-82ed-020ad3811cb4.png)


### What was done

- Added css to counter the rules for the responsive tables.

### Test Steps

1. Drag a table widget to the screens, using apps ROU2653Reactive and ROU2653Native (already with Theme from branch).

### Checklist

-   [x] tested locally
-   [x] documented the code
-   [x] clean all warnings and errors of eslint
-   [x] requires changes in OutSystems (if so, provide a module with changes)
-   [x] requires new sample page in OutSystems (if so, provide a module with changes)
