### PR TITLE
ROU-2807 - Tooltip event propagation 

### DIFF
--- a/src/scripts/OSUIFramework/Pattern/Tooltip/Tooltip.ts
+++ b/src/scripts/OSUIFramework/Pattern/Tooltip/Tooltip.ts
@@ -20,7 +20,6 @@ namespace OSUIFramework.Patterns.Tooltip {
 			super(uniqueId, new TooltipConfig(configs));
 
 			this._isOpen = this.configs.StartVisible;
-
 			this.setCallbacks();
 		}
 
@@ -98,7 +97,8 @@ namespace OSUIFramework.Patterns.Tooltip {
 		}
 
 		// Trigger the tooltip at onClick behaviour
-		private _clickCallback(): void {
+		private _clickCallback(e: MouseEvent): void {
+			e.stopPropagation();
 			// Add a window event that will be responsible to close it, if it's opend by default
 			this.open();
 		}


### PR DESCRIPTION
This PR is for fixing the propagation of events related to the tooltip click for the following scenarios:

- A link inside a tooltip
- Tooltip inside an element that has its own click event
- Tooltip inside AccordionItem

### What was happening

- On clicking the tooltip all other events were being triggered

### What was done

- Added stopPropagation on click callback


### Checklist

-   [x] tested locally
-   [x] documented the code
-   [x] clean all warnings and errors of eslint
-   [x] requires changes in OutSystems (if so, provide a module with changes)
-   [ ] requires new sample page in OutSystems (if so, provide a module with changes)
