### PR TITLE
Rou 2467

### DIFF
--- a/src/scss/03-widgets/_table.scss
+++ b/src/scss/03-widgets/_table.scss
@@ -133,43 +133,43 @@
 				-servicestudio-display: table-header-group;
 			}
 		}
+	}
 
-		tr,
-		td {
+	tr,
+	td {
+		display: block;
+
+		// Service Studio Preview
+		& {
+			-servicestudio-display: table-row !important;
+		}
+	}
+
+	tr {
+		border-bottom: var(--border-size-s) solid var(--color-neutral-4);
+	}
+
+	td {
+		border-bottom: 0;
+		display: flex;
+		height: auto;
+		position: relative;
+		text-align: left !important;
+		width: 100% !important;
+
+		&:before {
+			content: attr(data-header);
 			display: block;
-
-			// Service Studio Preview
-			& {
-				-servicestudio-display: table-row !important;
-			}
+			font-weight: bold;
+			margin-right: 10px;
+			max-width: 110px;
+			min-width: 110px;
+			word-break: break-word;
 		}
 
-		tr {
-			border-bottom: var(--border-size-s) solid var(--color-neutral-4);
-		}
-
-		td {
-			border-bottom: 0;
-			display: flex;
-			height: auto;
-			position: relative;
-			text-align: left !important;
-			width: 100% !important;
-
+		&:not([data-header]) {
 			&:before {
-				content: attr(data-header);
-				display: block;
-				font-weight: bold;
-				margin-right: 10px;
-				max-width: 110px;
-				min-width: 110px;
-				word-break: break-word;
-			}
-
-			&:not([data-header]) {
-				&:before {
-					display: none;
-				}
+				display: none;
 			}
 		}
 	}


### PR DESCRIPTION
This PR is for the improvement of our table styles to look properly within all devices.

### What was done

- Changed the architecture of tables on mobile devices at _tables.scss  
- Suggestion: Word-break should be activated. Without this, users could not view the information that was too large to fit inside the screen. 

### Test Steps

1. Open the test page on Desktop and Mobile in order to visualize the effects of the implemented selectors.

### Screenshots

Native App
- First table with the .table-responsive selector activated
- Second table with the default behavior

![image](https://user-images.githubusercontent.com/90854874/139099012-ff4489a0-dbe1-4cf3-b05b-ee9f2bfa43b9.png)


Reactive App
- First table with the .table-no-responsive selector activated
- Second table with the default behavior

![image](https://user-images.githubusercontent.com/90854874/139099035-9440a277-5e78-47f7-b19a-d29e098b3419.png)


### Checklist

-   [x] tested locally
-   [ ] documented the code
-   [ ] clean all warnings and errors of eslint
-   [x] requires changes in OutSystems (if so, provide a module with changes)
-   [ ] requires new sample page in OutSystems (if so, provide a module with changes)
