### PR TITLE
[PullToRefresh] - Ensure scroll is not available

### DIFF
--- a/src/scss/04-patterns/06-utilities/_pull-to-refresh.scss
+++ b/src/scss/04-patterns/06-utilities/_pull-to-refresh.scss
@@ -89,14 +89,10 @@
 
 // iOS ---------------------------------------------------------------------------
 ///
-.ios {
-	&.ptr-refresh {
-		.layout-native {
-			&.ios-bounce {
-				.main {
-					overflow: hidden;
-				}
-			}
+.ios.ptr-refresh {
+	.layout-native.ios-bounce {
+		.main {
+			overflow: hidden;
 		}
 	}
 }


### PR DESCRIPTION
This PR is for update the css in order to ensure scroll at the main container is not possible when pullToRefresh animation (spin) is visible!