### PR TITLE
ROU-2714 - Added styles for disabled tooltip

### DIFF
--- a/src/scripts/OSUIFramework/Pattern/RangeSlider/scss/_rangeslider.scss
+++ b/src/scripts/OSUIFramework/Pattern/RangeSlider/scss/_rangeslider.scss
@@ -318,6 +318,10 @@
 					color: var(--color-neutral-6);
 				}
 			}
+
+			.noUi-tooltip {
+				color: var(--color-neutral-6);
+			}
 		}
 	}
 }


### PR DESCRIPTION
This PR is for adding disabled styles on the tooltip from RangeSlider

![image](https://user-images.githubusercontent.com/32780808/140724018-b8d89018-aa42-4782-a349-35f5bf1bb5d6.png)


### Checklist

-   [ ] tested locally
-   [ ] documented the code
-   [ ] clean all warnings and errors of eslint
-   [ ] requires changes in OutSystems (if so, provide a module with changes)
-   [ ] requires new sample page in OutSystems (if so, provide a module with changes)
