### PR TITLE
Fixes the state of nested accordion items when their parent is open

### DIFF
--- a/src/scss/10-deprecated/_accordion-deprecated.scss
+++ b/src/scss/10-deprecated/_accordion-deprecated.scss
@@ -27,7 +27,7 @@
 		&-open {
 			border-top: var(--border-size-m) solid var(--color-primary);
 
-			.section-expandable-title {
+			> .section-expandable-title {
 				font-weight: var(--font-semi-bold);
 			}
 


### PR DESCRIPTION
This PR is for fixing the state nested accordion items have when their parent is open, i.e. when the parent item was open, its children would have the same "is open" styles.

### What was done

- Specificity of the selectors was increased.

### Checklist

-   [x] tested locally
-   [x] documented the code
-   [x] clean all warnings and errors of eslint
-   [ ] requires changes in OutSystems (if so, provide a module with changes)
-   [ ] requires new sample page in OutSystems (if so, provide a module with changes)
