### PR TITLE
ROU-3831v2: fixed dropdown z-index with header

### DIFF
--- a/src/scripts/Providers/Dropdown/VirtualSelect/scss/_virtualselect.scss
+++ b/src/scripts/Providers/Dropdown/VirtualSelect/scss/_virtualselect.scss
@@ -30,7 +30,6 @@
 // Wrapper container
 .vscomp-wrapper {
 	position: relative;
-	z-index: 300;
 
 	&.focused,
 	&:focus {
@@ -517,6 +516,10 @@ body {
 	&.vscomp-popup-active {
 		.vscomp-wrapper:not(.focused) {
 			z-index: 0;
+		}
+
+		.vscomp-wrapper {
+			z-index: 300;
 		}
 	}
 }


### PR DESCRIPTION
This PR is for fixing the z-index to account for the layout header and instead make the rule more specific for when is in popup mode.

### Checklist

-   [x] tested locally
-   [x] documented the code
-   [x] clean all warnings and errors of eslint
-   [ ] requires changes in OutSystems (if so, provide a module with changes)
-   [ ] requires new sample page in OutSystems (if so, provide a module with changes)
