### PR TITLE
ROU-2811: Application name word break

### DIFF
--- a/src/scss/02-layout/_header.scss
+++ b/src/scss/02-layout/_header.scss
@@ -20,6 +20,10 @@
 
 	&-logo {
 		padding-right: var(--space-base);
+
+		.application-name {
+			word-break: break-word;
+		}
 	}
 
 	&-navigation {


### PR DESCRIPTION
This PR is to fix one of the issues reported at ROU-2811

### What was happening

![image](https://user-images.githubusercontent.com/90854874/147239627-520a198b-93bc-4111-9f4f-401c8679fcae.png)

### What was done

- Word break implemented at the application-name class.
![image](https://user-images.githubusercontent.com/90854874/147239664-1ca2ad04-8101-40d9-8bb6-9e056e128293.png)

### Test Steps

1. Tested on a sandbox application

### Checklist

-   [x] tested locally
-   [ ] documented the code
-   [ ] clean all warnings and errors of eslint
-   [x] requires changes in OutSystems (if so, provide a module with changes)
-   [ ] requires new sample page in OutSystems (if so, provide a module with changes)
