### PR TITLE
ROU-2732 - Fix FlipContent classes

### DIFF
--- a/src/scripts/OSUIFramework/Pattern/FlipContent/Enum.ts
+++ b/src/scripts/OSUIFramework/Pattern/FlipContent/Enum.ts
@@ -15,8 +15,8 @@ namespace OSUIFramework.Patterns.FlipContent.Enum {
 		PatternBack = 'osui-flip-content__container__back',
 		PatternContainer = 'osui-flip-content__container',
 		PatternDataFlipped = 'data-flipped',
-		PatternFlipSelf = 'osui-flip-content__container--flip-self',
+		PatternFlipSelf = 'osui-flip-content--flip-self',
 		PatternFront = 'osui-flip-content__container__front',
-		PatternIsFlipped = 'osui-flip-content__container--flipped',
+		PatternIsFlipped = 'osui-flip-content--flipped',
 	}
 }


### PR DESCRIPTION
This PR is for fixing FlipContent scss BEM conversion.

### Checklist

-   [x] tested locally
-   [x] documented the code
-   [x] clean all warnings and errors of eslint
-   [x] requires changes in OutSystems (if so, provide a module with changes)
-   [ ] requires new sample page in OutSystems (if so, provide a module with changes)
