### PR TITLE
[ROU-3857]: DatePicker and DatePickerRange - Fix issues

### DIFF
--- a/src/scripts/Providers/Datepicker/Flatpickr/AbstractFlatpickrConfig.ts
+++ b/src/scripts/Providers/Datepicker/Flatpickr/AbstractFlatpickrConfig.ts
@@ -167,10 +167,7 @@ namespace Providers.Datepicker.Flatpickr {
 				allowInput: this.AllowInput,
 				disable: this.Disable.length === 0 ? undefined : this.Disable,
 				disableMobile: this.DisableMobile,
-				dateFormat:
-					this.TimeFormat !== OSFramework.Patterns.DatePicker.Enum.TimeFormatMode.Disable
-						? this.ServerDateFormat + ' H:i:s' // do not change 'H:i:s' since it's absoluted needed due to platform conversions!
-						: this.ServerDateFormat,
+				dateFormat: this.ServerDateFormat + ' H:i:s', // do not change 'H:i:s' since it's absoluted needed due to platform conversions, it's needed even when dateformat does not contain time, otherwise platform will not deal well with the dates conversion!
 				maxDate: OSFramework.Helper.Dates.IsNull(this.MaxDate) ? undefined : this.MaxDate,
 				minDate: OSFramework.Helper.Dates.IsNull(this.MinDate) ? undefined : this.MinDate,
 				onChange: this.OnChange,

--- a/src/scripts/Providers/Datepicker/Flatpickr/RangeDate/FlatpickrRangeDate.ts
+++ b/src/scripts/Providers/Datepicker/Flatpickr/RangeDate/FlatpickrRangeDate.ts
@@ -48,13 +48,16 @@ namespace Providers.Datepicker.Flatpickr.RangeDate {
 				}
 			}
 
-			// Trigger platform's onChange callback event
-			OSFramework.Helper.AsyncInvocation(
-				this._onSelectedCallbackEvent,
-				this.widgetId,
-				_selectedDate[0],
-				_selectedDate[1]
-			);
+			// Ensure user has selected start and end dates before trigger the onSelectedDate callback!
+			if (selectedDates.length === 2) {
+				// Trigger platform's onChange callback event
+				OSFramework.Helper.AsyncInvocation(
+					this._onSelectedCallbackEvent,
+					this.widgetId,
+					_selectedDate[0],
+					_selectedDate[1]
+				);
+			}
 		}
 
 		/**


### PR DESCRIPTION
This PR is for fixing issues related with platform date conversion...
- When an input was inside a Form during the form validation the date structure was being passed into platform was ending on issues due to missing seconds on the passed date.
- Other issue was related with DatepickerRange since after open the Start/End dates to be updated at the OnParametersChange once the StartDate was selected a redraw was being happen and calendar was getting closed before letting user select the EndDate.