### PR TITLE
ROU-3811: [Datepickers] - Calendar is fixed after being opened

### DIFF
--- a/src/scripts/Providers/Datepicker/Flatpickr/AbstractFlatpickr.ts
+++ b/src/scripts/Providers/Datepicker/Flatpickr/AbstractFlatpickr.ts
@@ -87,7 +87,7 @@ namespace Providers.Datepicker.Flatpickr {
 		// Add Events
 		private _setUpEvents(): void {
 			// Check if native behaviour is disabled
-			if (this.configs.DisableMobile === true) {
+			if (OSFramework.Helper.DeviceInfo.IsDesktop || this.configs.DisableMobile === true) {
 				// Add the BodyScroll callback that will be used to update the balloon coodinates
 				OSFramework.Event.GlobalEventManager.Instance.addHandler(
 					OSFramework.Event.Type.BodyOnScroll,
@@ -99,7 +99,7 @@ namespace Providers.Datepicker.Flatpickr {
 		// Remove Added Events
 		private _unsetEvents(): void {
 			// Check if native behaviour is disabled
-			if (this.configs.DisableMobile === true) {
+			if (OSFramework.Helper.DeviceInfo.IsDesktop || this.configs.DisableMobile === true) {
 				OSFramework.Event.GlobalEventManager.Instance.removeHandler(
 					OSFramework.Event.Type.BodyOnScroll,
 					this._eventOnBodyScroll


### PR DESCRIPTION
This PR is for adding an improvement to the Datepickers calendar since calendar was getting fixed after being opened and user do scroll on the screen. With this fix calendar will follow the input during the onScroll.