### PR TITLE
ROU-3430: Remove the underline when a link is placed inside Submenu header

### DIFF
--- a/src/scripts/OSUIFramework/Pattern/Submenu/scss/_submenu.scss
+++ b/src/scripts/OSUIFramework/Pattern/Submenu/scss/_submenu.scss
@@ -37,6 +37,7 @@
 					&,
 					a {
 						color: var(--color-primary);
+						text-decoration: none;
 					}
 				}
 
@@ -121,6 +122,10 @@
 				color: var(--color-neutral-8);
 				display: flex;
 				height: 100%;
+
+				&:hover {
+					text-decoration: none;
+				}
 			}
 		}
 	}


### PR DESCRIPTION
This PR is for remove the underline when a link is placed inside Submenu header

### Checklist

-   [X] tested locally
-   [X] documented the code
-   [X] clean all warnings and errors of eslint
-   [ ] requires changes in OutSystems (if so, provide a module with changes)
-   [ ] requires new sample page in OutSystems (if so, provide a module with changes)
