### PR TITLE
ROU-3279: Add NoOptionsText optional config to Dropdowns

### DIFF
--- a/src/scripts/Providers/Dropdown/VirtualSelect/AbstractVirtualSelect.ts
+++ b/src/scripts/Providers/Dropdown/VirtualSelect/AbstractVirtualSelect.ts
@@ -218,6 +218,9 @@ namespace Providers.Dropdown.VirtualSelect {
 					case OSFramework.Patterns.Dropdown.Enum.Properties.IsDisabled:
 						this._manageDisableStatus();
 						break;
+					case Enum.Properties.NoOptionsText:
+						this.redraw();
+						break;
 					case Enum.Properties.NoResultsText:
 						this.redraw();
 						break;

--- a/src/scripts/Providers/Dropdown/VirtualSelect/AbstractVirtualSelectConfig.ts
+++ b/src/scripts/Providers/Dropdown/VirtualSelect/AbstractVirtualSelectConfig.ts
@@ -13,6 +13,7 @@ namespace Providers.Dropdown.VirtualSelect {
 		// Store the Provider Options
 		private _providerOptions: VirtualSelectOpts;
 		public ElementId: string;
+		public NoOptionsText: string;
 		public NoResultsText: string;
 		public OptionsList: DropDownOption[];
 		public Prompt: string;
@@ -84,7 +85,7 @@ namespace Providers.Dropdown.VirtualSelect {
 				dropboxWrapper: OSFramework.Constants.Dot + OSFramework.GlobalEnum.CssClassElements.Layout,
 				hideClearButton: false,
 				labelRenderer: this._getOptionInfo.bind(this),
-				noOptionsText: this.NoResultsText,
+				noOptionsText: this.NoOptionsText,
 				noSearchResultsText: this.NoResultsText,
 				options: this.OptionsList as [],
 				placeholder: this.Prompt,
@@ -116,6 +117,9 @@ namespace Providers.Dropdown.VirtualSelect {
 			let validatedValue = undefined;
 
 			switch (key) {
+				case Enum.Properties.NoOptionsText:
+					validatedValue = this.validateString(value as string, undefined);
+					break;
 				case Enum.Properties.NoResultsText:
 					validatedValue = this.validateString(value as string, undefined);
 					break;

--- a/src/scripts/Providers/Dropdown/VirtualSelect/AbstractVirtualSelectEnum.ts
+++ b/src/scripts/Providers/Dropdown/VirtualSelect/AbstractVirtualSelectEnum.ts
@@ -30,6 +30,7 @@ namespace Providers.Dropdown.VirtualSelect.Enum {
 	 * Properties
 	 */
 	export enum Properties {
+		NoOptionsText = 'NoOptionsText',
 		NoResultsText = 'NoResultsText',
 		OptionsList = 'OptionsList',
 		Prompt = 'Prompt',


### PR DESCRIPTION
This PR is for add new parameter NoOptionsText.

### What was done

- Added new parameter in AbstractVirtualSelectConfig
- Added validation of NoOptionsText in validateDefault
- Added redraw when NoOptionsText is changed.

### Test Steps

1. Clear the options of the dropdown. The default value "There are no options to show" appears.
2. Assing new text to NoOptionsText parameter and clear the options of the dropdown. The text assigned should appear.

### Checklist

-   [x] tested locally
-   [x] documented the code
-   [x] clean all warnings and errors of eslint
-   [x] requires changes in OutSystems (if so, provide a module with changes)
-   [x] requires new sample page in OutSystems (if so, provide a module with changes)
