### PR TITLE
Removed CSS specificity at Pagination

### DIFF
--- a/src/scss/04-patterns/04-navigation/_pagination.scss
+++ b/src/scss/04-patterns/04-navigation/_pagination.scss
@@ -10,11 +10,6 @@
 	justify-content: space-between;
 	margin-top: var(--space-m);
 
-	// pagination-counter
-	&-counter {
-		color: var(--color-neutral-7);
-	}
-
 	// pagination-container
 	&-container {
 		align-items: center;
@@ -77,8 +72,10 @@
 		}
 	}
 
-	// With ShowGoToPage parameter, this container is in this context
+	// pagination-counter
 	&-counter {
+		color: var(--color-neutral-7);
+		// With ShowGoToPage parameter, this container is in this context
 		margin-left: var(--space-s);
 	}
 


### PR DESCRIPTION
This PR is for remove CSS specificity in order to avoid issues on users custom styling.

### What was happening

- According reported the new CSS version was generating more specific CSS selectors at the pagination pattern which  could be an issue for some users that are adding custom styles to pagination.

### What was done

- Based on old theme specificity has been removed.

### Checklist

-   [x] tested locally
-   [ ] documented the code
-   [x] clean all warnings and errors of eslint
-   [ ] requires changes in OutSystems (if so, provide a module with changes)
-   [ ] requires new sample page in OutSystems (if so, provide a module with changes)
