### PR TITLE
ROU-3907: Push pickers box to front inside of popups

### DIFF
--- a/src/scripts/Providers/SharedProviderResources/Flatpickr/scss/_flatpickr.scss
+++ b/src/scripts/Providers/SharedProviderResources/Flatpickr/scss/_flatpickr.scss
@@ -8,10 +8,6 @@
 	box-shadow: var(--shadow-none);
 	width: 320px;
 
-	&.open {
-		z-index: 99;
-	}
-
 	&.arrowTop {
 		&:before,
 		&::after {


### PR DESCRIPTION
This PR is for fixing the visibility of pickers box when is inside of popups. Check the JIRA issue for more information.

### Checklist
-   [X] tested locally
-   [X] documented the code
-   [X] clean all warnings and errors of eslint
-   [ ] requires changes in OutSystems (if so, provide a module with changes)
-   [ ] requires new sample page in OutSystems (if so, provide a module with changes)
