### PR TITLE
ROU-3577: Fixed tabs overflowing 1px

### DIFF
--- a/src/scripts/OSFramework/Pattern/Tabs/scss/_tabs.scss
+++ b/src/scripts/OSFramework/Pattern/Tabs/scss/_tabs.scss
@@ -210,7 +210,7 @@
 
 		&-item {
 			height: 100%;
-			max-width: 99.99%; /* prevent render issues on chrome, in some scree-sizes, due to overflow hidden and css snap */
+			max-width: 99.99%; /* prevent render issues on chrome, in some screen-sizes, due to overflow hidden and css snap */
 			overflow-y: auto;
 			padding: var(--space-m) var(--space-none);
 			scroll-snap-align: start;


### PR DESCRIPTION
This PR is for tabs overflowing 1px in chrome, in some screen sizes, due to the overflow: hidden and css snap properties.

### Checklist

-   [x] tested locally
-   [x] documented the code
-   [x] clean all warnings and errors of eslint
-   [x] requires changes in OutSystems (if so, provide a module with changes)
-   [ ] requires new sample page in OutSystems (if so, provide a module with changes)
