### PR TITLE
MasterDetail - Close RightButton once at Tablet.

### DIFF
--- a/src/scss/04-patterns/01-adaptive/_master-detail.scss
+++ b/src/scss/04-patterns/01-adaptive/_master-detail.scss
@@ -160,6 +160,7 @@
 			padding-top: calc(var(--header-size) + var(--os-safe-area-top));
 
 			.split-right-close {
+				display: block;
 				left: calc(var(--os-safe-area-left) + var(--space-base));
 			}
 		}


### PR DESCRIPTION
This PR is for fixing an issue that was preventing the display of the close right content once at tablet.
This was happening due to an issue that is adding phone and desktop classes to the body at the same time once we're at native apps and at iPadMini.