### PR TITLE
ROU-3461: Fix timeline line

### DIFF
--- a/src/scss/04-patterns/04-navigation/_timeline.scss
+++ b/src/scss/04-patterns/04-navigation/_timeline.scss
@@ -58,7 +58,7 @@
 }
 
 ///
-[data-block*='TimelineItem'] {
+[data-block='Navigation.TimelineItem'] {
 	&:last-of-type {
 		.timeline-icon {
 			flex-direction: column;


### PR DESCRIPTION
This PR is for the Timeline Pattern when used in contexts of blocks that contains the word TimelineItem as Block Name.


### Checklist

-   [x] tested locally
-   [x] documented the code
-   [x] clean all warnings and errors of eslint
-   [x] requires changes in OutSystems (if so, provide a module with changes)
-   [ ] requires new sample page in OutSystems (if so, provide a module with changes)
