### PR TITLE
RangeSlier - remove background-color from tooltip

### DIFF
--- a/src/scripts/OSUIFramework/Pattern/RangeSlider/scss/_rangeslider.scss
+++ b/src/scripts/OSUIFramework/Pattern/RangeSlider/scss/_rangeslider.scss
@@ -250,7 +250,7 @@
 		}
 
 		&-tooltip {
-			background: var(--color-neutral-0);
+			background: transparent;
 			border: none;
 			color: var(--color-neutral-10);
 			padding: var(--space-xs);


### PR DESCRIPTION
This PR is for removing the white background on the range slider's tooltip.

### Checklist

-   [ ] tested locally
-   [ ] documented the code
-   [ ] clean all warnings and errors of eslint
-   [ ] requires changes in OutSystems (if so, provide a module with changes)
-   [ ] requires new sample page in OutSystems (if so, provide a module with changes)
