### PR TITLE
ROU-3998 - Fixed video hide controls classes

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
 		"setup": "npm i && npm run dev",
 		"docs": "npx typedoc"
 	},
-	"author": "OutSystems UI Team",
+	"author": "UI Components Team",
 	"devDependencies": {
 		"@splidejs/splide": "^4.0.7",
 		"@typescript-eslint/eslint-plugin": "^4.23.0",

--- a/src/scss/04-patterns/03-interaction/_video.scss
+++ b/src/scss/04-patterns/03-interaction/_video.scss
@@ -5,16 +5,18 @@
 
 ///
 .video {
-	.hide-controls {
+	&-preview {
+		display: block;
+	}
+}
+
+.video-wrapper {
+	&.hide-controls {
 		pointer-events: none;
 
 		&::-webkit-media-controls-panel,
 		&::-webkit-media-controls-panel-container {
 			display: none !important;
 		}
-	}
-
-	&-preview {
-		display: block;
 	}
 }


### PR DESCRIPTION
This PR is to fix video hide controls classes to be tight to the wrapper.

[Sample page](url)

### What was happening

- The class hide-control was not working and we were able to interact with the video, even when we have controls disabled

### What was done

- Fixed the video hide controls classes to be tight to the wrapper instead of the video

### Test Steps

1. Go to Video functional test pages
2. Set Controls = False 
3. Click Apply 
4. Check that we will not be able to play/stop the video on click and that the controls aren't available
5. Set Controls = False 
6. Click Apply
7. Check that we will now be able to play/stop the video on click and that the controls are available on hover


### Checklist

-   [X] tested locally
-   [ ] documented the code
-   [ ] clean all warnings and errors of eslint
-   [X] requires changes in OutSystems (if so, provide a module with changes)
-   [ ] requires new sample page in OutSystems (if so, provide a module with changes)
