### PR TITLE
ROU-2806: Floating content full width fixed

### DIFF
--- a/src/scss/04-patterns/02-content/_floating-content.scss
+++ b/src/scss/04-patterns/02-content/_floating-content.scss
@@ -270,9 +270,16 @@
 .phone {
 	.layout-native {
 		.floating-content {
-			&.floating-content-full-height.absolute-top {
-				top: var(--os-safe-area-top);
-			}
+            &.floating-content-full {
+            	&-height.absolute-top {
+            		top: var(--os-safe-area-top);
+            	}
+            	
+            	&-width {
+            		left: 0;
+            		right: 0;
+            	}
+            }
 
 			&.absolute-bottom {
 				bottom: var(--os-safe-area-bottom);


### PR DESCRIPTION
This PR is to fix the full width property of the floating content pattern on phone devices.

### What was happening

- Full width was not respected.
 
![image](https://user-images.githubusercontent.com/90854874/145992340-5fd53ccd-d941-426e-8723-7afa9e14224c.png)

### What was done

- Phone selector regarding this property was missing.

![image](https://user-images.githubusercontent.com/90854874/145992491-8dba0512-18ec-4e7a-945c-6a525f68a3ba.png)

### Test Steps

1. Tested directly on the app where this case was noted.

### Checklist

-   [x] tested locally
-   [ ] documented the code
-   [ ] clean all warnings and errors of eslint
-   [x] requires changes in OutSystems (if so, provide a module with changes)
-   [ ] requires new sample page in OutSystems (if so, provide a module with changes)
