### PR TITLE
Always update active indicator in Tabs

### DIFF
--- a/src/scripts/OSFramework/Pattern/Tabs/Tabs.ts
+++ b/src/scripts/OSFramework/Pattern/Tabs/Tabs.ts
@@ -840,10 +840,9 @@ namespace OSFramework.Patterns.Tabs {
 				if (triggeredByObserver === false) {
 					this._scrollToTargetContent(newContentItem);
 				}
-
-				// Update active indicator
-				this._handleTabIndicator();
 			}
+			// Update active indicator
+			this._handleTabIndicator();
 
 			// Update configs
 			this.configs.StartingTab = newTabIndex;


### PR DESCRIPTION
This PR is to make it possible to always update the active indicator 


### What was happening

- When the number of Tab Headers is different from the Tabs content the active indicator was not updated:
![ROU3654_Issue](https://user-images.githubusercontent.com/29493222/182792327-1b8e8157-75ce-4ca8-99ba-46c91a46deed.gif)

### What was done

- Now the Tabs active indicator is always updated.

### Test Steps

1. On a page with the number of Tab Headers different from the Tabs content
2. Change Tabs
3. Check that the indicator is updated and the CSS variables as well


### Checklist

-   [X] tested locally
-   [X] documented the code
-   [X] clean all warnings and errors of eslint
-   [ ] requires changes in OutSystems (if so, provide a module with changes)
-   [ ] requires new sample page in OutSystems (if so, provide a module with changes)
