### PR TITLE
ROU-3908: fix columns inside tabs

### DIFF
--- a/src/scripts/OSFramework/Pattern/Tabs/scss/_tabs.scss
+++ b/src/scripts/OSFramework/Pattern/Tabs/scss/_tabs.scss
@@ -213,11 +213,15 @@
 
 		&-item {
 			height: 100%;
-			max-width: 99.99%; /* prevent render issues on chrome, in some screen-sizes, due to overflow hidden and css snap */
 			overflow-y: auto;
 			padding: var(--space-m) var(--space-none);
 			scroll-snap-align: start;
 			scroll-snap-stop: always;
+
+			&,
+			* {
+				max-width: 99.99%; /* prevent render issues on chrome, in some screen-sizes, due to overflow hidden and css snap */
+			}
 
 			// Service Studio Preview
 			& {


### PR DESCRIPTION
This PR is for preventing scroll inside tabs when using columns, when scroll is not needed.

### Checklist

-   [x] tested locally
-   [x] documented the code
-   [x] clean all warnings and errors of eslint
-   [ ] requires changes in OutSystems (if so, provide a module with changes)
-   [ ] requires new sample page in OutSystems (if so, provide a module with changes)
