### PR TITLE
ROU-3445: DropdownTags vertical alignment

### DIFF
--- a/src/scripts/Providers/Dropdown/VirtualSelect/scss/_virtualselect.scss
+++ b/src/scripts/Providers/Dropdown/VirtualSelect/scss/_virtualselect.scss
@@ -355,9 +355,15 @@
 		font-size: var(--font-size-h5);
 		font-weight: var(--font-semi-bold);
 		height: 24px;
-		line-height: 1.1;
+		line-height: 1;
 		text-align: center;
 		width: 24px;
+
+		// Fix vertical alignemnt differences due to system fonts usage
+		.osx &,
+		.ios & {
+			line-height: 1.1;
+		}
 
 		&:hover {
 			background-color: var(--color-neutral-7);


### PR DESCRIPTION
This PR is to merge hotfix already in dev, regarding DropdownTags arrow vertical alignment and hover styles.

### Checklist

-   [x] tested locally
-   [x] documented the code
-   [x] clean all warnings and errors of eslint
-   [x] requires changes in OutSystems (if so, provide a module with changes)
-   [ ] requires new sample page in OutSystems (if so, provide a module with changes)
