### PR TITLE
ROU-3254: Dropdown popup doesn't appear in Tabs mobile

### DIFF
--- a/src/scripts/OSUIFramework/Pattern/Dropdown/scss/_dropdown.scss
+++ b/src/scripts/OSUIFramework/Pattern/Dropdown/scss/_dropdown.scss
@@ -47,11 +47,3 @@
 		}
 	}
 }
-
-// Popup Mode inside Tabs --------------------------------------------------------
-body.vscomp-popup-active .tabs-content-wrapper {
-	display: contents;
-}
-body.vscomp-popup-active .tabs-content-wrapper .OSBlockWidget {
-	display: flex;
-}

--- a/src/scripts/Providers/Dropdown/VirtualSelect/scss/_virtualselect.scss
+++ b/src/scripts/Providers/Dropdown/VirtualSelect/scss/_virtualselect.scss
@@ -415,3 +415,16 @@
 		}
 	}
 }
+
+// Popup Mode inside Tabs --------------------------------------------------------
+body {
+	&.vscomp-popup-active {
+		.tabs-content-wrapper {
+			display: contents;
+
+			.OSBlockWidget {
+				display: flex;
+			}
+		}
+	}
+}


### PR DESCRIPTION
This PR is for fixing the issue when inside Tabs on mobile, the popup mode of the Dropdown Search and Tags was not working properly

### What was happening

- When inside Tabs on mobile, the popup mode of the Dropdown Search and Tags was not working properly:

![open](https://user-images.githubusercontent.com/29493222/161350356-9ed6dacf-1903-43ce-8d95-21b531d05447.gif)


### What was done

- Rollback the library to Virtual Select v1.0.26
- Add a fix in the CSS to properly show Dropdown Search and Tags 


### Checklist

-   [X] tested locally
-   [X] documented the code
-   [X] clean all warnings and errors of eslint
-   [X] requires changes in OutSystems

