### PR TITLE
ROU-3737 - [OSUI] TimePicker - Client action to disable the native behavior

### DIFF
--- a/src/scripts/Providers/Timepicker/Flatpickr/FlatpickrTimeConfig.ts
+++ b/src/scripts/Providers/Timepicker/Flatpickr/FlatpickrTimeConfig.ts
@@ -5,7 +5,7 @@ namespace Providers.Timepicker.Flatpickr {
 	 *
 	 * @export
 	 * @class FlatpickrTimeConfig
-	 * @extends {AbstractFlatpickrConfig}
+	 * @extends {AbstractTimePickerConfig}
 	 */
 	export class FlatpickrTimeConfig extends OSFramework.Patterns.TimePicker.AbstractTimePickerConfig {
 		// Store the language that will be assigned as a locale to the TimePicker
@@ -72,6 +72,7 @@ namespace Providers.Timepicker.Flatpickr {
 				altInput: true,
 				allowInput: this.AllowInput,
 				defaultDate: OSFramework.Helper.Times.IsNull(this.InitialTime) ? undefined : this.InitialTime,
+				disableMobile: this.DisableMobile,
 				enableTime: true,
 				noCalendar: true,
 				maxTime: OSFramework.Helper.Times.IsNull(this.MaxTime) ? undefined : this.MaxTime,


### PR DESCRIPTION
This PR is for make available the API to enable/disable the native behavior.

### What was done

- add disableMobile config option to TimePicker provider config;

### Test Steps

1. Add a button to the page;
2. Call the API method setting the value to false;
3. Open the page on a mobile device;
4. Check the input opens as native;
5. Click on the button;
6. Check the picker is redraw with the default behavior;

### Checklist

-   [x] tested locally
-   [x] documented the code
-   [x] clean all warnings and errors of eslint
-   [x] requires changes in OutSystems (if so, provide a module with changes)
-   [ ] requires new sample page in OutSystems (if so, provide a module with changes)
