### PR TITLE
ROU-2739: Fix SS preview of CardBackground inside Gallery

### DIFF
--- a/src/scripts/OSUIFramework/Pattern/Gallery/scss/_gallery.scss
+++ b/src/scripts/OSUIFramework/Pattern/Gallery/scss/_gallery.scss
@@ -25,6 +25,10 @@
 		.animate {
 			height: 100%;
 		}
+
+		.card-background {
+			-servicestudio-height: 100% !important;
+		}
 	}
 
 	& > img {


### PR DESCRIPTION
This PR is for fixing the SS preview of card background inside gallery. The issue is related to the height of the items. Check the JIRA issue for more info.

### Checklist

-   [ ] tested locally
-   [ ] documented the code
-   [ ] clean all warnings and errors of eslint
-   [ ] requires changes in OutSystems (if so, provide a module with changes)
-   [ ] requires new sample page in OutSystems (if so, provide a module with changes)
