### PR TITLE
RMAC-9180: Remove thead css rule for layout .phone class group

### DIFF
--- a/src/scss/08-servicestudio-preview/_servicestudiopreview.scss
+++ b/src/scss/08-servicestudio-preview/_servicestudiopreview.scss
@@ -154,12 +154,18 @@ html[data-uieditorversion^='1'] {
 	.tablet {
 		.layout:not(.layout-native) {
 			thead {
+				display: initial;
+
 				& > tr {
 					-servicestudio-position: relative;
 				}
+			}
 
-				& > tr:not(:empty):before {
-					-servicestudio-display: none;
+			table.table > thead > tr {
+				display: none;
+
+				&:empty {
+					display: block;
 				}
 			}
 


### PR DESCRIPTION
This PR is for the bug RMAC-9180 with title "UIEditor :: Mobile/Tablet Preview of tables is broken in some screens"

### What was happening

Thead element was visible in mobile view port

### What was done

Removed Css rule which keeps the thead element visible under the .phone class group.

### Screenshots


https://user-images.githubusercontent.com/89786267/164217597-82f59bc7-f75e-48ee-879d-ae4fa3486ed2.mp4


### Checklist

-   [x] tested locally
-   [ ] documented the code
-   [ ] clean all warnings and errors of eslint
-   [ ] requires changes in OutSystems (if so, provide a module with changes)
-   [ ] requires new sample page in OutSystems (if so, provide a module with changes)
