### PR TITLE
ROU-2844 - removed table rule that was causing preview issues

### DIFF
--- a/src/scss/03-widgets/_table.scss
+++ b/src/scss/03-widgets/_table.scss
@@ -28,11 +28,6 @@
 			padding: var(--space-none) var(--space-m);
 			text-align: left;
 
-			// Service Studio Preview
-			& {
-				-servicestudio-width: 100%;
-			}
-
 			&:first-child {
 				border-radius: var(--border-radius-soft) var(--border-radius-none) var(--border-radius-none)
 					var(--border-radius-none);


### PR DESCRIPTION
This PR is for fixing the table preview inside Service Studio

### What was happening

- The first column was always too big.

### What was done

- Removed preview rule and now the preview is the same as the runtime.

### Checklist

-   [x] tested locally
-   [x] documented the code
-   [x] clean all warnings and errors of eslint
-   [x] requires changes in OutSystems (if so, provide a module with changes)
-   [ ] requires new sample page in OutSystems (if so, provide a module with changes)
