### PR TITLE
Removes the CSS rule for Edge.

### DIFF
--- a/src/scss/04-patterns/04-navigation/_section-index.scss
+++ b/src/scss/04-patterns/04-navigation/_section-index.scss
@@ -79,14 +79,6 @@
 }
 
 ///
-.edge {
-	.section-index {
-		&.is--sticky {
-			position: fixed;
-		}
-	}
-}
-
 // Fixes the sticky problem on Safari 14.1
 .safari {
 	[data-block*='SectionIndex'] {


### PR DESCRIPTION
This PR is for removing a CSS rule that was preventing the correct behaviour of SectionIndex on Edge.

### Checklist

-   [x] tested locally
-   [x] documented the code
-   [x] clean all warnings and errors of eslint
-   [ ] requires changes in OutSystems (if so, provide a module with changes)
-   [ ] requires new sample page in OutSystems (if so, provide a module with changes)
