### PR TITLE
ROU-2690: Tolltip Fixed

### DIFF
--- a/src/scripts/OSUIFramework/Pattern/Tooltip/scss/_tooltip.scss
+++ b/src/scripts/OSUIFramework/Pattern/Tooltip/scss/_tooltip.scss
@@ -4,7 +4,7 @@
 /// Patterns - Content - Tooltip
 
 // myCustom tooltip variables
-$osui-tooltip-arrow-size: 8px;
+$osui-tooltip-arrow-size: 9px;
 
 ///
 .osui-tooltip {
@@ -178,7 +178,7 @@ $osui-tooltip-arrow-size: 8px;
 				&:before {
 					border-color: var(--color-neutral-9) transparent transparent transparent;
 					border-width: $osui-tooltip-arrow-size $osui-tooltip-arrow-size 0 $osui-tooltip-arrow-size;
-					bottom: 0;
+					bottom: 1px;
 					top: initial;
 				}
 			}
@@ -311,7 +311,7 @@ $osui-tooltip-arrow-size: 8px;
 			left: var(--space-s);
 			opacity: 0;
 			position: absolute;
-			top: 0;
+			top: 1px;
 			transform: translateY(0);
 			width: 0;
 		}

--- a/src/scss/10-deprecated/_tooltip-deprecated.scss
+++ b/src/scss/10-deprecated/_tooltip-deprecated.scss
@@ -44,8 +44,8 @@
 			}
 
 			&:after {
-				border: 7px solid transparent;
-				border-top: 7px solid var(--color-neutral-9);
+				border: 8px solid transparent;
+				border-top: 8px solid var(--color-neutral-9);
 				bottom: -14px;
 				content: '';
 				height: 0;
@@ -60,8 +60,8 @@
 				right: calc(100% - var(--space-m));
 
 				&:after {
-					border: 7px solid transparent;
-					border-top: 7px solid var(--color-neutral-9);
+					border: 8px solid transparent;
+					border-top: 8px solid var(--color-neutral-9);
 					bottom: -14px;
 					content: '';
 					height: 0;
@@ -76,8 +76,8 @@
 				left: calc(100% - var(--space-m));
 
 				&:after {
-					border: 7px solid transparent;
-					border-top: 7px solid var(--color-neutral-9);
+					border: 8px solid transparent;
+					border-top: 8px solid var(--color-neutral-9);
 					bottom: -14px;
 					content: '';
 					height: 0;
@@ -94,8 +94,8 @@
 			transform: translateX(-50%);
 
 			&:after {
-				border: 7px solid transparent;
-				border-bottom: 7px solid var(--color-neutral-9);
+				border: 8px solid transparent;
+				border-bottom: 8px solid var(--color-neutral-9);
 				content: '';
 				height: 0;
 				left: 50%;
@@ -110,8 +110,8 @@
 				top: calc(100% + var(--space-s));
 
 				&:after {
-					border: 7px solid transparent;
-					border-bottom: 7px solid var(--color-neutral-9);
+					border: 8px solid transparent;
+					border-bottom: 8px solid var(--color-neutral-9);
 					content: '';
 					height: 0;
 					position: absolute;
@@ -126,8 +126,8 @@
 				top: calc(100% + var(--space-s));
 
 				&:after {
-					border: 7px solid transparent;
-					border-bottom: 7px solid var(--color-neutral-9);
+					border: 8px solid transparent;
+					border-bottom: 8px solid var(--color-neutral-9);
 					content: '';
 					height: 0;
 					left: 7px;
@@ -144,8 +144,8 @@
 			transform: translateY(-50%);
 
 			&:after {
-				border: 7px solid transparent;
-				border-left: 7px solid var(--color-neutral-9);
+				border: 8px solid transparent;
+				border-left: 8px solid var(--color-neutral-9);
 				content: '';
 				height: 0;
 				left: 100%;
@@ -162,8 +162,8 @@
 			transform: translateY(-50%);
 
 			&:after {
-				border: 7px solid transparent;
-				border-right: 7px solid var(--color-neutral-9);
+				border: 8px solid transparent;
+				border-right: 8px solid var(--color-neutral-9);
 				content: '';
 				height: 0;
 				position: absolute;


### PR DESCRIPTION
This PR is to fix the tooltip behavior when zooming the window inside the browser.

### What was happening

- On Firefox and Chrome, Tooltip arrow had 1px gap in different scenarios.

### What was done

- The border-width, top and bottom properties were modified in order to fix this issue.

### Test Steps

1. Tested the new implementation on two pages (either for the old tooltip and the new tooltip) using different browsers and zoom percentages.

### Checklist

-   [x] tested locally
-   [ ] documented the code
-   [ ] clean all warnings and errors of eslint
-   [x] requires changes in OutSystems (if so, provide a module with changes)
-   [ ] requires new sample page in OutSystems (if so, provide a module with changes)
