### PR TITLE
Submenu - Removed iOS event

### DIFF
--- a/src/scripts/OSUIFramework/Pattern/Submenu/Submenu.ts
+++ b/src/scripts/OSUIFramework/Pattern/Submenu/Submenu.ts
@@ -258,11 +258,6 @@ namespace OSUIFramework.Patterns.Submenu {
 			if (this._hasElements) {
 				this._submenuHeaderElement.addEventListener(this._submenuEventType, this._eventClick);
 				this._submenuHeaderElement.addEventListener(GlobalEnum.HTMLEvent.keyDown, this._eventKeypress);
-			} else {
-				// Add event to force focus element when a user tap in an empty submenu on a iOS device
-				if (Helper.DeviceInfo.IsIos) {
-					this._submenuHeaderElement.addEventListener(this._submenuEventType, this._eventFocus);
-				}
 			}
 
 			// Add the handler to Event Manager
@@ -331,16 +326,6 @@ namespace OSUIFramework.Patterns.Submenu {
 			if (this._hasElements) {
 				this._submenuHeaderElement.removeEventListener(this._submenuEventType, this._eventClick);
 				this._submenuHeaderElement.removeEventListener(GlobalEnum.HTMLEvent.keyDown, this._eventKeypress);
-			} else {
-				// Remove event to force focus element when a user tap in an empty submenu on a iOS device
-				if (Helper.DeviceInfo.IsIos) {
-					this._submenuHeaderElement.removeEventListener(this._submenuEventType, this._eventFocus);
-				}
-			}
-
-			// Remove event only if is iOS
-			if (Helper.DeviceInfo.IsIos) {
-				this._submenuLinksElement.removeEventListener(this._submenuEventType, this._eventClickLinks);
 			}
 
 			// Remove global handlers
@@ -410,11 +395,6 @@ namespace OSUIFramework.Patterns.Submenu {
 
 			this._updateA11yProperties();
 
-			// Remove event only if is iOS
-			if (Helper.DeviceInfo.IsIos) {
-				this._submenuLinksElement.removeEventListener(this._submenuEventType, this._eventClickLinks);
-			}
-
 			// Remove the handler from Event Manager when is closed
 			OSUIFramework.Event.GlobalEventManager.Instance.removeHandler(
 				OSUIFramework.Event.Type.BodyOnClick,
@@ -451,11 +431,6 @@ namespace OSUIFramework.Patterns.Submenu {
 			this._isOpen = true;
 
 			this._updateA11yProperties();
-
-			// Add event only if is iOS
-			if (Helper.DeviceInfo.IsIos) {
-				this._submenuLinksElement.addEventListener(this._submenuEventType, this._eventClickLinks);
-			}
 
 			// Add the handler to Event Manager when is opened
 			OSUIFramework.Event.GlobalEventManager.Instance.addHandler(


### PR DESCRIPTION
This PR is for fixing not being able to click on subMenuItems on iOS devices.


### What was done

- Removed the event that was being added when isIOS, to fix the accesibility styles, as it seems it was no longer needed.


### Checklist

-   [x] tested locally
-   [x] documented the code
-   [x] clean all warnings and errors of eslint
-   [x] requires changes in OutSystems (if so, provide a module with changes)
-   [ ] requires new sample page in OutSystems (if so, provide a module with changes)
