### PR TITLE
ROU 2816 - issues found in the new Accordion

### DIFF
--- a/src/scripts/OSUIFramework/Pattern/AccordionItem/AccordionItem.ts
+++ b/src/scripts/OSUIFramework/Pattern/AccordionItem/AccordionItem.ts
@@ -221,8 +221,7 @@ namespace OSUIFramework.Patterns.AccordionItem {
 		}
 
 		public changeProperty(propertyName: string, propertyValue: unknown): void {
-			// Checks if the state is the same when resetting the variable linked to the IsExpandedState - prevents a loop of OnParametersChanged.
-			const expandedState = this.configs.IsExpanded === propertyValue;
+			const expandedState = this.configs.IsExpanded;
 			super.changeProperty(propertyName, propertyValue);
 			if (this.isBuilt) {
 				switch (propertyName) {


### PR DESCRIPTION
This PR is for fixing issues found in the new Accordion

[Sample page](url)

### What was happening

- When opening an accordion that has another accordion inside, the accordion child headers are also in bold

### What was done

- Increased the specificity of the Title's CSS when the state is open


### Checklist

-   [x] tested locally
-   [x] documented the code
-   [x] clean all warnings and errors of eslint
-   [ ] requires changes in OutSystems (if so, provide a module with changes)
-   [ ] requires new sample page in OutSystems (if so, provide a module with changes)
