### PR TITLE
Tabs Content Item - Redefine selector to be specific instead generic.

### DIFF
--- a/src/scripts/OSFramework/Pattern/Tabs/scss/_tabs.scss
+++ b/src/scripts/OSFramework/Pattern/Tabs/scss/_tabs.scss
@@ -229,15 +229,15 @@
 			scroll-snap-align: start;
 			scroll-snap-stop: always;
 
-			&,
-			* {
-				max-width: 99.99%; /* prevent render issues on chrome, in some screen-sizes, due to overflow hidden and css snap */
-			}
-
 			// Service Studio Preview
 			& {
 				-servicestudio-display: block !important;
 				-servicestudio-margin-bottom: var(--space-m);
+			}
+
+			// This selector is used to prevent render issues on chrome, in some screen-sizes, due to overflow hidden and css snap
+			.columns {
+				max-width: 99.99%;
 			}
 		}
 	}


### PR DESCRIPTION
This PR is for fix an issue related with a selector was being set the max-width to all the items inside the TabsContentItem.