### PR TITLE
ROU-2718 - Added display: block to ph:empty on IDE

### DIFF
--- a/src/scss/08-servicestudio-preview/_servicestudiopreview.scss
+++ b/src/scss/08-servicestudio-preview/_servicestudiopreview.scss
@@ -82,6 +82,10 @@ html[data-uieditorversion^='1'] {
 		-servicestudio-display: none;
 	}
 
+	.ph:empty {
+		-servicestudio-display: block;
+	}
+
 	.table {
 		tr:empty {
 			-servicestudio-display: block !important;


### PR DESCRIPTION
This PR is for fixing a issue on the latest development version of Hybrid IDE, causing empty placeholders to not be visible on Design Time. As this is a rule added by us, this new line of css was added just for the Hybrid preview.

### Checklist

-   [ ] tested locally
-   [ ] documented the code
-   [ ] clean all warnings and errors of eslint
-   [ ] requires changes in OutSystems (if so, provide a module with changes)
-   [ ] requires new sample page in OutSystems (if so, provide a module with changes)
