### PR TITLE
ROU-3930: Added fix for indicator render issue

### DIFF
--- a/src/scripts/OSFramework/Pattern/Tabs/scss/_tabs.scss
+++ b/src/scripts/OSFramework/Pattern/Tabs/scss/_tabs.scss
@@ -178,6 +178,7 @@
 
 		&__indicator {
 			background-color: var(--color-primary);
+			perspective: 1000px; // prevent rendering issues on webkit browsers, when inside overflow elements
 			position: absolute;
 			transition: transform 200ms linear;
 			transform-origin: 0 0;


### PR DESCRIPTION
This PR is for fixing a render issue on chrome when tabs were inside the Accordion, the indicator was not appearing.

### Checklist

-   [x] tested locally
-   [x] documented the code
-   [x] clean all warnings and errors of eslint
-   [x] requires changes in OutSystems (if so, provide a module with changes)
-   [ ] requires new sample page in OutSystems (if so, provide a module with changes)
