### PR TITLE
ROU-3982: Fix error on LayoutPrivate

### DIFF
--- a/src/scripts/OutSystems/OSUI/Utils/LayoutPrivateCloseDeprecatedSubmenu.ts
+++ b/src/scripts/OutSystems/OSUI/Utils/LayoutPrivateCloseDeprecatedSubmenu.ts
@@ -17,15 +17,18 @@ namespace OutSystems.OSUI.Utils.LayoutPrivate {
 			this._checkMenuLinks = activeScreen.querySelector(
 				OSFramework.Constants.Dot + OSFramework.GlobalEnum.CssClassElements.MenuLinks
 			);
-			// Store the deprecated submenu items
-			this._deprecatedSubmenuItems = this._checkMenuLinks.querySelectorAll(
-				OSFramework.Constants.Dot + OSFramework.GlobalEnum.CssClassElements.DeprecatedSubmenu
-			);
+			//Since we'll be using a querySelectorAll we'll do this check first in order to avoid throwing an exception
+			if (this._checkMenuLinks) {
+				// Store the deprecated submenu items
+				this._deprecatedSubmenuItems = this._checkMenuLinks.querySelectorAll(
+					OSFramework.Constants.Dot + OSFramework.GlobalEnum.CssClassElements.DeprecatedSubmenu
+				);
+			}
 		}
 
 		// Method attach the event to close all open deprecated submenu items
 		private static _closeDeprecatedSubmenu(): void {
-			if (this._deprecatedSubmenuItems.length > 0) {
+			if (this._deprecatedSubmenuItems && this._deprecatedSubmenuItems.length > 0) {
 				// Close all of them if contains the class open
 				for (const item of this._deprecatedSubmenuItems) {
 					if (item.classList.contains('open')) {
@@ -49,6 +52,7 @@ namespace OutSystems.OSUI.Utils.LayoutPrivate {
 			this.Unset();
 
 			if (
+				this._deprecatedSubmenuItems &&
 				this._deprecatedSubmenuItems.length > 0 &&
 				OSFramework.Helper.DeviceInfo.IsDesktop &&
 				!OSUI.Utils.DeviceDetection.CheckIsLayoutSide()


### PR DESCRIPTION
This PR is to fix an issue when 'app-menu-links' is not on the page since we were using querySelectorAll, which throws an exception when this case exists.

### What was happening
- When 'app-menu-links' is not on the page since we were using querySelectorAll, which throws an exception when this case exists.
- This happened for instance when using a LayoutBlank and is most visible on the Login page.

![image](https://user-images.githubusercontent.com/29493222/202901640-959877fb-a900-4495-b291-643cd7f64642.png)


### What was done
- Added a 

### Test Steps

1. Go to a Login page 
2. Check that there's no error being thrown
3. Go to a page using another Layout besides the LayoutBlank
4. Check that the Submenu (deprecated and new) works as expected


### Checklist

-   [X] tested locally
-   [X] documented the code
-   [X] clean all warnings and errors of eslint
-   [ ] requires changes in OutSystems (if so, provide a module with changes)
-   [ ] requires new sample page in OutSystems (if so, provide a module with changes)
