### PR TITLE
ROU-2810 V3: Prevent the update of StartsOpen parameter on changeProperty

### DIFF
--- a/src/scripts/OSUIFramework/Pattern/Notification/Notification.ts
+++ b/src/scripts/OSUIFramework/Pattern/Notification/Notification.ts
@@ -355,7 +355,7 @@ namespace OSUIFramework.Patterns.Notification {
 						break;
 					case Enum.Properties.StartsOpen:
 						console.warn(
-							`Notification (${this.widgetId}): changes to ${Enum.Properties.StartsOpen} parameter do not affect the notification. Use the client actions 'NotificationShow' and 'NotificationHide' to affect the Notification.`
+							`${GlobalEnum.PatternsNames.Notification} (${this.widgetId}): changes to ${Enum.Properties.StartsOpen} parameter do not affect the ${GlobalEnum.PatternsNames.Notification}. Use the client actions 'NotificationShow' and 'NotificationHide' to affect the ${GlobalEnum.PatternsNames.Notification}.`
 						);
 						break;
 					case Enum.Properties.Position:


### PR DESCRIPTION
This PR is for preventing the update of StartsOpen parameter and add the console.warn, alerting the available actions.

### Checklist
-   [X] tested locally
-   [X] documented the code
-   [X] clean all warnings and errors of eslint
-   [ ] requires changes in OutSystems (if so, provide a module with changes)
-   [ ] requires new sample page in OutSystems (if so, provide a module with changes)
