### PR TITLE
ROU-3821 - [OSUI] Datepicker - Error validation doesn't have a red border

### DIFF
--- a/src/scripts/OSFramework/Pattern/DatePicker/scss/_datepicker.scss
+++ b/src/scripts/OSFramework/Pattern/DatePicker/scss/_datepicker.scss
@@ -98,6 +98,10 @@
 			}
 		}
 	}
+
+	.not-valid + .input {
+		border-color: var(--color-error);
+	}
 }
 
 ///

--- a/src/scripts/OSFramework/Pattern/MonthPicker/scss/_monthpicker.scss
+++ b/src/scripts/OSFramework/Pattern/MonthPicker/scss/_monthpicker.scss
@@ -39,6 +39,10 @@
 			}
 		}
 	}
+
+	.not-valid + .input {
+		border-color: var(--color-error);
+	}
 }
 
 ///

--- a/src/scripts/OSFramework/Pattern/TimePicker/scss/_timepicker.scss
+++ b/src/scripts/OSFramework/Pattern/TimePicker/scss/_timepicker.scss
@@ -72,6 +72,10 @@
 			}
 		}
 	}
+
+	.not-valid + .input {
+		border-color: var(--color-error);
+	}
 }
 
 ///


### PR DESCRIPTION
This PR is for fixing the style of invalid pickers.

### What was happening
- When the inputs inside the pickers were not-valid, we weren't giving that feedback visually. Because the input that has the state is hidden and the one we are seeing is a clone that doesn't have the invalid state.

### What was done

- Add border-error to pickers Inputs;

### Test Steps

1. Add a Picker to the page
2. Call a action to change the valid value.
3. At runtime call the action
4. Check if the input is invalid

### Checklist

-   [x] tested locally
-   [x] documented the code
-   [x] clean all warnings and errors of eslint
-   [ ] requires changes in OutSystems (if so, provide a module with changes)
-   [ ] requires new sample page in OutSystems (if so, provide a module with changes)
