### PR TITLE
ROU-2468

### DIFF
--- a/src/scss/03-widgets/_dropdown.scss
+++ b/src/scss/03-widgets/_dropdown.scss
@@ -182,6 +182,13 @@ select.dropdown-display[disabled] {
 	select.dropdown-display {
 		font-size: var(--font-size-base);
 		height: 48px;
+
+		.dropdown-display-content {
+			& > span,
+			& > div {
+				font-size: var(--font-size-base);
+			}
+		}
 	}
 }
 


### PR DESCRIPTION
This PR is for fixing font-size issues on the native dropdown while in phone and tablet.

### What was happening

- When in phone and tablet, the font-size of the native dropdown was not the same as the font-size used in dropdown search/tags

### What was done

- CSS to override the font-size when in phone and tablet.


### Checklist

-   [x] tested locally
-   [x] documented the code
-   [x] clean all warnings and errors of eslint
-   [ ] requires changes in OutSystems (if so, provide a module with changes)
-   [ ] requires new sample page in OutSystems (if so, provide a module with changes)
