### PR TITLE
Update _ios-bounce.scss

### DIFF
--- a/src/scss/02-layout/_ios-bounce.scss
+++ b/src/scss/02-layout/_ios-bounce.scss
@@ -31,7 +31,7 @@
 				}
 
 				.pull-to-refresh {
-					top: var(--header-size, 0);
+					top: calc(var(--header-size) + var(--header-size-content) + var(--os-safe-area-top));
 				}
 
 				.content {


### PR DESCRIPTION
This PR is to fix an issue in the Pull to Refresh loading not showing when HeaderContent placeholder has elements.

### What was happening

-  Pull to Refresh loading not showing when HeaderContent placeholder has elements:
![IssuePullRefreshiOS](https://user-images.githubusercontent.com/29493222/199059886-8a7ed3c6-7434-41d9-9fa7-08e1eee02c70.gif)


### What was done

- Fixed a CSS selector applicable only on mobile applications when running in iOS and with the layout input UsePullToRefresh = True

### Test Steps

Test Case 1:
1. Go to the test page "TestPullToRefresh_NoHeaderContent"
2. Pull to refresh and check that the loading appears and disappears afterwards

Test Case 2
1. Go to the test page "TestPullToRefresh_WithHeaderContent"
2. Pull to refresh and check that the loading appears and disappears afterwards


### Checklist

-   [X] tested locally
-   [ ] documented the code
-   [ ] clean all warnings and errors of eslint
-   [ ] requires changes in OutSystems (if so, provide a module with changes)
-   [X] requires new sample page in OutSystems (if so, provide a module with changes)
