### PR TITLE
ROU-3906: Removed redraw as async

### DIFF
--- a/src/scripts/OSFramework/Pattern/AbstractProviderPattern.ts
+++ b/src/scripts/OSFramework/Pattern/AbstractProviderPattern.ts
@@ -98,7 +98,7 @@ namespace OSFramework.Patterns {
 				this._provider.destroy();
 
 				// Trigger a new instance creation with updated configs
-				Helper.AsyncInvocation(this.prepareConfigs.bind(this));
+				this.prepareConfigs();
 			}
 		}
 

--- a/src/scripts/Providers/Carousel/Splide/Splide.ts
+++ b/src/scripts/Providers/Carousel/Splide/Splide.ts
@@ -147,6 +147,7 @@ namespace Providers.Carousel.Splide {
 		 * @memberof Providers.Carousel.Splide.OSUISplide
 		 */
 		protected prepareConfigs(): void {
+			this._prepareCarouselItems();
 			// Call the following methods here, so that all DOM elements are iterated and ready to init the library
 			this._splideOptions = this.configs.getProviderConfig();
 			// Init the Library
@@ -216,8 +217,6 @@ namespace Providers.Carousel.Splide {
 			}
 
 			this._togglePaginationClass();
-
-			this._prepareCarouselItems();
 		}
 
 		/**


### PR DESCRIPTION
This PR is for fixing a render issue on Carousel, where the provider was being created, without the html being ready for it.

Also, due to a async call on the redraw() method, the provider was being init without the most updated version of the configs, which was making the extensibility options to be ignored.

### Checklist

-   [ ] tested locally
-   [ ] documented the code
-   [ ] clean all warnings and errors of eslint
-   [ ] requires changes in OutSystems (if so, provide a module with changes)
-   [ ] requires new sample page in OutSystems (if so, provide a module with changes)
