### PR TITLE
ROU-3856: fix dropdowns resize event lifecycle

### DIFF
--- a/src/scripts/Providers/Dropdown/VirtualSelect/AbstractVirtualSelect.ts
+++ b/src/scripts/Providers/Dropdown/VirtualSelect/AbstractVirtualSelect.ts
@@ -162,7 +162,7 @@ namespace Providers.Dropdown.VirtualSelect {
 			this.provider.destroy();
 
 			// Create a new VirtualSelect instance with the updated configs
-			this.prepareConfigs();
+			OSFramework.Helper.AsyncInvocation(this.prepareConfigs.bind(this));
 		}
 
 		/**


### PR DESCRIPTION
This PR is for fixing an error triggered by resize event handlers belonging to provider instances that no longer exist.

### Checklist

-   [x] tested locally
-   [x] documented the code
-   [x] clean all warnings and errors of eslint
-   [x] requires changes in OutSystems (if so, provide a module with changes)
-   [ ] requires new sample page in OutSystems (if so, provide a module with changes)
