### PR TITLE
Fix issue at UpdateDates method.

### DIFF
--- a/src/scripts/OSFramework/Helper/Dates.ts
+++ b/src/scripts/OSFramework/Helper/Dates.ts
@@ -15,7 +15,7 @@ namespace OSFramework.Helper {
 		 * @return {*}  {boolean}
 		 * @memberof OSFramework.Helper.Dates
 		 */
-		public static IsMinorThan(date1: string, date2: string): boolean {
+		public static IsBeforeThan(date1: string, date2: string): boolean {
 			return Date.parse(date1) <= Date.parse(date2);
 		}
 

--- a/src/scripts/OutSystems/OSUI/Patterns/DatePickerAPI.ts
+++ b/src/scripts/OutSystems/OSUI/Patterns/DatePickerAPI.ts
@@ -356,7 +356,7 @@ namespace OutSystems.OSUI.Patterns.DatePickerAPI {
 				OSFramework.Helper.Dates.IsNull(date1) === false &&
 				date2 !== undefined &&
 				OSFramework.Helper.Dates.IsNull(date2) === false &&
-				OSFramework.Helper.Dates.IsMinorThan(date1, date2) === false
+				OSFramework.Helper.Dates.IsBeforeThan(date1, date2) === false
 			) {
 				responseObj.isSuccess = false;
 				responseObj.message = `Date1: '${date1}', can't be after Date2: '${date2}'.`;

--- a/src/scripts/Providers/Datepicker/Flatpickr/RangeDate/FlatpickrRangeDate.ts
+++ b/src/scripts/Providers/Datepicker/Flatpickr/RangeDate/FlatpickrRangeDate.ts
@@ -36,7 +36,7 @@ namespace Providers.Datepicker.Flatpickr.RangeDate {
 			if (
 				this.configs.InitialStartDate !== undefined &&
 				this.configs.InitialEndDate !== undefined &&
-				OSFramework.Helper.Dates.IsMinorThan(this.configs.InitialStartDate, this.configs.InitialEndDate) ===
+				OSFramework.Helper.Dates.IsBeforeThan(this.configs.InitialStartDate, this.configs.InitialEndDate) ===
 					false
 			) {
 				// Give a error console message in order to alert developers about this unexpected given dates!
@@ -172,7 +172,7 @@ namespace Providers.Datepicker.Flatpickr.RangeDate {
 				this.configs.InitialStartDate = startDate;
 				this.configs.InitialEndDate = endDate;
 
-				if (OSFramework.Helper.Dates.IsMinorThan(startDate, endDate)) {
+				if (OSFramework.Helper.Dates.IsBeforeThan(startDate, endDate)) {
 					this.prepareToAndRedraw();
 				} else {
 					console.error(

--- a/src/scripts/Providers/Datepicker/Flatpickr/RangeDate/FlatpickrRangeDateConfig.ts
+++ b/src/scripts/Providers/Datepicker/Flatpickr/RangeDate/FlatpickrRangeDateConfig.ts
@@ -36,7 +36,7 @@ namespace Providers.Datepicker.Flatpickr.RangeDate {
 			if (
 				this.InitialEndDate !== undefined &&
 				this.InitialStartDate !== undefined &&
-				OSFramework.Helper.Dates.IsMinorThan(this.InitialStartDate, this.InitialEndDate) === false
+				OSFramework.Helper.Dates.IsBeforeThan(this.InitialStartDate, this.InitialEndDate) === false
 			) {
 				throw new Error(`StartDate '${this.InitialStartDate}' can't be after EndDate '${this.InitialEndDate}'`);
 			}


### PR DESCRIPTION
This PR is for fix an issue that was happening when UpdateDates was being triggered. 

If at the selected dates event callback user was not being update the same variable that is assigned to the InititalStartDate and InitialEndDate the parametersChange didn't occur, that said on that moment the redraw was not being triggered and the calendar do not react as expected.