### PR TITLE
Section-Index: changed partial do current.css

### DIFF
--- a/src/scss/10-deprecated/_section-index-deprecated.scss
+++ b/src/scss/10-deprecated/_section-index-deprecated.scss
@@ -1,8 +1,4 @@
 /*! Patterns - Navigation - Section Index */
-////
-/// @group Patterns-Section_Index
-/// Patterns - Navigation - Section Index
-
 ///
 .section-index {
 	border-left: var(--border-size-s) solid var(--color-neutral-5);

--- a/src/scss/os-ui-current.scss
+++ b/src/scss/os-ui-current.scss
@@ -287,7 +287,7 @@
 @import '04-patterns/04-navigation/bottom-bar-item';
 @import '04-patterns/04-navigation/breadcrumbs';
 @import '04-patterns/04-navigation/pagination';
-@import '10-deprecated/section-index-deprecated';
+@import '../scripts/OSUIFramework/Pattern/SectionIndex/scss/sectionindex';
 @import '../scripts/OSUIFramework/Pattern/Submenu/scss/submenu';
 @import '../scripts/OSUIFramework/Pattern/Tabs/scss/tabs';
 @import '04-patterns/04-navigation/timeline';
@@ -326,6 +326,7 @@
 @import '10-deprecated/progress-bar-deprecated';
 @import '10-deprecated/progress-circle-deprecated';
 @import '10-deprecated/progress-circle-fraction-deprecated';
+@import '10-deprecated/section-index-deprecated';
 @import '10-deprecated/sidebar-deprecated';
 @import '10-deprecated/submenu-deprecated';
 @import '10-deprecated/tooltip-deprecated';


### PR DESCRIPTION
This PR is for moving the deprecated-section-index partial to the deprecated section, and start using the new section-index.scss on the current.css

### Checklist

-   [x] tested locally
-   [x] documented the code
-   [x] clean all warnings and errors of eslint
-   [x] requires changes in OutSystems (if so, provide a module with changes)
-   [ ] requires new sample page in OutSystems (if so, provide a module with changes)
