### PR TITLE
ROU-3325: Update _dropdown-search-and-tags-deprecated.scss V1

### DIFF
--- a/src/scss/10-deprecated/_dropdown-search-and-tags-deprecated.scss
+++ b/src/scss/10-deprecated/_dropdown-search-and-tags-deprecated.scss
@@ -66,6 +66,10 @@
 					user-select: none;
 				}
 
+				&__input::placeholder {
+					color: var(--color-neutral-6);
+				}
+
 				&__item {
 					cursor: not-allowed;
 


### PR DESCRIPTION
This PR is for add the missing styles for disable states

### Checklist
-   [X] tested locally
-   [X] documented the code
-   [X] clean all warnings and errors of eslint
-   [ ] requires changes in OutSystems (if so, provide a module with changes)
-   [ ] requires new sample page in OutSystems (if so, provide a module with changes)
