### PR TITLE
ROU-3802 - Sidebar not working properly within Tabs

### DIFF
--- a/src/scripts/OSFramework/Pattern/Tabs/scss/_tabs.scss
+++ b/src/scripts/OSFramework/Pattern/Tabs/scss/_tabs.scss
@@ -24,7 +24,6 @@
 				}
 
 				& > .osui-tabs__header__indicator {
-					z-index: 1;
 					left: 0;
 				}
 			}
@@ -46,7 +45,6 @@
 				}
 
 				& > .osui-tabs__header__indicator {
-					z-index: 1;
 					right: 0;
 				}
 			}
@@ -104,7 +102,6 @@
 		}
 
 		.osui-tabs__header__indicator {
-			z-index: 1;
 			bottom: 0;
 			min-width: 1px;
 			height: 2px;
@@ -185,6 +182,7 @@
 			transition: transform 200ms linear;
 			transform-origin: 0 0;
 			will-change: transform;
+			z-index: 1;
 
 			&[disabled] {
 				background-color: var(--color-neutral-6);


### PR DESCRIPTION
This PR is for fix sidebar not working properly within Tabs

### What was happening
- The tabs where overlapping the sidebar when the sidebars were placed inside tabs.

### What was done
- Removed the z-index from Tabs header and content
- Added `z-index:1` to the header indicator so that it appears above the gray top border of the tabs content

### Test steps
- Go to the sample test page
- For each screen check if the sidebar is not being overlapped by the tabs .

### Checklist

-   [x] tested locally
-   [x] documented the code
-   [x] clean all warnings and errors of eslint
-   [ ] requires changes in OutSystems (if so, provide a module with changes)
-   [ ] requires new sample page in OutSystems (if so, provide a module with changes)
