### PR TITLE
ROU-3659: make indicator absolute to prevent overflow

### DIFF
--- a/src/scripts/OSFramework/Pattern/Tabs/scss/_tabs.scss
+++ b/src/scripts/OSFramework/Pattern/Tabs/scss/_tabs.scss
@@ -102,6 +102,8 @@
 		}
 
 		.osui-tabs__header__indicator {
+			bottom: 0;
+			min-width: 1px;
 			height: 2px;
 			transform: translateX(var(--tabs-indicator-transform)) translateY(0) translateZ(0)
 				scaleX(var(--tabs-indicator-scale));
@@ -176,6 +178,7 @@
 
 		&__indicator {
 			background-color: var(--color-primary);
+			position: absolute;
 			transition: transform 200ms linear;
 			transform-origin: 0 0;
 			will-change: transform;


### PR DESCRIPTION
This PR is for fixing some rare cases where the indicator would cause a scrollbar to appear unnecessary.

### Checklist

-   [x] tested locally
-   [x] documented the code
-   [x] clean all warnings and errors of eslint
-   [x] requires changes in OutSystems (if so, provide a module with changes)
-   [ ] requires new sample page in OutSystems (if so, provide a module with changes)
