### PR TITLE
Fixes on AccordionItem animation

### DIFF
--- a/src/scripts/OSUIFramework/Pattern/AccordionItem/AccordionItem.ts
+++ b/src/scripts/OSUIFramework/Pattern/AccordionItem/AccordionItem.ts
@@ -288,7 +288,8 @@ namespace OSUIFramework.Patterns.AccordionItem {
 
 			const expandedHeight = this._accordionContent.getBoundingClientRect().height;
 
-			Helper.Style.AddClass(this._accordionContent, Enum.CssClass.Expanded);
+			Helper.Style.AddClass(this._accordionContent, Enum.CssClass.Collapsed);
+			Helper.Style.RemoveClass(this._accordionContent, Enum.CssClass.Expanded);
 
 			Helper.Style.SetStyleAttribute(this._accordionContent, 'height', collapsedHeight + GlobalEnum.Units.Pixel);
 


### PR DESCRIPTION
While applying changes requested on the original PR, the classes that were used to animate the item's open action were wrongly applied. This PR fixes those classes, restoring the animation to its original state.