### PR TITLE
ROU-3233: Fixed submenu hover on layout-side

### DIFF
--- a/src/scripts/OSUIFramework/Pattern/Submenu/scss/_submenu.scss
+++ b/src/scripts/OSUIFramework/Pattern/Submenu/scss/_submenu.scss
@@ -254,6 +254,18 @@
 			}
 		}
 
+		&__header {
+			&:hover {
+				border-bottom: var(--border-size-m) solid var(--color-primary);
+			}
+
+			&__item {
+				a:hover {
+					color: var(--color-neutral-9);
+				}
+			}
+		}
+
 		&__items {
 			a {
 				&:hover {
@@ -272,18 +284,6 @@
 		.app-menu-links {
 			.osui-submenu {
 				height: 100%;
-
-				&__header {
-					&:hover {
-						border-bottom: var(--border-size-m) solid var(--color-primary);
-					}
-
-					&__item {
-						a:hover {
-							color: var(--color-neutral-9);
-						}
-					}
-				}
 			}
 		}
 	}
@@ -293,6 +293,7 @@
 			.osui-submenu {
 				&__header {
 					&:hover {
+						border-bottom: none;
 						border-left: var(--border-size-m) solid var(--color-primary);
 					}
 				}


### PR DESCRIPTION
This PR is for fixing the styles of the submenu hover when used on .layout-side navigation.

### Checklist

-   [x] tested locally
-   [x] documented the code
-   [x] clean all warnings and errors of eslint
-   [x] requires changes in OutSystems (if so, provide a module with changes)
-   [ ] requires new sample page in OutSystems (if so, provide a module with changes)
