### PR TITLE
ROU-3711: (v2) Fixed safari render issue

### DIFF
--- a/src/scripts/OSFramework/Pattern/Tabs/scss/_tabs.scss
+++ b/src/scripts/OSFramework/Pattern/Tabs/scss/_tabs.scss
@@ -139,6 +139,7 @@
 
 	&__header {
 		display: grid;
+		height: -webkit-fit-content; // this is important to fix Safari render issues on onRender changes
 		position: relative;
 		z-index: 1;
 


### PR DESCRIPTION
This PR is for fixing a Safari render issue after the onRender update and when scroll is visible, so that the header-item height correctly adapts to the changes.

### Checklist

-   [x] tested locally
-   [x] documented the code
-   [x] clean all warnings and errors of eslint
-   [ ] requires changes in OutSystems (if so, provide a module with changes)
-   [ ] requires new sample page in OutSystems (if so, provide a module with changes)
