### PR TITLE
ROU-3633 - [OSUI] - Issue with the custom dropdown widget

### DIFF
--- a/src/scss/03-widgets/_dropdown.scss
+++ b/src/scss/03-widgets/_dropdown.scss
@@ -162,6 +162,8 @@ select {
 
 div {
 	&.dropdown-display-content {
+		width: 100%;
+
 		& > span,
 		& > div {
 			font-size: var(--font-size-s);


### PR DESCRIPTION
This PR is for fixing an issue related with the dropdown widget when in custom mode.

### What was happening

- When the dropdown has more than one content it misalign the children

### What was done

-- force width 100% on placeholder div

### Test Steps

1. Use a dropdown in custom mode;
2. Add 2 or more elements inside;
3. Check if the dropdown appears has expected;

### Checklist

-   [x] tested locally
-   [x] documented the code
-   [x] clean all warnings and errors of eslint
-   [ ] requires changes in OutSystems 
-   [ ] requires new sample page in OutSystems
