### PR TITLE
ROU-2765: fix tables on hybrid IDE

### DIFF
--- a/src/scss/08-servicestudio-preview/_servicestudiopreview.scss
+++ b/src/scss/08-servicestudio-preview/_servicestudiopreview.scss
@@ -126,7 +126,21 @@ html[data-uieditorversion^='1'] {
 				-servicestudio-display: block;
 
 				td {
-					-servicestudio-min-width: 100vw;
+					-servicestudio-min-width: 10vw;
+				}
+
+				&:not(.table-no-responsive) {
+					th {
+						-servicestudio-display: none;
+					}
+				}
+			}
+
+			.table-no-responsive {
+				thead {
+					& > tr:not(:empty):before {
+						-servicestudio-display: none;
+					}
 				}
 			}
 
@@ -145,18 +159,13 @@ html[data-uieditorversion^='1'] {
 				}
 
 				& > tr:not(:empty):before {
-					-servicestudio-position: absolute;
-					-servicestudio-left: 0;
-					-servicestudio-top: 0;
-					-servicestudio-background-color: var(--color-neutral-3);
-					-servicestudio-width: 100%;
-					-servicestudio-height: 100%;
-					-servicestudio-content: 'Table Header is hidden on responsive devices';
-					-servicestudio-z-index: 1;
-					-servicestudio-display: flex;
-					-servicestudio-align-items: center;
-					-servicestudio-justify-content: center;
-					-servicestudio-font-weight: var(--font-semi-bold);
+					-servicestudio-display: none;
+				}
+			}
+
+			.table-no-responsive {
+				thead {
+					-servicestudio-display: table-header-group;
 				}
 			}
 		}


### PR DESCRIPTION
This PR is to fix tables preview on hybrid IDE.

### What was happening

- On hybrid IDE tables did not have the expected behavior

### What was done

- Modifications were done at the level of our hybrid css selectors.

### Test Steps

1. Tested on a sandbox app.

### Checklist

-   [x] tested locally
-   [ ] documented the code
-   [ ] clean all warnings and errors of eslint
-   [x] requires changes in OutSystems (if so, provide a module with changes)
-   [ ] requires new sample page in OutSystems (if so, provide a module with changes)
