### PR TITLE
ROU-3193: re-added missing css rule

### DIFF
--- a/src/scss/02-layout/_layout.scss
+++ b/src/scss/02-layout/_layout.scss
@@ -23,11 +23,9 @@ body,
 	min-height: 100vh;
 
 	&.layout {
-		&-top {
-			&,
-			&:not(.layout-native) {
-				flex-direction: column;
-			}
+		&-top,
+		&-side:not(.layout-native) {
+			flex-direction: column;
 		}
 
 		&-left {


### PR DESCRIPTION
This PR is for adding back missing flex-direction: column to layout-side.

### Checklist

-   [x] tested locally
-   [x] documented the code
-   [x] clean all warnings and errors of eslint
-   [x] requires changes in OutSystems (if so, provide a module with changes)
-   [ ] requires new sample page in OutSystems (if so, provide a module with changes)
