### PR TITLE
ROU-3759 - [OSUI] - Date Picker closing after selecting date and don't allow time to be selected

### DIFF
--- a/src/scripts/Providers/Datepicker/Flatpickr/AbstractFlatpickr.ts
+++ b/src/scripts/Providers/Datepicker/Flatpickr/AbstractFlatpickr.ts
@@ -12,6 +12,8 @@ namespace Providers.Datepicker.Flatpickr {
 		protected _flatpickrInputElem: HTMLInputElement;
 		// Store the provider options
 		protected _flatpickrOpts: FlatpickrOptions;
+		// Store on a flag status when the picker is updating the default date;
+		protected _isUpdatingDefaultDate = false;
 		// Flatpickr onChange (SelectedDate) event
 		protected _onChangeCallbackEvent: OSFramework.Patterns.DatePicker.Callbacks.OSOnChangeEvent;
 

--- a/src/scripts/Providers/Datepicker/Flatpickr/RangeDate/FlatpickrRangeDate.ts
+++ b/src/scripts/Providers/Datepicker/Flatpickr/RangeDate/FlatpickrRangeDate.ts
@@ -64,6 +64,26 @@ namespace Providers.Datepicker.Flatpickr.RangeDate {
 		 * @memberof Flatpickr.RangeDate
 		 */
 		protected prepareConfigs(): void {
+			if (this._isUpdatingDefaultDate === false) {
+				// Check if any Date was selected
+				if (this.provider?.selectedDates.length > 0) {
+					// Set the new Start DefaultDate value
+					this.configs.InitialStartDate = this.provider.formatDate(
+						this.provider.selectedDates[0],
+						this._flatpickrOpts.dateFormat
+					);
+
+					// Set the new End DefaultDate value
+					if (this.provider.selectedDates[1]) {
+						this.configs.InitialEndDate = this.provider.formatDate(
+							this.provider.selectedDates[1],
+							this._flatpickrOpts.dateFormat
+						);
+					}
+				}
+			}
+
+			this._isUpdatingDefaultDate = false;
 			// Get the library configurations
 			this._flatpickrOpts = this.configs.getProviderConfig();
 
@@ -119,6 +139,7 @@ namespace Providers.Datepicker.Flatpickr.RangeDate {
 		 * @memberof Flatpickr.RangeDate
 		 */
 		public updateInitialDate(startDate: string, endDate: string): void {
+			this._isUpdatingDefaultDate = true;
 			// Redefine the Initial dates
 			this.configs.InitialStartDate = startDate;
 			this.configs.InitialEndDate = endDate;

--- a/src/scripts/Providers/Datepicker/Flatpickr/SingleDate/FlatpickrSingleDate.ts
+++ b/src/scripts/Providers/Datepicker/Flatpickr/SingleDate/FlatpickrSingleDate.ts
@@ -29,6 +29,19 @@ namespace Providers.Datepicker.Flatpickr.SingleDate {
 		 * @memberof Flatpickr.SingleDate
 		 */
 		protected prepareConfigs(): void {
+			if (this._isUpdatingDefaultDate === false) {
+				// Check if any Date was selected
+				if (this.provider?.selectedDates.length > 0) {
+					// Set the new DefaultDate values
+					this.configs.InitialDate = this.provider.formatDate(
+						this.provider.selectedDates[0],
+						this._flatpickrOpts.dateFormat
+					);
+				}
+			}
+
+			this._isUpdatingDefaultDate = false;
+
 			// Get the library configurations
 			this._flatpickrOpts = this.configs.getProviderConfig();
 
@@ -96,6 +109,7 @@ namespace Providers.Datepicker.Flatpickr.SingleDate {
 		 * @memberof Flatpickr.SingleDate
 		 */
 		public updateInitialDate(value: string): void {
+			this._isUpdatingDefaultDate = true;
 			// Redefine the Initial date
 			this.configs.InitialDate = value;
 			// Trigger the Redraw method in order to update calendar with this new value


### PR DESCRIPTION
This PR is for fixing an issue related to redraws made while interacting with the picker or its APIs


### What was happening

- Some APIs need to redraw the picker to have the results displayed correctly, however, this was not possible to happen since the provider didn't have the right info about the defaultDate (it was never updated internally)

### What was done
- set InitialStartDate and InitialEndDate taking into consideration selectedDates;
- add isUpdatingDefaultDate flag;

### Test Steps

1. Add a DatePicker to a page;
2. Add a Button to call DatePickerDisableWeekDays;
3. Add a Button to call DatePickerUpdateDate and an input to feed this API;
4. On the page select a date, and click on the disable days button;
5. Check if the Picker was refreshed with the disabled days and the selected date is correct;
6. Click on the button to update the date;
7. Check if the selected date is updated; 

### Checklist

-   [x] tested locally
-   [x] documented the code
-   [x] clean all warnings and errors of eslint
-   [ ] requires changes in OutSystems (if so, provide a module with changes)
-   [ ] requires new sample page in OutSystems (if so, provide a module with changes)
