### PR TITLE
Added new scss to current-theme

### DIFF
--- a/src/scss/os-ui-current.scss
+++ b/src/scss/os-ui-current.scss
@@ -278,8 +278,7 @@
 @import '04-patterns/03-interaction/lightbox-image';
 @import '10-deprecated/notification-deprecated';
 //@import '../scripts/OSUIFramework/Pattern/Notification/scss/notification';
-@import '10-deprecated/range-slider-deprecated';
-//@import '../scripts/OSUIFramework/Pattern/RangeSlider/scss/rangeslider';
+@import '../scripts/OSUIFramework/Pattern/RangeSlider/scss/rangeslider';
 @import '04-patterns/03-interaction/scrollable-area';
 @import '../scripts/OSUIFramework/Pattern/Search/scss/search';
 @import '../scripts/OSUIFramework/Pattern/Sidebar/scss/sidebar';


### PR DESCRIPTION
This PR is for adding the scss for new component on the current-css file.

The deprecated scss uis still kept but not imported, as on this case the css will go to the deprecated block (due to the way the css was done on the old pattern)

### Checklist

-   [ ] tested locally
-   [ ] documented the code
-   [ ] clean all warnings and errors of eslint
-   [ ] requires changes in OutSystems (if so, provide a module with changes)
-   [ ] requires new sample page in OutSystems (if so, provide a module with changes)
