### PR TITLE
Tooltip wrapper container issue

### DIFF
--- a/src/scripts/OSUIFramework/Pattern/Tooltip/BoundsPosition.ts
+++ b/src/scripts/OSUIFramework/Pattern/Tooltip/BoundsPosition.ts
@@ -63,12 +63,12 @@ namespace OSUIFramework.Patterns.Tooltip {
 		): string | undefined {
 			// Get Bounds element and sizes
 			const elemBound = elem.getBoundingClientRect();
-			const elemHeight = elem.clientHeight;
-			const elemWidth = elem.clientWidth;
+			const elemHeight = elemBound.height;
+			const elemWidth = elemBound.width;
 
 			const viewElemBound = viewElem.getBoundingClientRect();
-			const viewElemHeight = viewElem.clientHeight;
-			const viewElemWidth = viewElem.clientWidth;
+			const viewElemHeight = viewElemBound.height;
+			const viewElemWidth = viewElemBound.width;
 
 			// Check if it's out of the viewport on each side
 			const out = {


### PR DESCRIPTION
This PR is for fixing an issue related with the size wrapper container for the tooltip.

### What was happening

- Since the clientHeight and clientWidth was in use in some contexts this could return wrong values.

### What was done

- Swap clientWidth and clientHeight into getBoundingClientRect() properties!

### Checklist

-   [x] tested locally
-   [x] documented the code
-   [x] clean all warnings and errors of eslint
-   [ ] requires changes in OutSystems (if so, provide a module with changes)
-   [ ] requires new sample page in OutSystems (if so, provide a module with changes)
