### PR TITLE
ROU-3126: Fix width of input when is used inside the AlignCenter pattern

### DIFF
--- a/src/scss/04-patterns/06-utilities/_align-center.scss
+++ b/src/scss/04-patterns/06-utilities/_align-center.scss
@@ -9,7 +9,7 @@
 	display: flex;
 	flex-direction: row;
 
-	// Fix with of input when is used inside the AlignCenter pattern
+	// Fix width of input when is used inside the AlignCenter pattern
 	> span.input-text,
 	> label ~ span {
 		flex: 1;


### PR DESCRIPTION
This PR is for fixing the use cases of inputs and textareas when used inside the AlignCenter pattern. Check the JIRA issue for more information.

### Checklist
-   [X] tested locally
-   [X] documented the code
-   [X] clean all warnings and errors of eslint
-   [ ] requires changes in OutSystems (if so, provide a module with changes)
-   [ ] requires new sample page in OutSystems (if so, provide a module with changes)
