### PR TITLE
ROU-3587: Fix dropdown z-index inside lists

### DIFF
--- a/src/scripts/OSUIFramework/Pattern/Dropdown/scss/_dropdown-search.scss
+++ b/src/scripts/OSUIFramework/Pattern/Dropdown/scss/_dropdown-search.scss
@@ -13,11 +13,6 @@
 		}
 	}
 
-	// Added this selector to override the z-index because the Virtual Select adds inline z-index to vscomp-wrapper and prevents the visibility of pattern above other patterns
-	.vscomp-wrapper {
-		z-index: 3;
-	}
-
 	// Service Studio Preview
 	&-ss-preview {
 		-servicestudio-background-color: var(--color-neutral-0);

--- a/src/scripts/OSUIFramework/Pattern/Dropdown/scss/_dropdown-tags.scss
+++ b/src/scripts/OSUIFramework/Pattern/Dropdown/scss/_dropdown-tags.scss
@@ -13,11 +13,6 @@
 		}
 	}
 
-	// Added this selector to override the z-index because the Virtual Select adds inline z-index to vscomp-wrapper and prevents the visibility of pattern above other patterns
-	.vscomp-wrapper {
-		z-index: 3;
-	}
-
 	// Service Studio Preview
 	&-ss-preview {
 		-servicestudio-background-color: var(--color-neutral-0);

--- a/src/scss/10-deprecated/_tabs-deprecated.scss
+++ b/src/scss/10-deprecated/_tabs-deprecated.scss
@@ -95,7 +95,7 @@
 		overflow-x: auto;
 		position: relative;
 		width: 100%;
-		z-index: 2;
+		z-index: 1;
 	}
 
 	&-tab {


### PR DESCRIPTION
This PR is for fixing the z-index inside lists, that was making the balloon appear behind the next dropdownBlock

### Checklist

-   [x] tested locally
-   [x] documented the code
-   [x] clean all warnings and errors of eslint
-   [x] requires changes in OutSystems (if so, provide a module with changes)
-   [ ] requires new sample page in OutSystems (if so, provide a module with changes)
