### PR TITLE
Fix SkipToContent function validation

### DIFF
--- a/src/scripts/OutSystems/OSUI/Utils/Accessibility.ts
+++ b/src/scripts/OutSystems/OSUI/Utils/Accessibility.ts
@@ -73,7 +73,7 @@ namespace OutSystems.OSUI.Utils.Accessibility {
 		if (target) {
 			const isFocusable = OSFramework.Helper.Dom.Attribute.Get(target, 'tabindex');
 
-			if (isFocusable === null) {
+			if (isFocusable === undefined) {
 				OSFramework.Helper.Dom.Attribute.Set(target, 'tabindex', '0');
 				target.focus();
 				OSFramework.Helper.Dom.Attribute.Remove(target, 'tabindex');


### PR DESCRIPTION
This PR is for a fix on SkipToContent function that was not working as expected due to an invalid validation.

### What was happening

- In version 2.10.0 SkipToContent didn't focus on the content. 

### What was done

- In SkipToContent function the validation was comparing to null and it should be undefined.

### Test Steps

1. Enable accessibility features on an app
2. Use tab on the header and once focusing on the Skip Content press Enter
3. The focus should now be in the main content as expected 


### Checklist

-   [X] tested locally
-   [X] documented the code
-   [X] clean all warnings and errors of eslint
-   [ ] requires changes in OutSystems (if so, provide a module with changes)
-   [ ] requires new sample page in OutSystems (if so, provide a module with changes)
