### PR TITLE
ROU-2690: Tooltip gap fixed

### DIFF
--- a/src/scripts/OSUIFramework/Pattern/Tooltip/scss/_tooltip.scss
+++ b/src/scripts/OSUIFramework/Pattern/Tooltip/scss/_tooltip.scss
@@ -238,7 +238,7 @@ $osui-tooltip-arrow-size: 9px;
 					border-color: transparent var(--color-neutral-9) transparent transparent;
 					border-width: $osui-tooltip-arrow-size $osui-tooltip-arrow-size $osui-tooltip-arrow-size 0;
 					left: initial;
-					right: 100%;
+					right: calc(100% - 1px);
 					top: 50%;
 					transform: translate(0, -50%);
 				}
@@ -260,7 +260,7 @@ $osui-tooltip-arrow-size: 9px;
 				&:before {
 					border-color: transparent transparent transparent var(--color-neutral-9);
 					border-width: $osui-tooltip-arrow-size 0 $osui-tooltip-arrow-size $osui-tooltip-arrow-size;
-					left: 100%;
+					left: calc(100% - 1px);
 					right: initial;
 				}
 			}

--- a/src/scss/10-deprecated/_tooltip-deprecated.scss
+++ b/src/scss/10-deprecated/_tooltip-deprecated.scss
@@ -148,7 +148,7 @@
 				border-left: 8px solid var(--color-neutral-9);
 				content: '';
 				height: 0;
-				left: 100%;
+				left: calc(100% - 1px);
 				position: absolute;
 				top: 50%;
 				transform: translateY(-50%);
@@ -167,7 +167,7 @@
 				content: '';
 				height: 0;
 				position: absolute;
-				right: 100%;
+				right: calc(100% - 1px);
 				top: 50%;
 				transform: translateY(-50%);
 				width: 0;


### PR DESCRIPTION
This PR is to fix a gap found on tooltip left and tooltip right when users zoomed in on PWA's.

### What was happening

![image](https://user-images.githubusercontent.com/90854874/141976246-b3718b5e-928c-491f-b525-6f15159ec9b3.png)

### What was done

- CSS selectors were modified in order to achieve the following behavior:
![image](https://user-images.githubusercontent.com/90854874/141976295-61cb559d-0036-45c1-808b-306d8f9632d3.png)


### Checklist

-   [x] tested locally
-   [ ] documented the code
-   [ ] clean all warnings and errors of eslint
-   [x] requires changes in OutSystems (if so, provide a module with changes)
-   [ ] requires new sample page in OutSystems (if so, provide a module with changes)
