### PR TITLE
Removed duplicated imported SCSS. Updated calendar z-index.

### DIFF
--- a/src/scripts/Providers/SharedProviderResources/Flatpickr/scss/_flatpickr.scss
+++ b/src/scripts/Providers/SharedProviderResources/Flatpickr/scss/_flatpickr.scss
@@ -8,6 +8,10 @@
 	box-shadow: var(--shadow-none);
 	width: 320px;
 
+	&.open {
+		z-index: 99;
+	}
+
 	&.arrowTop {
 		&:before,
 		&::after {

--- a/src/scripts/Providers/Timepicker/Flatpickr/scss/_flatpickr.scss
+++ b/src/scripts/Providers/Timepicker/Flatpickr/scss/_flatpickr.scss
@@ -1,5 +1,3 @@
-@import '../../../SharedProviderResources/Flatpickr/flatpickr.scss';
-
 // TimePicker
 .osui-timepicker__dropdown {
 	.numInputWrapper {


### PR DESCRIPTION
This PR is for will remove an duplicated imported scss partial and will update the z-index for the flatpicker calendar in order to not be on top of the menu!