### PR TITLE
ROU-3063: Fix input width when is inside of AlignCenter

### DIFF
--- a/src/scss/04-patterns/06-utilities/_align-center.scss
+++ b/src/scss/04-patterns/06-utilities/_align-center.scss
@@ -11,6 +11,7 @@
 
 	span {
 		display: inherit;
+		flex: 1;
 	}
 }
 


### PR DESCRIPTION
This PR is for fixing the input width when AlignCenter has inputs inside. Check the JIRA issue for more information.

### Checklist

-   [X] tested locally
-   [X] documented the code
-   [X] clean all warnings and errors of eslint
-   [ ] requires changes in OutSystems (if so, provide a module with changes)
-   [ ] requires new sample page in OutSystems (if so, provide a module with changes)
