### PR TITLE
AccordionItem: Changed border color when open and disabled

### DIFF
--- a/src/scripts/OSUIFramework/Pattern/AccordionItem/scss/_accordion-item.scss
+++ b/src/scripts/OSUIFramework/Pattern/AccordionItem/scss/_accordion-item.scss
@@ -44,6 +44,12 @@
 				}
 			}
 
+			&.osui-accordion-item--is-disabled {
+				&::after {
+					border-color: var(--color-neutral-6);
+				}
+			}
+
 			&::after {
 				border-color: var(--color-primary);
 				opacity: 1;


### PR DESCRIPTION
This PR is for changing border color when AccordionItem is open and disabled.

![image](https://user-images.githubusercontent.com/32780808/154306049-0379da1d-1b82-4f03-b940-de86c9eee39a.png)


### Checklist

-   [x] tested locally
-   [x] documented the code
-   [x] clean all warnings and errors of eslint
-   [x] requires changes in OutSystems (if so, provide a module with changes)
-   [ ] requires new sample page in OutSystems (if so, provide a module with changes)
