### PR TITLE
ROU-3214: Fix Carousel window resize event

### DIFF
--- a/src/scripts/Providers/Carousel/Splide/Splide.ts
+++ b/src/scripts/Providers/Carousel/Splide/Splide.ts
@@ -165,7 +165,6 @@ namespace Providers.Splide {
 				OSUIFramework.Event.Type.WindowResize,
 				this._eventOnResize
 			);
-			//window.addEventListener(OSUIFramework.GlobalEnum.HTMLEvent.Resize, this._eventOnResize);
 		}
 
 		/**
@@ -215,7 +214,6 @@ namespace Providers.Splide {
 		 */
 		protected unsetCallbacks(): void {
 			// remove event listener
-			//window.removeEventListener(OSUIFramework.GlobalEnum.HTMLEvent.Resize, this._eventOnResize);
 			OSUIFramework.Event.GlobalEventManager.Instance.removeHandler(
 				OSUIFramework.Event.Type.WindowResize,
 				this._eventOnResize


### PR DESCRIPTION
This PR is for fixing an issue when resizing the window after a carousel has been destroyed and created again in runtime.

- Now the event is removed before the callback is set to undefined.
- Now the global event manager is used.

### Checklist

-   [x] tested locally
-   [x] documented the code
-   [x] clean all warnings and errors of eslint
-   [x] requires changes in OutSystems (if so, provide a module with changes)
-   [ ] requires new sample page in OutSystems (if so, provide a module with changes)
