### PR TITLE
ROU-3543 - [OSUI] Datepicker - Text alignment of the input when we toggle between native/not native

### DIFF
--- a/src/scripts/Providers/Datepicker/Flatpickr/scss/_flatpickr.scss
+++ b/src/scripts/Providers/Datepicker/Flatpickr/scss/_flatpickr.scss
@@ -420,6 +420,19 @@ span.flatpickr-weekday {
 		// Hack to disable zoom focus on mobile
 		font-size: var(--font-size-base);
 	}
+
+	// Hack to force alignment left on iOS 15+
+	.flatpickr-mobile::-webkit-date-and-time-value {
+		text-align: left;
+	}
+
+	// IsRTL ---------------
+	.is-rtl {
+		// Hack to force alignment right on iOS 15+
+		.flatpickr-mobile::-webkit-date-and-time-value {
+			text-align: right;
+		}
+	}
 }
 
 // IsRTL -------------------------------------------------------------------------


### PR DESCRIPTION
This PR is for fixing the alignment of the date+time on the input since it's different when toggling between native and not native (iOS 15+ version).


### What was happening

- When we use a native date picker on iOS15+ the alignment of the input was always center. 

### What was done

- add a custom selector to force iOS alignment;

### Test Steps

1. With a device iOS15+ interact with a date picker with the native enabled. 
2. Test it in RTL too. 

### Checklist

-   [x] tested locally
-   [x] documented the code
-   [x] clean all warnings and errors of eslint
-   [ ] requires changes in OutSystems 
-   [ ] requires new sample page in OutSystems
