### PR TITLE
 Pagination Counter with unwanted margin left

### DIFF
--- a/src/scss/04-patterns/04-navigation/_pagination.scss
+++ b/src/scss/04-patterns/04-navigation/_pagination.scss
@@ -75,8 +75,6 @@
 	// pagination-counter
 	&-counter {
 		color: var(--color-neutral-7);
-		// With ShowGoToPage parameter, this container is in this context
-		margin-left: var(--space-s);
 	}
 
 	.list.list-group {
@@ -85,7 +83,7 @@
 
 	.form-control[data-input] {
 		height: 32px;
-		margin-left: var(--space-s);
+		margin: var(--space-none) var(--space-s);
 		padding: 0;
 		text-align: center;
 		width: 32px;


### PR DESCRIPTION
This PR is for fixing an issue at the pagination.

### What was happening

- A margin was been added and it shouldn't.

### What was done

- Redefined the pagination selectors.

### Screenshots

![145006384-3d81156d-61bc-4630-a8cc-5f81829f5eb7](https://user-images.githubusercontent.com/5339917/145015042-e529b35c-6a5c-4666-93da-98e03a793539.png)

### Checklist

-   [x] tested locally
-   [x] documented the code
-   [x] clean all warnings and errors of eslint
-   [ ] requires changes in OutSystems (if so, provide a module with changes)
-   [ ] requires new sample page in OutSystems (if so, provide a module with changes)
