### PR TITLE
Tooltip screen container issue (2)

### DIFF
--- a/src/scripts/OSUIFramework/Pattern/Tooltip/BoundsPosition.ts
+++ b/src/scripts/OSUIFramework/Pattern/Tooltip/BoundsPosition.ts
@@ -83,7 +83,7 @@ namespace OSUIFramework.Patterns.Tooltip {
 				out.top = false;
 			}
 			// Since it has a smaller height than the viewElem and doesn't fit at top position, check if fits at bottom!
-			else if (out.top && Math.abs(elemBound.top - viewElemBound.top) < elemHeight) {
+			else if (out.top && elemBound.top >= 0 && elemBound.top - viewElemBound.top < elemHeight) {
 				out.top = false;
 			}
 


### PR DESCRIPTION
This PR is used as an update to https://github.com/OutSystems/outsystems-ui/pull/190 one.

### What was happening

- Tooltip balloon was having top negative values;

### What was done

- Adding a new validation in order to check if those values are negative.

### Checklist

-   [x] tested locally
-   [x] documented the code
-   [x] clean all warnings and errors of eslint
-   [ ] requires changes in OutSystems (if so, provide a module with changes)
-   [ ] requires new sample page in OutSystems (if so, provide a module with changes)
