### PR TITLE
Button loading safari issue

### DIFF
--- a/src/scripts/OSUIFramework/Pattern/ButtonLoading/scss/_button-loading.scss
+++ b/src/scripts/OSUIFramework/Pattern/ButtonLoading/scss/_button-loading.scss
@@ -33,11 +33,11 @@
 	}
 
 	&.is--loading {
+		pointer-events: none;
+
 		.btn {
-			&,
-			& * {
-				pointer-events: none;
-			}
+			display: inline-block;
+			pointer-events: none;
 		}
 	}
 


### PR DESCRIPTION
This PR is to solve an issue at safari!

### What was happening

- After the previous PR the issue remains.

### What was done

- In order to pointer events properly work at safari, all the links and buttons must also have a **display: inline-block | block**.
