### PR TITLE
DropdownSearch/Tags: Added UniqueId attribute to the Balloon

### DIFF
--- a/src/scripts/OSUIFramework/GlobalEnum.ts
+++ b/src/scripts/OSUIFramework/GlobalEnum.ts
@@ -101,7 +101,6 @@ namespace OSUIFramework.GlobalEnum {
 		Id = 'id',
 		Name = 'name',
 		Style = 'style',
-		UniqueId = 'unique-id',
 	}
 
 	/**

--- a/src/scripts/Providers/Dropdown/VirtualSelect/AbstractVirtualSelect.ts
+++ b/src/scripts/Providers/Dropdown/VirtualSelect/AbstractVirtualSelect.ts
@@ -106,10 +106,7 @@ namespace Providers.Dropdown.VirtualSelect {
 
 			this._virtualselectMethods = this.provider.$ele;
 			// Since at native devices we're detaching the balloon from pattern context we must set this attribute to it in order to be possible create a relation between pattern default structure and the detached balloon!
-			this.provider.$dropboxContainer.setAttribute(
-				OSUIFramework.GlobalEnum.HTMLAttributes.UniqueId,
-				this.uniqueId
-			);
+			this.provider.$dropboxContainer.setAttribute(OSUIFramework.GlobalEnum.HTMLAttributes.Name, this.uniqueId);
 
 			// Add the pattern Events!
 			this._setUpEvents();


### PR DESCRIPTION
Since at native devices we're detaching the DropdownBalloon from the pattern context we must create a relation between the detached element and the pattern structure.
That said, UniqueId attribute has been added to the DropdownBalloon!
