### PR TITLE
Rou 2467: word break issue fixed

### DIFF
--- a/src/scss/03-widgets/_table.scss
+++ b/src/scss/03-widgets/_table.scss
@@ -170,7 +170,6 @@
 			position: relative;
 			text-align: left !important;
 			width: 100% !important;
-			height: 56px;
 
 			&:before {
 				content: attr(data-header);
@@ -207,7 +206,6 @@
 				padding: var(--space-s) var(--space-m);
 				vertical-align: inherit;
 				width: auto !important;
-				height: 56px;
 			}
 
 			td:before {


### PR DESCRIPTION
This PR is a minor fix for a specific issue regarding table responsiveness in iOS devices.

### What was happening

This was not the expected behavior:
![image](https://user-images.githubusercontent.com/90854874/139834750-22d66820-28b7-4512-a243-e0f9ad6d675e.png)

### What was done

- Word break property was fixed;

### Test Steps

1. Tested on a native app.

### Screenshots

![image](https://user-images.githubusercontent.com/90854874/139835156-9413e6e1-f7b6-419c-a6a1-62d0cfec0252.png)

### Checklist

-   [x] tested locally
-   [ ] documented the code
-   [ ] clean all warnings and errors of eslint
-   [x] requires changes in OutSystems (if so, provide a module with changes)
-   [ ] requires new sample page in OutSystems (if so, provide a module with changes)
