### PR TITLE
ROU-2801: Native fix on tabs

### DIFF
--- a/src/scss/04-patterns/04-navigation/_tabs.scss
+++ b/src/scss/04-patterns/04-navigation/_tabs.scss
@@ -215,6 +215,7 @@
 			vertical-align: top;
 			white-space: normal;
 			width: 100%;
+			overflow: hidden;
 
 			& > * {
 				left: 0;


### PR DESCRIPTION
This PR is to fix a small issue on tabs pattern regarding native layout.

### What was happening

![image](https://user-images.githubusercontent.com/90854874/145563786-917e00df-2db1-4c4c-ac95-6e689145560e.png)

### What was done

- Overflow property fixed.
![image](https://user-images.githubusercontent.com/90854874/145563751-54370ca5-2b21-45e2-9587-e156a0141bfd.png)

### Checklist

-   [x] tested locally
-   [ ] documented the code
-   [ ] clean all warnings and errors of eslint
-   [x] requires changes in OutSystems (if so, provide a module with changes)
-   [ ] requires new sample page in OutSystems (if so, provide a module with changes)
