### PR TITLE
ROU-2723: Button Loading - Fix an issue related with selector specificity.

### DIFF
--- a/src/scripts/OSUIFramework/Pattern/ButtonLoading/scss/_button-loading.scss
+++ b/src/scripts/OSUIFramework/Pattern/ButtonLoading/scss/_button-loading.scss
@@ -6,7 +6,7 @@
 /* -------------------------------------------------------------------------------
 NOTE:
 .btn-show-label, .btn-loading & .btn-label and this 
-section are used to retrocompatilibilty --------------------------------------- */
+------------------------------------------------------------------------------- */
 .is--loading {
 	.btn {
 		pointer-events: none;
@@ -18,6 +18,24 @@ section are used to retrocompatilibilty --------------------------------------- 
 
 	.btn-label {
 		opacity: 0;
+	}
+
+	&:not(.btn-show-label) {
+		.btn {
+			.btn-loading {
+				.loading-spinner {
+					margin: 0;
+				}
+			}
+		}
+	}
+
+	&.show-spinner-only {
+		.btn {
+			.loading-spinner {
+				margin: 0;
+			}
+		}
 	}
 }
 
@@ -39,7 +57,6 @@ section are used to retrocompatilibilty --------------------------------------- 
 		opacity: 1;
 	}
 }
-// -------------------------------------------------------------------------------
 
 ///
 .osui-btn-loading {
@@ -105,27 +122,6 @@ section are used to retrocompatilibilty --------------------------------------- 
 
 		.loading-spinner {
 			@extend %loading-spinner;
-		}
-	}
-}
-
-///
-.is--loading {
-	&:not(.btn-show-label) {
-		.btn {
-			.btn-loading {
-				.loading-spinner {
-					margin: 0;
-				}
-			}
-		}
-	}
-
-	&.show-spinner-only {
-		.btn {
-			.loading-spinner {
-				margin: 0;
-			}
 		}
 	}
 }


### PR DESCRIPTION
This PR is for fix an issue related with the increased selector specificity.

### What was happening
- Since the button loading has a new css selector and a new structure, the specificity has increased. That way some custom styles were being override.

### What was done
- Changed css styles structure in order to be possible to use the new selector and maintaining the retrocompatibility.


### Checklist
-   [x] tested locally
-   [x] documented the code
-   [x] clean all warnings and errors of eslint
-   [ ] requires changes in OutSystems (if so, provide a module with changes)
-   [ ] requires new sample page in OutSystems (if so, provide a module with changes)
