### PR TITLE
Added deprecated tabs to new

### DIFF
--- a/src/scss/os-ui-new.scss
+++ b/src/scss/os-ui-new.scss
@@ -302,6 +302,7 @@
 @import '10-deprecated/progress-bar-deprecated';
 @import '10-deprecated/progress-circle-deprecated';
 @import '10-deprecated/date-picker-deprecated';
+@import '10-deprecated/tabs-deprecated';
 
 /*! =========================================================================== */
 /*! Usefull Classes                                                             */


### PR DESCRIPTION
This PR is for adding the deprecated tabs partial to the new-theme.css

### Checklist

-   [x] tested locally
-   [x] documented the code
-   [x] clean all warnings and errors of eslint
-   [x] requires changes in OutSystems (if so, provide a module with changes)
-   [ ] requires new sample page in OutSystems (if so, provide a module with changes)
