### PR TITLE
Changed overlay width

### DIFF
--- a/src/scripts/OSUIFramework/Pattern/Sidebar/scss/_sidebar.scss
+++ b/src/scripts/OSUIFramework/Pattern/Sidebar/scss/_sidebar.scss
@@ -112,7 +112,7 @@
 			position: fixed;
 			top: 0;
 			transition: opacity 130ms ease-in;
-			width: 100vw;
+			width: 200vw;
 			will-change: opacity;
 			z-index: 129;
 


### PR DESCRIPTION
This PR is for the sidebar overlay transition in some devices.

### What was happening
- When we changed this to a pseudo element, the issue was not noticed. In some devices, it can be possible to see the overlay coming in with the sidebar aside.

### What was done
- As the sidebar is off-canvas -102%, also is the overlay, as it is a pseudo element. That's why old width: 100vw could not be enough in some cases.
- Changed width to 200vw, to make sure its at least double the side of the screen, and it will never be visible when entering the screen

### Checklist

-   [x] tested locally
-   [x] documented the code
-   [x] clean all warnings and errors of eslint
-   [x] requires changes in OutSystems (if so, provide a module with changes)
-   [ ] requires new sample page in OutSystems (if so, provide a module with changes)
