### PR TITLE
ROU-3825: fixed inline styles for pickers

### DIFF
--- a/src/scripts/Providers/SharedProviderResources/Flatpickr/scss/_flatpickr.scss
+++ b/src/scripts/Providers/SharedProviderResources/Flatpickr/scss/_flatpickr.scss
@@ -55,6 +55,10 @@
 			}
 		}
 	}
+
+	&.inline {
+		display: inline-block;
+	}
 }
 
 // Flatpickr - Top info wrapper container


### PR DESCRIPTION
This PR is for fixing the monthPicker styles when inline is true.

### Checklist

-   [ ] tested locally
-   [ ] documented the code
-   [ ] clean all warnings and errors of eslint
-   [ ] requires changes in OutSystems (if so, provide a module with changes)
-   [ ] requires new sample page in OutSystems (if so, provide a module with changes)
