### PR TITLE
ROU-2843 - Fixed contentItem dispose

### DIFF
--- a/src/scripts/OSUIFramework/Pattern/Tabs/Tabs.ts
+++ b/src/scripts/OSUIFramework/Pattern/Tabs/Tabs.ts
@@ -260,7 +260,7 @@ namespace OSUIFramework.Patterns.Tabs {
 			this._setPosition(this._configs.TabsVerticalPosition);
 			this._setHeight(this._configs.Height);
 			this._setIsJustified(this._configs.JustifyHeaders);
-			// Set the HeaderItems css variable
+			// Set the --tabs-header-items css variable
 			this._setHeaderItemsCustomProperty();
 			// Setting as false, to avoid trigering changeTab event on screen load
 			this.changeTab(this.configs.StartingTab, undefined, false, true);


### PR DESCRIPTION
This PR is for fixing the contentItems removal, as they were trying to set a css variable on the tabs, when was not built

### Checklist

-   [x] tested locally
-   [x] documented the code
-   [x] clean all warnings and errors of eslint
-   [x] requires changes in OutSystems (if so, provide a module with changes)
-   [ ] requires new sample page in OutSystems (if so, provide a module with changes)
