### PR TITLE
ROU-3650: [Tabs] - Tabs SetActiveTab not working properly

### DIFF
--- a/src/scripts/OSFramework/Pattern/Tabs/ITabs.ts
+++ b/src/scripts/OSFramework/Pattern/Tabs/ITabs.ts
@@ -8,7 +8,8 @@ namespace OSFramework.Patterns.Tabs {
 			tabIndex: number,
 			tabsHeaderItem: TabsHeaderItem.ITabsHeaderItem,
 			blockObserver?: boolean,
-			triggerEvent?: boolean
+			triggerEvent?: boolean,
+			triggeredByObserver?: boolean
 		);
 		toggleDragGestures(addDragGestures: boolean);
 	}

--- a/src/scripts/OutSystems/OSUI/Patterns/TabsAPI.ts
+++ b/src/scripts/OutSystems/OSUI/Patterns/TabsAPI.ts
@@ -187,7 +187,7 @@ namespace OutSystems.OSUI.Patterns.TabsAPI {
 		try {
 			const tabs = GetTabsById(tabsId);
 
-			tabs.changeTab(tabsNumber, undefined, true, true);
+			tabs.changeTab(tabsNumber, undefined, true);
 		} catch (error) {
 			responseObj.isSuccess = false;
 			responseObj.message = error.message;


### PR DESCRIPTION
This PR is for fix an issue at **SetActiveTab()** API method once the tabsContent was not being change.