### PR TITLE
ROU-3773: fixed intialDate logic

### DIFF
--- a/src/scripts/Providers/Datepicker/Flatpickr/RangeDate/FlatpickrRangeDate.ts
+++ b/src/scripts/Providers/Datepicker/Flatpickr/RangeDate/FlatpickrRangeDate.ts
@@ -68,17 +68,11 @@ namespace Providers.Datepicker.Flatpickr.RangeDate {
 				// Check if any Date was selected
 				if (this.provider?.selectedDates.length > 0) {
 					// Set the new Start DefaultDate value
-					this.configs.InitialStartDate = this.provider.formatDate(
-						this.provider.selectedDates[0],
-						this._flatpickrOpts.dateFormat
-					);
+					this.configs.InitialStartDate = this.provider.selectedDates[0];
 
 					// Set the new End DefaultDate value
 					if (this.provider.selectedDates[1]) {
-						this.configs.InitialEndDate = this.provider.formatDate(
-							this.provider.selectedDates[1],
-							this._flatpickrOpts.dateFormat
-						);
+						this.configs.InitialEndDate = this.provider.selectedDates[1];
 					}
 				}
 			}

--- a/src/scripts/Providers/Datepicker/Flatpickr/SingleDate/FlatpickrSingleDate.ts
+++ b/src/scripts/Providers/Datepicker/Flatpickr/SingleDate/FlatpickrSingleDate.ts
@@ -33,10 +33,7 @@ namespace Providers.Datepicker.Flatpickr.SingleDate {
 				// Check if any Date was selected
 				if (this.provider?.selectedDates.length > 0) {
 					// Set the new DefaultDate values
-					this.configs.InitialDate = this.provider.formatDate(
-						this.provider.selectedDates[0],
-						this._flatpickrOpts.dateFormat
-					);
+					this.configs.InitialDate = this.provider.selectedDates[0];
 				}
 			}
 


### PR DESCRIPTION
This PR is for fixing the redraw issue on Safari <16,  introduced by ROU-3759. 

Why the issue was happening was happening only on this browser is still unknown to me, but the change here fixes it and it does make sense, as it seems that we shouldn't apply the provider format on that moment. 
Not only because it is being destroyed on another async call, but also because the correct final format will be handled on the AbstractConfig, by the checkServerDateFormat() method


### Checklist

-   [x] tested locally
-   [x] documented the code
-   [x] clean all warnings and errors of eslint
-   [x] requires changes in OutSystems (if so, provide a module with changes)
-   [ ] requires new sample page in OutSystems (if so, provide a module with changes)
