### PR TITLE
Improves the top border of the AccordionItem when it is open.

### DIFF
--- a/src/scripts/OSUIFramework/Pattern/AccordionItem/scss/_accordion-item.scss
+++ b/src/scripts/OSUIFramework/Pattern/AccordionItem/scss/_accordion-item.scss
@@ -17,7 +17,7 @@
 
 	&--is {
 		&-open {
-			border-top: var(--border-size-m) solid var(--color-primary);
+			box-shadow: inset 0 var(--border-size-m) 0 0 var(--color-primary);
 
 			> .osui-accordion-item__title {
 				font-weight: var(--font-semi-bold);


### PR DESCRIPTION
This PR is for improving the AccordionItem's state when opened.

### What was happening

- The top border of the Accordion Item was adding height to its header

### What was done

- Applied the CSS rule `box-shadow` instead of the `border-top`; this way, there won't be any added height to the header nor the content.

### Checklist

-   [x] tested locally
-   [x] documented the code
-   [x] clean all warnings and errors of eslint
-   [ ] requires changes in OutSystems (if so, provide a module with changes)
-   [ ] requires new sample page in OutSystems (if so, provide a module with changes)
