### PR TITLE
Fix for the sticky property on Safari 14.1

### DIFF
--- a/src/scss/04-patterns/04-navigation/_section-index.scss
+++ b/src/scss/04-patterns/04-navigation/_section-index.scss
@@ -87,6 +87,13 @@
 	}
 }
 
+// Fixes the sticky problem on Safari 14.1
+.safari {
+	[data-block*='SectionIndex'] {
+		display: contents;
+	}
+}
+
 // Accessibility ---------------------------------------------------------------------------
 ///
 .has-accessible-features {


### PR DESCRIPTION
This PR is for adding a fix for the property `position: sticky` on Safari 14.1

### Checklist

-   [x] tested locally
-   [x] documented the code
-   [x] clean all warnings and errors of eslint
-   [ ] requires changes in OutSystems (if so, provide a module with changes)
-   [ ] requires new sample page in OutSystems (if so, provide a module with changes)
