### PR TITLE
ROU-3930: (v2) make perspective apply only on desktop webkit

### DIFF
--- a/src/scripts/OSFramework/Pattern/Tabs/scss/_tabs.scss
+++ b/src/scripts/OSFramework/Pattern/Tabs/scss/_tabs.scss
@@ -178,7 +178,6 @@
 
 		&__indicator {
 			background-color: var(--color-primary);
-			perspective: 1000px; // prevent rendering issues on webkit browsers, when inside overflow elements
 			position: absolute;
 			transition: transform 200ms linear;
 			transform-origin: 0 0;
@@ -326,6 +325,16 @@
 				box-shadow: 0 0 0 1px var(--color-focus-outer) inset;
 			}
 		}
+	}
+}
+
+// Browser specific rules
+.windows.chrome,
+.windows.edge,
+.osx.chrome,
+.osx.edge {
+	.osui-tabs__header__indicator {
+		perspective: 1000px; // prevent rendering issues on webkit browsers, when inside overflow elements
 	}
 }
 


### PR DESCRIPTION
This PR is for making the rule only for webkit browsers on non-native apps.

### Checklist

-   [x] tested locally
-   [x] documented the code
-   [x] clean all warnings and errors of eslint
-   [ ] requires changes in OutSystems (if so, provide a module with changes)
-   [ ] requires new sample page in OutSystems (if so, provide a module with changes)
