### PR TITLE
ROU-3866: Added new TimeFormat parameter to TimePicker

### DIFF
--- a/src/scripts/OSFramework/Pattern/TimePicker/AbstractTimePickerConfig.ts
+++ b/src/scripts/OSFramework/Pattern/TimePicker/AbstractTimePickerConfig.ts
@@ -6,6 +6,7 @@ namespace OSFramework.Patterns.TimePicker {
 		public Is24Hours: boolean;
 		public MaxTime: string;
 		public MinTime: string;
+		public TimeFormat: string;
 
 		constructor(config: JSON) {
 			super(config);

--- a/src/scripts/OSFramework/Pattern/TimePicker/Enum.ts
+++ b/src/scripts/OSFramework/Pattern/TimePicker/Enum.ts
@@ -24,6 +24,7 @@ namespace OSFramework.Patterns.TimePicker.Enum {
 		Is24Hours = 'Is24Hours',
 		MaxTime = 'MaxTime',
 		MinTime = 'MinTime',
+		TimeFormat = 'TimeFormat',
 	}
 
 	/**

--- a/src/scripts/Providers/Timepicker/Flatpickr/FlatpickrTime.ts
+++ b/src/scripts/Providers/Timepicker/Flatpickr/FlatpickrTime.ts
@@ -240,6 +240,7 @@ namespace Providers.TimePicker.Flatpickr {
 					case OSFramework.Patterns.TimePicker.Enum.Properties.Is24Hours:
 					case OSFramework.Patterns.TimePicker.Enum.Properties.MaxTime:
 					case OSFramework.Patterns.TimePicker.Enum.Properties.MinTime:
+					case OSFramework.Patterns.TimePicker.Enum.Properties.TimeFormat:
 						this.redraw();
 						break;
 					case OSFramework.GlobalEnum.CommonPatternsProperties.ExtendedClass:

--- a/src/scripts/Providers/Timepicker/Flatpickr/FlatpickrTimeConfig.ts
+++ b/src/scripts/Providers/Timepicker/Flatpickr/FlatpickrTimeConfig.ts
@@ -78,7 +78,7 @@ namespace Providers.TimePicker.Flatpickr {
 		 */
 		public getProviderConfig(): FlatpickrOptions {
 			this._providerOptions = {
-				altFormat: this._checkAltFormat(),
+				altFormat: this.TimeFormat ? this.TimeFormat : this._checkAltFormat(),
 				altInput: true,
 				allowInput: this.AllowInput,
 				defaultDate: OSFramework.Helper.Times.IsNull(this.InitialTime) ? undefined : this.InitialTime,


### PR DESCRIPTION
This PR is for add new TimeFormat parameter to TimePicker

### What was done

- Added new TimeFormat parameter to AbstractTimePicker.
- Modified the getProviderConfig method of FlatpickrTimeConfig so that when a TimeFormat is defined, it is assigned to the altFormat provider config option.
- Modified FlatpickrTime's changeProperty method so that the pattern reacts to TimeFormat changes.


### Test Steps

1. Go to test page
2. Set TimeFormat input field to "G:i K".
3. Set the Initial Time input field to "13:12:11"
4. Click on Apply button
Expected: The displayed time should be "01:12 PM"
5. Set TimeFormat input field to "H\\hi\\m".
6. Click on Apply button
Expected: The displayed time should be "13h12m"


### Checklist

-   [x] tested locally
-   [x] documented the code
-   [x] clean all warnings and errors of eslint
-   [x] requires changes in OutSystems (if so, provide a module with changes)
-   [ ] requires new sample page in OutSystems (if so, provide a module with changes)
