### PR TITLE
ROU 3184 - Table :last-child double rule

### DIFF
--- a/src/scss/03-widgets/_table.scss
+++ b/src/scss/03-widgets/_table.scss
@@ -85,10 +85,13 @@
 	}
 
 	.table-row:last-child {
-		&:last-child td {
+		& td {
 			border-bottom: none;
-			border-radius: var(--border-radius-none) var(--border-radius-none) var(--border-radius-soft)
-				var(--border-radius-none);
+
+			&:last-child {
+				border-radius: var(--border-radius-none) var(--border-radius-none) var(--border-radius-soft)
+					var(--border-radius-none);
+			}
 		}
 
 		td:first-child {


### PR DESCRIPTION
This PR is to correct the pseudo-element on table-rows.


### What was happening
The selector was duplicated:
![image](https://user-images.githubusercontent.com/7048430/158408333-3146831b-c234-4c9f-a022-183e2b168b90.png)

This seems to be introduced when we transformed our CSS into SASS partials, as seen here (OutSystemsUI 2.6.13): 
![image](https://user-images.githubusercontent.com/7048430/158406386-77f27b0a-2597-4ba9-8fe6-452c2bfb27f9.png)


### What was done

- The pseudo-element was corrected
![image](https://user-images.githubusercontent.com/7048430/158407355-0fb52ac3-c2de-47e0-b007-b627fb4d12ea.png)

### Checklist

-   [x] tested locally
-   [x] documented the code
-   [x] clean all warnings and errors of eslint
-   [ ] requires changes in OutSystems (if so, provide a module with changes)
-   [ ] requires new sample page in OutSystems (if so, provide a module with changes)
