### PR TITLE
ROU-3468-DF: adjust margin on RangeSlider

### DIFF
--- a/src/scripts/OSUIFramework/Pattern/RangeSlider/Enum.ts
+++ b/src/scripts/OSUIFramework/Pattern/RangeSlider/Enum.ts
@@ -6,6 +6,7 @@ namespace OSUIFramework.Patterns.RangeSlider.Enum {
 	export enum CssClass {
 		ClassModifier = 'osui-range-slider--is-',
 		IsInterval = 'osui-range-slider--is-interval',
+		HasTicks = 'osui-range-slider--has-ticks',
 		RangeSlider = 'osui-range-slider',
 		RangeSliderProviderElem = 'osui-range-slider__provider',
 	}

--- a/src/scripts/OSUIFramework/Pattern/RangeSlider/scss/_rangeslider.scss
+++ b/src/scripts/OSUIFramework/Pattern/RangeSlider/scss/_rangeslider.scss
@@ -19,6 +19,22 @@
 		height: var(--range-slider-size);
 	}
 
+	&--has-ticks {
+		.noUi {
+			&-target {
+				margin: var(--space-m) var(--space-none) var(--space-xl);
+			}
+		}
+	}
+
+	&:not(.osui-range-slider--has-ticks) {
+		.noUi {
+			&-target {
+				margin: var(--space-m) var(--space-none);
+			}
+		}
+	}
+
 	// Service Studio Preview
 	& {
 		-servicestudio-margin-bottom: var(--space-base);
@@ -37,7 +53,6 @@
 			border: var(--border-size-none);
 			border-radius: var(--border-radius-soft);
 			box-shadow: none;
-			margin: var(--space-m) var(--space-none) 45px;
 		}
 
 		&-horizontal,

--- a/src/scripts/Providers/RangeSlider/NoUISlider/AbstractNoUiSlider.ts
+++ b/src/scripts/Providers/RangeSlider/NoUISlider/AbstractNoUiSlider.ts
@@ -132,6 +132,18 @@ namespace Providers.RangeSlider.NoUISlider {
 						OSUIFramework.GlobalEnum.Orientation.Vertical
 				);
 			}
+
+			if (this.configs.ShowTickMarks) {
+				OSUIFramework.Helper.Dom.Styles.AddClass(
+					this._selfElem,
+					OSUIFramework.Patterns.RangeSlider.Enum.CssClass.HasTicks
+				);
+			} else {
+				OSUIFramework.Helper.Dom.Styles.RemoveClass(
+					this._selfElem,
+					OSUIFramework.Patterns.RangeSlider.Enum.CssClass.HasTicks
+				);
+			}
 		}
 
 		/**


### PR DESCRIPTION
This PR is to merge the fix to adjust margin on RangeSliders, when showTicks is true.

### Checklist

-   [x] tested locally
-   [x] documented the code
-   [x] clean all warnings and errors of eslint
-   [x] requires changes in OutSystems (if so, provide a module with changes)
-   [ ] requires new sample page in OutSystems (if so, provide a module with changes)
