### PR TITLE
ROU-3815: fix zoom on firefox and chrome

### DIFF
--- a/src/scripts/OSFramework/Pattern/Tabs/Tabs.ts
+++ b/src/scripts/OSFramework/Pattern/Tabs/Tabs.ts
@@ -32,6 +32,8 @@ namespace OSFramework.Patterns.Tabs {
 		private _hasSingleContent: boolean;
 		// Store the number of headerItems to be used to set the css variable
 		private _headerItemsLength: number;
+		// Store if the current browser is chrome
+		private _isChrome: boolean;
 		// Store the onTabsChange platform callback
 		private _platformEventTabsOnChange: Callbacks.OSOnChangeEvent;
 		// Store the id of the requestAnimationFrame called to animate the indicator
@@ -49,6 +51,7 @@ namespace OSFramework.Patterns.Tabs {
 			// Check if running on native shell, to enable drag gestures
 			this._hasDragGestures =
 				Helper.DeviceInfo.IsNative && this.configs.TabsOrientation === GlobalEnum.Orientation.Horizontal;
+			this._isChrome = Helper.DeviceInfo.GetBrowser() === 'chrome';
 		}
 
 		// Method that it's called whenever a new TabsContentItem is rendered
@@ -275,17 +278,18 @@ namespace OSFramework.Patterns.Tabs {
 					? -(this._tabsHeaderElement.offsetWidth - activeElement.offsetLeft - activeElement.offsetWidth)
 					: activeElement.offsetLeft;
 
-				// Check current indicator size
-				const currentSize = isVertical
-					? this._tabsIndicatorElement.offsetHeight
-					: this._tabsIndicatorElement.offsetWidth;
-
 				// Check current active item size
 				const newSize = isVertical ? activeElement.offsetHeight : activeElement.offsetWidth;
 
+				let pixelRatio = 1;
+
+				if (this._isChrome) {
+					// devicePixelRatio used here to account for browser or system zoom
+					pixelRatio = window.devicePixelRatio;
+				}
+
 				// translate pixel sized value to a scale value
-				// devicePixelRatio used here to account for browser or system zoom
-				const newScaleValue = (devicePixelRatio * (newSize / currentSize)) / Math.round(devicePixelRatio);
+				const newScaleValue = (pixelRatio * newSize) / Math.round(pixelRatio);
 
 				// Update the css variables, that will trigger a transform transition
 				function updateIndicatorUI() {

--- a/src/scripts/OSFramework/Pattern/Tabs/scss/_tabs.scss
+++ b/src/scripts/OSFramework/Pattern/Tabs/scss/_tabs.scss
@@ -7,6 +7,7 @@
 .osui-tabs {
 	--header-item-width: fit-content(30%);
 	--header-item-alignment: auto;
+	--tabs-indicator-size: 1px;
 	display: grid;
 	height: var(--tabs-height);
 	overflow: hidden;
@@ -66,7 +67,7 @@
 			}
 
 			& > .osui-tabs__header__indicator {
-				min-height: 1px;
+				min-height: var(--tabs-indicator-size);
 				position: absolute;
 				top: 0;
 				transform: translateY(var(--tabs-indicator-transform)) translateX(0) translateZ(0)
@@ -103,7 +104,7 @@
 
 		.osui-tabs__header__indicator {
 			bottom: 0;
-			min-width: 1px;
+			min-width: var(--tabs-indicator-size);
 			height: 2px;
 			transform: translateX(var(--tabs-indicator-transform)) translateY(0) translateZ(0)
 				scaleX(var(--tabs-indicator-scale));
@@ -328,13 +329,16 @@
 	}
 }
 
-// Browser specific rules
+// Issue on accordion in webkit
 .windows.chrome,
 .windows.edge,
 .osx.chrome,
 .osx.edge {
-	.osui-tabs__header__indicator {
-		perspective: 1000px; // prevent rendering issues on webkit browsers, when inside overflow elements
+	.osui-accordion,
+	.section-expandable {
+		.osui-tabs__header__indicator {
+			perspective: 1000px; // prevent rendering issues on webkit browsers, when inside overflow elements
+		}
 	}
 }
 


### PR DESCRIPTION
This PR is for fixing zoom on chrome and Firefox browsers, by using the window.devicePixelRatio API.

### Checklist

-   [x] tested locally
-   [x] documented the code
-   [ ] clean all warnings and errors of eslint
-   [ ] requires changes in OutSystems (if so, provide a module with changes)
-   [ ] requires new sample page in OutSystems (if so, provide a module with changes)
