### PR TITLE
ROU-3192: Add focus styles to dropdown widget

### DIFF
--- a/src/scss/03-widgets/_dropdown.scss
+++ b/src/scss/03-widgets/_dropdown.scss
@@ -49,7 +49,6 @@
 					border: var(--border-size-s) solid var(--color-neutral-6);
 				}
 
-				&:focus,
 				&:focus {
 					border: var(--border-size-s) solid var(--color-primary);
 				}


### PR DESCRIPTION
This PR is for adding missing focus styles of dropdown widget.

### Checklist

-   [X] tested locally
-   [X] documented the code
-   [X] clean all warnings and errors of eslint
-   [ ] requires changes in OutSystems (if so, provide a module with changes)
-   [ ] requires new sample page in OutSystems (if so, provide a module with changes)
