### PR TITLE
Ignore click at [data-allow-event-propagation] child items

### DIFF
--- a/src/scss/05-useful/_miscellaneous.scss
+++ b/src/scss/05-useful/_miscellaneous.scss
@@ -25,6 +25,13 @@
 	visibility: hidden;
 }
 
+/* Used in order to deal with allow propagation event when is't blocked by default
+Example can be checked at Tooltip since we can have clickable containers. */
+///
+[data-allow-event-propagation='true'] > * {
+	pointer-events: none;
+}
+
 // Responsive --------------------------------------------------------------------
 ///
 .tablet .tablet-full-width,


### PR DESCRIPTION
This PR is for adding a selector that will ignore the click into html elements containing [data-allow-event-propagation] attribute in order to properly deal with the event propagation.