### PR TITLE
ROU-3900: Keep the same UI on Close icon

### DIFF
--- a/src/scripts/Providers/Dropdown/VirtualSelect/scss/_virtualselect.scss
+++ b/src/scripts/Providers/Dropdown/VirtualSelect/scss/_virtualselect.scss
@@ -32,7 +32,6 @@
 				&::before {
 					background-color: inherit;
 					left: 50%;
-					transform: none;
 					transform: translateX(-50%);
 				}
 			}
@@ -42,11 +41,8 @@
 	&-ele .vscomp-clear-icon:after,
 	&-search-clear:after {
 		align-items: center;
-		align-items: center;
 		color: var(--color-neutral-7);
 		content: '\f00d';
-		display: -ms-flexbox;
-		display: -webkit-box;
 		display: flex;
 		font: normal normal normal 14px/1 FontAwesome;
 		height: 100%;


### PR DESCRIPTION
This PR is for fixing the issue on UI inside the Dropdown Search that has different styles for each close icon. Please check the JIRA issue for more info.

### Checklist
-   [X] tested locally
-   [X] documented the code
-   [X] clean all warnings and errors of eslint
-   [ ] requires changes in OutSystems (if so, provide a module with changes)
-   [ ] requires new sample page in OutSystems (if so, provide a module with changes)
