### PR TITLE
ROU-2845 - decreased specificity of btn in tablet

### DIFF
--- a/src/scss/03-widgets/_btn.scss
+++ b/src/scss/03-widgets/_btn.scss
@@ -102,15 +102,13 @@
 		font-size: var(--font-size-base);
 		height: 48px;
 
-		&.btn {
-			&-small {
-				font-size: var(--font-size-s);
-				height: 40px;
-			}
+		&-small {
+			font-size: var(--font-size-s);
+			height: 40px;
+		}
 
-			&-large {
-				height: 56px;
-			}
+		&-large {
+			height: 56px;
 		}
 	}
 }


### PR DESCRIPTION
This PR is for fixing the increased of btn rules in tablet on the scss transition.

### What was happening

- Custom css to override this was no longer working

### What was done

- Removed the class .btn from rule, as before.


### Checklist

-   [x] tested locally
-   [x] documented the code
-   [x] clean all warnings and errors of eslint
-   [x] requires changes in OutSystems (if so, provide a module with changes)
-   [ ] requires new sample page in OutSystems (if so, provide a module with changes)
