### PR TITLE
ROU-3999 - Fix Scroll content in Sidebar doesn't scroll

### DIFF
--- a/src/scripts/OSFramework/Behaviors/AnimateOnDrag.ts
+++ b/src/scripts/OSFramework/Behaviors/AnimateOnDrag.ts
@@ -202,7 +202,7 @@ namespace OSFramework.Behaviors {
 			this._dragParams.InvalidDrag =
 				this._dragParams.IsOpen && _dragDirection !== this._dragParams.ExpectedDirection;
 
-			// CHeck if swiped in wrong direction
+			// Check if swiped in wrong direction
 			if (this._dragParams.InvalidDrag) {
 				this._updateLastPositions(currentX, currentY);
 				return;

--- a/src/scripts/OSFramework/Event/GestureEvents/AbstractGestureEvent.ts
+++ b/src/scripts/OSFramework/Event/GestureEvents/AbstractGestureEvent.ts
@@ -70,8 +70,7 @@ namespace OSFramework.Event.GestureEvent {
 				this._gestureParams.currentY = evt.changedTouches[0].pageY;
 				this._gestureParams.offsetX = this._gestureParams.currentX - this._gestureParams.startX;
 				this._gestureParams.offsetY = this._gestureParams.currentY - this._gestureParams.startY;
-				// Prevent scrolling the page while doing gesture
-				evt.preventDefault();
+
 				if (this._moveTriggerCallback !== undefined) {
 					this._moveTriggerCallback(
 						this._gestureParams.currentX,

--- a/src/scripts/OSFramework/Pattern/Sidebar/Sidebar.ts
+++ b/src/scripts/OSFramework/Pattern/Sidebar/Sidebar.ts
@@ -69,7 +69,7 @@ namespace OSFramework.Patterns.Sidebar {
 			this._focusTrapInstance = new Behaviors.FocusTrap(opts);
 		}
 
-		// Method to hadnle the creation of the GestureEvents
+		// Method to handle the creation of the GestureEvents
 		private _handleGestureEvents(): void {
 			if (Helper.DeviceInfo.IsNative) {
 				// Create and save gesture event instance. Created here and not on constructor,


### PR DESCRIPTION
This PR is for fixing a issue on the sidebar when the gestures events are enable and its content needs to be scrollable.


### What was happening

- The Sidebar wasn't allowing the scroll because of the gestures events on Native Apps.


### What was done

- delete prevent default from gesture events abstract;
- fix typos

### Test Steps

On a mobile app
1. Add a Sidebar to a page with enough content to be scrollable;
2. Go to the page
3. Trigger the sidebar
4. Try to do a horizontal drag and check if the sidebar behaves as expected;
5. Try to scroll the content and check if it reacts as expected 


### Checklist

-   [x] tested locally
-   [x] documented the code
-   [x] clean all warnings and errors of eslint
-   [ ] requires changes in OutSystems (if so, provide a module with changes)
-   [ ] requires new sample page in OutSystems (if so, provide a module with changes)
