### PR TITLE
ROU-3456: Fix false statement

### DIFF
--- a/src/scripts/OutSystems/OSUI/Utils/DeviceDetection.ts
+++ b/src/scripts/OutSystems/OSUI/Utils/DeviceDetection.ts
@@ -53,6 +53,8 @@ namespace OutSystems.OSUI.Utils.DeviceDetection {
 				layout,
 				OSUIFramework.GlobalEnum.CssClassElements.LayoutNative
 			);
+		} else {
+			return false;
 		}
 	}
 
@@ -106,6 +108,8 @@ namespace OutSystems.OSUI.Utils.DeviceDetection {
 				OSUIFramework.Helper.Dom.TagSelector(document.body, '.active-screen .layout.layout-blank');
 
 			return isNotOldNativeLayouts && CheckIsLayoutNative() === false;
+		} else {
+			return false;
 		}
 	}
 	/**


### PR DESCRIPTION
This PR is for fixing the IsWebApp() and IsLayoutNative() actions, when used in the context of a screen, as platform functions

### What was happening
- the method was returning undefined, creating an error with the outsystems parameter, that was expecting a boolean.

### Checklist

-   [x] tested locally
-   [x] documented the code
-   [x] clean all warnings and errors of eslint
-   [x] requires changes in OutSystems (if so, provide a module with changes)
-   [ ] requires new sample page in OutSystems (if so, provide a module with changes)
