### PR TITLE
Updated current with deprecated and new patterns

### DIFF
--- a/src/scss/10-deprecated/_accordion-deprecated.scss
+++ b/src/scss/10-deprecated/_accordion-deprecated.scss
@@ -1,7 +1,4 @@
 /*! Patterns - Content - Accordion */
-////
-/// @group Patterns-Accordion
-/// Patterns - Content - Accordion
 
 ///
 [data-block*='AccordionItem'] {

--- a/src/scss/10-deprecated/_flip-content-deprecated.scss
+++ b/src/scss/10-deprecated/_flip-content-deprecated.scss
@@ -1,0 +1,56 @@
+/*! Patterns - Content - Flip_Content */
+.flip-content {
+	position: relative;
+	-webkit-perspective: 1000;
+	perspective: 1000;
+	-servicestudio--webkit-perspective: initial;
+	-servicestudio-perspective: initial;
+}
+
+.flip-content-container {
+	position: relative;
+	transition: all 630ms cubic-bezier(0.03, 0.01, 0.67, 1.97);
+	-webkit-transform-style: preserve-3d;
+	transform-style: preserve-3d;
+	-servicestudio--webkit-transform-style: initial;
+	-servicestudio-transform-style: initial;
+}
+
+.flip-content-front,
+.flip-content-back {
+	left: 0;
+	top: 0;
+	-webkit-backface-visibility: hidden;
+	backface-visibility: hidden;
+}
+
+.flip-content-front:empty,
+.flip-content-back:empty {
+	-servicestudio-min-height: 80px;
+}
+
+.flip-content-front {
+	position: relative;
+	z-index: 2;
+}
+
+.flip-content-back {
+	position: absolute;
+	width: 100%;
+	-servicestudio-position: static;
+}
+
+.flip-content.flipped .flip-content-front {
+	position: absolute;
+}
+
+.flip-content.flipped .flip-content-back {
+	position: relative;
+	-webkit-transform: rotateY(90deg);
+	transform: rotateY(90deg);
+}
+
+.flip-content.flipped .flip-content-container {
+	-webkit-transform: rotateY(-90deg);
+	transform: rotateY(-90deg);
+}

--- a/src/scss/os-ui-current.scss
+++ b/src/scss/os-ui-current.scss
@@ -227,8 +227,7 @@
 @import '04-patterns/02-content/list-item-content';
 @import '04-patterns/02-content/section';
 @import '04-patterns/02-content/tag';
-// @import '../scripts/OSUIFramework/Pattern/Tooltip/scss/tooltip';
-@import '10-deprecated/tooltip-deprecated';
+@import '../scripts/OSUIFramework/Pattern/Tooltip/scss/tooltip';
 @import '04-patterns/02-content/user-avatar';
 
 /* ============================================================================ */
@@ -252,8 +251,7 @@
 //@import '../scripts/OSUIFramework/Pattern/RangeSlider/scss/rangeslider';
 @import '04-patterns/03-interaction/scrollable-area';
 @import '../scripts/OSUIFramework/Pattern/Search/scss/search';
-// @import '../scripts/OSUIFramework/Pattern/Sidebar/scss/sidebar';
-@import '10-deprecated/sidebar-deprecated';
+@import '../scripts/OSUIFramework/Pattern/Sidebar/scss/sidebar';
 @import '04-patterns/03-interaction/stacked-cards';
 @import '04-patterns/03-interaction/video';
 
@@ -264,8 +262,7 @@
 @import '04-patterns/04-navigation/breadcrumbs';
 @import '04-patterns/04-navigation/pagination';
 @import '04-patterns/04-navigation/section-index';
-// @import '../scripts/OSUIFramework/Pattern/Submenu/scss/submenu';
-@import '10-deprecated/submenu-deprecated';
+@import '../scripts/OSUIFramework/Pattern/Submenu/scss/submenu';
 @import '04-patterns/04-navigation/tabs';
 @import '04-patterns/04-navigation/timeline';
 @import '04-patterns/04-navigation/wizard';
@@ -287,8 +284,7 @@
 /*      - Utilities                                                             */
 /* ============================================================================ */
 @import '04-patterns/06-utilities/align-center';
-// @import '../scripts/OSUIFramework/Pattern/ButtonLoading/scss/button-loading';
-@import '10-deprecated/button-loading-deprecated';
+@import '../scripts/OSUIFramework/Pattern/ButtonLoading/scss/button-loading';
 @import '04-patterns/06-utilities/center-content';
 @import '04-patterns/06-utilities/margin-container';
 @import '04-patterns/06-utilities/separator';
@@ -299,6 +295,11 @@
 /*! Deprecated Patterns                                                         */
 /*! =========================================================================== */
 @import '10-deprecated/horizontal-scroll-deprecated';
+@import '10-deprecated/tooltip-deprecated';
+@import '10-deprecated/sidebar-deprecated';
+@import '10-deprecated/flip-content-deprecated';
+@import '10-deprecated/button-loading-deprecated';
+@import '10-deprecated/submenu-deprecated';
 
 /*! =========================================================================== */
 /*! Usefull Classes                                                             */

--- a/src/scss/os-ui-new.scss
+++ b/src/scss/os-ui-new.scss
@@ -290,7 +290,7 @@
 /*! =========================================================================== */
 /*! Deprecated Patterns                                                         */
 /*! =========================================================================== */
-@import '10-deprecated/accordion';
+@import '10-deprecated/accordion-deprecated';
 @import '10-deprecated/horizontal-scroll-deprecated';
 @import '10-deprecated/carousel-deprecated';
 @import '10-deprecated/notification-deprecated';


### PR DESCRIPTION
This PR is for updating the current.css with the patterns deprecated and the css for the new ones to be released now:

- AnimatedLabel (not deprecated)
- Sidebar
- ButtonLoading
- Tooltip
- Submenu
- FlipContent

### Checklist

-   [ ] tested locally
-   [ ] documented the code
-   [ ] clean all warnings and errors of eslint
-   [ ] requires changes in OutSystems (if so, provide a module with changes)
-   [ ] requires new sample page in OutSystems (if so, provide a module with changes)
