### PR TITLE
Tooltip: Added the data-allow-event-propagation attribute

### DIFF
--- a/src/scripts/OSFramework/GlobalEnum.ts
+++ b/src/scripts/OSFramework/GlobalEnum.ts
@@ -102,6 +102,7 @@ namespace OSFramework.GlobalEnum {
 	 * OutSystemsUI HTML Attributes
 	 */
 	export enum HTMLAttributes {
+		AllowEventPropagation = '[data-allow-event-propagation=true]',
 		DataInput = 'data-input',
 		Disabled = 'disabled',
 		Id = 'id',

--- a/src/scripts/OSFramework/Pattern/Tooltip/Tooltip.ts
+++ b/src/scripts/OSFramework/Pattern/Tooltip/Tooltip.ts
@@ -69,7 +69,9 @@ namespace OSFramework.Patterns.Tooltip {
 		private _onBalloonClick(e: MouseEvent): void {
 			// Get all possible clickable items inside tooltip balloon
 			const clickableItems = Array.from(
-				this._tooltipBalloonContentElem.querySelectorAll(Constants.FocusableElems)
+				this._tooltipBalloonContentElem.querySelectorAll(
+					Constants.FocusableElems + ', ' + GlobalEnum.HTMLAttributes.AllowEventPropagation
+				)
 			);
 
 			// If there no clickable items, do not let the click be propagated!


### PR DESCRIPTION
This PR is for adding the new **data-allow-event-propagation** attribute that will be used to allow the propagation event.
In this use case it's used to be added to a container that will have a click event.