### PR TITLE
ROU-3321: fixing the font family on the new dropdowns

### DIFF
--- a/src/scripts/OSUIFramework/Pattern/Dropdown/scss/_dropdown.scss
+++ b/src/scripts/OSUIFramework/Pattern/Dropdown/scss/_dropdown.scss
@@ -14,10 +14,6 @@
 	&-search,
 	&-serverside,
 	&-tags {
-    // Override the font-family of provider
-		.vscomp-wrapper {
-			font-family: inherit;
-		}
 		/// Disable states for dropdowns
 		&.vscomp-ele[disabled] {
 			// Override of library cursor on disable states
@@ -36,6 +32,11 @@
 					opacity: inherit;
 				}
 			}
+		}
+
+		// Override the font-family of provider
+		.vscomp-wrapper {
+			font-family: inherit;
 		}
 	}
 


### PR DESCRIPTION
This PR is for remove the CSS rule font-family: sans-serif; from .vscomp-wrapper. Please check the JIRA issue for more info.

### Checklist
-   [X] tested locally
-   [X] documented the code
-   [X] clean all warnings and errors of eslint
-   [ ] requires changes in OutSystems (if so, provide a module with changes)
-   [ ] requires new sample page in OutSystems (if so, provide a module with changes)
