### PR TITLE
ROU-3162: [DropdownSearch and DropdownTags] - Fix "Maximum call stack size exceeded" issue.

### DIFF
--- a/src/scripts/OSUIFramework/Pattern/Dropdown/AbstractDropdown.ts
+++ b/src/scripts/OSUIFramework/Pattern/Dropdown/AbstractDropdown.ts
@@ -4,17 +4,20 @@ namespace OSUIFramework.Patterns.Dropdown {
 		extends AbstractPattern<C>
 		implements IDropdown, Interface.IProviderPattern<P>
 	{
+		// keeps the instance of the provider of the pattern.
+		private _provider: P;
+
 		// eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/explicit-module-boundary-types
 		constructor(uniqueId: string, configs: C) {
 			super(uniqueId, configs);
 		}
 
 		public get provider(): P {
-			return this.provider;
+			return this._provider;
 		}
 
 		public set provider(p: P) {
-			this.provider = p;
+			this._provider = p;
 		}
 
 		public abstract clear(): void;


### PR DESCRIPTION
This issue was happening at **Dropdown** (**Search** and **Tags**) that are based on VirtualSelect provider.