### PR TITLE
ROU-2680

### DIFF
--- a/src/scss/03-widgets/_table.scss
+++ b/src/scss/03-widgets/_table.scss
@@ -14,6 +14,11 @@
 	word-break: keep-all;
 
 	&-header {
+		// Service Studio Preview
+		& {
+			-servicestudio-border-bottom: none !important;
+		}
+
 		th {
 			background-color: var(--color-neutral-0);
 			border-bottom: var(--border-size-s) solid var(--color-neutral-4);
@@ -22,6 +27,11 @@
 			height: 48px;
 			padding: var(--space-none) var(--space-m);
 			text-align: left;
+
+			// Service Studio Preview
+			& {
+				-servicestudio-width: 100%;
+			}
 
 			&:first-child {
 				border-radius: var(--border-radius-soft) var(--border-radius-none) var(--border-radius-none)

--- a/src/scss/08-servicestudio-preview/_servicestudiopreview.scss
+++ b/src/scss/08-servicestudio-preview/_servicestudiopreview.scss
@@ -82,6 +82,12 @@ html[data-uieditorversion^='1'] {
 		-servicestudio-display: none;
 	}
 
+	.table {
+		tr:empty {
+			-servicestudio-display: block !important;
+		}
+	}
+
 	.blank-slate {
 		> div {
 			-servicestudio-display: flex;
@@ -109,50 +115,56 @@ html[data-uieditorversion^='1'] {
 			}
 		}
 	}
+
+	.phone {
+		.layout:not(.layout-native) {
+			.table {
+				-servicestudio-display: block;
+
+				td {
+					-servicestudio-min-width: 100vw;
+				}
+			}
+
+			thead {
+				-servicestudio-display: initial !important;
+			}
+		}
+	}
+
+	.phone,
+	.tablet {
+		.layout:not(.layout-native) {
+			thead {
+				& > tr {
+					-servicestudio-position: relative;
+				}
+
+				& > tr:not(:empty):before {
+					-servicestudio-position: absolute;
+					-servicestudio-left: 0;
+					-servicestudio-top: 0;
+					-servicestudio-background-color: var(--color-neutral-3);
+					-servicestudio-width: 100%;
+					-servicestudio-height: 100%;
+					-servicestudio-content: 'Table Header is hidden on responsive devices';
+					-servicestudio-z-index: 1;
+					-servicestudio-display: flex;
+					-servicestudio-align-items: center;
+					-servicestudio-justify-content: center;
+					-servicestudio-font-weight: var(--font-semi-bold);
+				}
+			}
+		}
+	}
 }
 
-// Table Preview MISSING SCSS NESTING
-html[data-uieditorversion^='1'] .phone .layout:not(.layout-native) .table {
-	-servicestudio-display: block;
-}
-html[data-uieditorversion^='1'] .phone .layout:not(.layout-native) .table td {
-	-servicestudio-min-width: 100vw;
-}
-html[data-uieditorversion^='1'] .phone .layout:not(.layout-native) thead > tr,
-html[data-uieditorversion^='1'] .tablet .layout:not(.layout-native) thead > tr {
-	-servicestudio-position: relative;
-}
-html[data-uieditorversion^='1'] .phone .layout:not(.layout-native) thead {
-	-servicestudio-display: initial !important;
-}
-html[data-uieditorversion^='1'] .phone .layout:not(.layout-native) thead > tr:not(:empty):before,
-html[data-uieditorversion^='1'] .tablet .layout:not(.layout-native) thead > tr:not(:empty):before {
-	-servicestudio-position: absolute;
-	-servicestudio-left: 0;
-	-servicestudio-top: 0;
-	-servicestudio-background-color: var(--color-neutral-3);
-	-servicestudio-width: 100%;
-	-servicestudio-height: 100%;
-	-servicestudio-content: 'Table Header is hidden on responsive devices';
-	-servicestudio-z-index: 1;
-	-servicestudio-display: flex;
-	-servicestudio-align-items: center;
-	-servicestudio-justify-content: center;
-	-servicestudio-font-weight: var(--font-semi-bold);
-}
-html[data-uieditorversion^='1'] .table tr:empty {
-	-servicestudio-display: block !important;
-}
-.table th {
-	-servicestudio-width: 100%;
-}
-html:not([data-uieditorversion^='1']) .phone td,
-html:not([data-uieditorversion^='1']) .tablet td {
-	-servicestudio-display: table-cell;
-}
-.table-header {
-	-servicestudio-border-bottom: none !important;
-}
-html:not([data-uieditorversion^='1']) .table {
-	-servicestudio-white-space: unset;
+html:not([data-uieditorversion^='1']) {
+	.phone td,
+	.tablet td {
+		-servicestudio-display: table-cell;
+	}
+	.table {
+		-servicestudio-white-space: unset;
+	}
 }


### PR DESCRIPTION
This PR is for fixing the Table Preview across the IDE Legacy and IDE Hybrid, with the table empty or with data.


### What was happening
- Preview image was cut on Legacy and invisible on Hybrid.
- Preview with data on the table was totally broken on responsive devices.

### What was done

- On hybrid, as it render equal to runtime, it was created a before element with a message warning the header is not visible, to avoid conflicts with platform's CSS to add preview image on tr:empty.
- On Legacy, the same behavior as before was kept, as we can't totally emulate the same UI as in runtime.

### Test Steps

1. Add table to screen.
2. Preview image is visible.
3. Switch between different device views.
4. Add data to table.
5. UI is not broken.

### Checklist

-   [ ] tested locally
-   [ ] documented the code
-   [ ] clean all warnings and errors of eslint
-   [ ] requires changes in OutSystems (if so, provide a module with changes)
-   [ ] requires new sample page in OutSystems (if so, provide a module with changes)
