### PR TITLE
ROU-2766: Tabs fixed

### DIFF
--- a/src/scss/04-patterns/04-navigation/_tabs.scss
+++ b/src/scss/04-patterns/04-navigation/_tabs.scss
@@ -7,6 +7,8 @@
 .tabs {
 	display: flex;
 	flex-wrap: wrap;
+	position: relative;
+	z-index: 1;
 
 	&.justified {
 		.tabs-header {


### PR DESCRIPTION
This PR is to fix an issue regarding the z-index of elements inside tabs.

### What was happening

- Dropdowns would overlap each other when closely located. 
![image](https://user-images.githubusercontent.com/90854874/144458403-286d06f5-a8ca-4c82-9b56-a2b60cfce229.png)

### What was done

- Tabs z-index was fixed.
![image](https://user-images.githubusercontent.com/90854874/144458580-b9a20878-f6b5-49bf-8151-806800be694a.png)

### Test Steps

1. Tested on a sandbox application.

### Checklist

-   [x] tested locally
-   [ ] documented the code
-   [ ] clean all warnings and errors of eslint
-   [x] requires changes in OutSystems (if so, provide a module with changes)
-   [ ] requires new sample page in OutSystems (if so, provide a module with changes)
