### PR TITLE
ROU-3372 Add calendar container verification

### DIFF
--- a/src/scripts/Providers/Datepicker/Flatpickr/AbstractFlatpickr.ts
+++ b/src/scripts/Providers/Datepicker/Flatpickr/AbstractFlatpickr.ts
@@ -107,27 +107,29 @@ namespace Providers.Datepicker.Flatpickr {
 			this._setAttributes();
 
 			// Since Flatpickr has a native behaviour (by default) if a mobile device is in use, we must ensure we can add our Classes and TodayBtn to it, since if it's native behaviour we can't do it!
-			if (
-				this.configs.calendarMode === OSUIFramework.Patterns.DatePicker.Enum.Mode.Range ||
-				(OSUIFramework.Helper.DeviceInfo.IsDesktop && OSUIFramework.Helper.DeviceInfo.IsNative === false)
-			) {
-				/* NOTE:
-					If it's not a native app, could we add our stuff to the calendar?
-						- If RangeDate calendar => We do not have a native behaviour for it, so => YES!
-						- If Desktop we also be able to add them
-					
-					Seams confused but we can be at:
-						- iPad Safari (rendered as desktop)
-						- iPad Chrome (rendered as native)
-				*/
+			if (this.provider.calendarContainer !== undefined) {
+				if (
+					this.configs.calendarMode === OSUIFramework.Patterns.DatePicker.Enum.Mode.Range ||
+					(OSUIFramework.Helper.DeviceInfo.IsDesktop && OSUIFramework.Helper.DeviceInfo.IsNative === false)
+				) {
+					/* NOTE:
+						If it's not a native app, could we add our stuff to the calendar?
+							- If RangeDate calendar => We do not have a native behaviour for it, so => YES!
+							- If Desktop we also be able to add them
+						
+						Seams confused but we can be at:
+							- iPad Safari (rendered as desktop)
+							- iPad Chrome (rendered as native)
+					*/
 
-				// Add TodayBtn
-				if (this.configs.ShowTodayButton) {
-					this.addTodayBtn();
+					// Add TodayBtn
+					if (this.configs.ShowTodayButton) {
+						this.addTodayBtn();
+					}
+
+					// Set Calendar CSS classes
+					this._setCalendarCssClasses();
 				}
-
-				// Set Calendar CSS classes
-				this._setCalendarCssClasses();
 			}
 
 			// Trigger platform's InstanceIntializedHandler client Action


### PR DESCRIPTION
This PR is for adding a validation on date picker's provider initialization.

[Sample page](url)

### What was happening

- When using chrome's device inspector and then refreshing the page an error was being thrown.

### What was done

- Added a verification to know if the element we're using as the container is not undefined.

### Test Steps

1. Open Chrome's inspector
2. Select the device inpector
3. Resize the window to a screensize above 1024
4. Refresh the page 

### Checklist

-   [x] tested locally
-   [x] documented the code
-   [x] clean all warnings and errors of eslint
-   [ ] requires changes in OutSystems (if so, provide a module with changes)
-   [ ] requires new sample page in OutSystems (if so, provide a module with changes)
