### PR TITLE
Deprecated ButtonLoading - Fix loading spinner position

### DIFF
--- a/src/scss/10-deprecated/_button-loading-deprecated.scss
+++ b/src/scss/10-deprecated/_button-loading-deprecated.scss
@@ -28,7 +28,8 @@ button.OSFillParent {
 }
 
 .is--loading:not(.btn-show-label) .btn-loading {
-	margin-right: var(--space-none);
+	left: 50%;
+	transform: translateX(-50%);
 }
 
 .is--loading .btn-label {


### PR DESCRIPTION
This PR is for fix a position issue at loading spinner when ShowLoadingAndLabel=false.


### What was happening

- Loading spinner was not proper placed when ShowLoadingAndLabel=false.

### What was done

- Changed the styles to proper align it.

### Screenshots

![Screenshot 2021-12-14 at 15 54 45](https://user-images.githubusercontent.com/5339917/146034769-8f7b4768-0859-483c-996b-dc0480ad94ac.png)

### Checklist

-   [x] tested locally
-   [x] documented the code
-   [x] clean all warnings and errors of eslint
-   [ ] requires changes in OutSystems (if so, provide a module with changes)
-   [ ] requires new sample page in OutSystems (if so, provide a module with changes)
