### PR TITLE
ROU-3815: fix tabs indicator zoom

### DIFF
--- a/src/scripts/OSFramework/Pattern/Tabs/Tabs.ts
+++ b/src/scripts/OSFramework/Pattern/Tabs/Tabs.ts
@@ -284,7 +284,8 @@ namespace OSFramework.Patterns.Tabs {
 				const newSize = isVertical ? activeElement.offsetHeight : activeElement.offsetWidth;
 
 				// translate pixel sized value to a scale value
-				const newScaleValue = newSize / currentSize;
+				// devicePixelRatio used here to account for browser or system zoom
+				const newScaleValue = (devicePixelRatio * (newSize / currentSize)) / Math.round(devicePixelRatio);
 
 				// Update the css variables, that will trigger a transform transition
 				function updateIndicatorUI() {


### PR DESCRIPTION
This PR is for fixing the tab indicator size when using browser or system zoom.

### Checklist

-   [ ] tested locally
-   [ ] documented the code
-   [ ] clean all warnings and errors of eslint
-   [ ] requires changes in OutSystems (if so, provide a module with changes)
-   [ ] requires new sample page in OutSystems (if so, provide a module with changes)
