### PR TITLE
updated import for warning message

### DIFF
--- a/pipelines/pipeline-run.js
+++ b/pipelines/pipeline-run.js
@@ -1,6 +1,7 @@
 const azdev = require('azure-devops-node-api');
 const commandLineArgs = require('command-line-args');
 const postErrorMessage = require('./azure_logging').postErrorMessage;
+const postWarningMessage = require('./azure_logging').postWarningMessage;
 const failtask = require('./azure_logging').failtask;
 
 const outSystemsUIProjectId = '8121bc01-f7eb-4048-9d11-a5141ebc74ce';

--- a/pipelines/pr-pipeline.yaml
+++ b/pipelines/pr-pipeline.yaml
@@ -70,3 +70,4 @@ jobs:
             displayName: Execute Pipeline
             inputs:
                 script: node pipelines/pipeline-run.js -- --tags="$(TAGS)" --branch="$(branch_name.branch)"
+                failOnStderr: true


### PR DESCRIPTION
Fix for pipeline. Now properly imports warning messages and pipeline correctly fails if there are stdErrors in task.

### What was happening
Because of not importing warning message method, script was failing preemtively before posting pipeline results. And because failOnStderr wasn't set it was marked as passed. 

### What was done
1) Fixed issues with import. Now warningMessage methods is imported correctly.
2) In order to catch such issues (that not based on test pipeline results) added failOnStderr input parameter in yaml file

### Checklist

-   [x] tested locally
-   [ ] documented the code
-   [x] clean all warnings and errors of eslint
-   [ ] requires changes in OutSystems (if so, provide a module with changes)
-   [ ] requires new sample page in OutSystems (if so, provide a module with changes)
