### PR TITLE
ROU-3967: Raise version of NoUiSlider from v15.6.0 to v15.6.1

### DIFF
--- a/docs/enums/Providers.RangeSlider.NoUiSlider-1.Enum.ProviderInfo.html
+++ b/docs/enums/Providers.RangeSlider.NoUiSlider-1.Enum.ProviderInfo.html
@@ -1,295 +1,887 @@
-<!DOCTYPE html><html class="default" lang="en"><head><meta charSet="utf-8"/><meta http-equiv="x-ua-compatible" content="IE=edge"/><title>ProviderInfo | outsystems-ui - v2.14.0</title><meta name="description" content="Documentation for outsystems-ui - v2.14.0"/><meta name="viewport" content="width=device-width, initial-scale=1"/><link rel="stylesheet" href="../assets/style.css"/><link rel="stylesheet" href="../assets/highlight.css"/><script async src="../assets/search.js" id="search-script"></script></head><body><script>document.documentElement.dataset.theme = localStorage.getItem("tsd-theme") || "os"</script><header class="tsd-page-toolbar">
-<div class="tsd-toolbar-contents container">
-<div class="table-cell" id="tsd-search" data-base="..">
-<div class="field"><label for="tsd-search-field" class="tsd-widget search no-caption"><svg width="16" height="16" viewBox="0 0 16 16" fill="none"><path d="M15.7824 13.833L12.6666 10.7177C12.5259 10.5771 12.3353 10.499 12.1353 10.499H11.6259C12.4884 9.39596 13.001 8.00859 13.001 6.49937C13.001 2.90909 10.0914 0 6.50048 0C2.90959 0 0 2.90909 0 6.49937C0 10.0896 2.90959 12.9987 6.50048 12.9987C8.00996 12.9987 9.39756 12.4863 10.5008 11.6239V12.1332C10.5008 12.3332 10.5789 12.5238 10.7195 12.6644L13.8354 15.7797C14.1292 16.0734 14.6042 16.0734 14.8948 15.7797L15.7793 14.8954C16.0731 14.6017 16.0731 14.1267 15.7824 13.833ZM6.50048 10.499C4.29094 10.499 2.50018 8.71165 2.50018 6.49937C2.50018 4.29021 4.28781 2.49976 6.50048 2.49976C8.71001 2.49976 10.5008 4.28708 10.5008 6.49937C10.5008 8.70852 8.71314 10.499 6.50048 10.499Z" fill="var(--color-text)"></path></svg></label><input type="text" id="tsd-search-field" aria-label="Search"/></div>
-<ul class="results">
-<li class="state loading">Preparing search index...</li>
-<li class="state failure">The search index is not available</li></ul><a href="../index.html" class="title">outsystems-ui - v2.14.0</a></div>
-<div class="table-cell" id="tsd-widgets"><a href="#" class="tsd-widget menu no-caption" data-toggle="menu" aria-label="Menu"><svg width="16" height="16" viewBox="0 0 16 16" fill="none"><rect x="1" y="3" width="14" height="2" fill="var(--color-text)"></rect><rect x="1" y="7" width="14" height="2" fill="var(--color-text)"></rect><rect x="1" y="11" width="14" height="2" fill="var(--color-text)"></rect></svg></a></div></div></header>
-<div class="container container-main">
-<div class="col-8 col-content">
-<div class="tsd-page-title">
-<ul class="tsd-breadcrumb">
-<li><a href="../modules.html">outsystems-ui - v2.14.0</a></li>
-<li><a href="../modules/Providers.html">Providers</a></li>
-<li><a href="../modules/Providers.RangeSlider.html">RangeSlider</a></li>
-<li><a href="../modules/Providers.RangeSlider.NoUiSlider-1.html">NoUiSlider</a></li>
-<li><a href="../modules/Providers.RangeSlider.NoUiSlider-1.Enum.html">Enum</a></li>
-<li><a href="Providers.RangeSlider.NoUiSlider-1.Enum.ProviderInfo.html">ProviderInfo</a></li></ul>
-<h1>Enumeration ProviderInfo</h1></div><aside class="tsd-sources">
-<ul>
-<li>Defined in <a href="https://github.com/OutSystems/outsystems-ui/blob/19049a0/src/scripts/Providers/RangeSlider/NoUISlider/NoUiSliderEnum.ts#L3">Providers/RangeSlider/NoUISlider/NoUiSliderEnum.ts:3</a></li></ul></aside>
-<section class="tsd-panel-group tsd-index-group">
-<section class="tsd-panel tsd-index-panel">
-<details class="tsd-index-content tsd-index-accordion" open><summary class="tsd-accordion-summary tsd-index-summary">
-<h5 class="tsd-index-heading uppercase" role="button" aria-expanded="false" tabIndex=0><svg width="16" height="16" viewBox="0 0 16 16" fill="none"><path d="M1.5 5.50969L8 11.6609L14.5 5.50969L12.5466 3.66086L8 7.96494L3.45341 3.66086L1.5 5.50969Z" fill="var(--color-text)"></path></svg> Index</h5></summary>
-<div class="tsd-accordion-details">
-<section class="tsd-index-section">
-<h3 class="tsd-index-heading">Enumeration Members</h3>
-<div class="tsd-index-list"><a href="Providers.RangeSlider.NoUiSlider-1.Enum.ProviderInfo.html#Name" class="tsd-index-link tsd-kind-enum-member tsd-parent-kind-enum"><svg class="tsd-kind-icon" width="24" height="24" viewBox="0 0 24 24"><rect fill="var(--color-icon-background)" stroke="#FF984D" stroke-width="1.5" x="1" y="1" width="22" height="22" rx="12" id="icon-1024-path"></rect><path d="M9.354 16V7.24H12.174C12.99 7.24 13.638 7.476 14.118 7.948C14.606 8.412 14.85 9.036 14.85 9.82C14.85 10.604 14.606 11.232 14.118 11.704C13.638 12.168 12.99 12.4 12.174 12.4H10.434V16H9.354ZM10.434 11.428H12.174C12.646 11.428 13.022 11.284 13.302 10.996C13.59 10.7 13.734 10.308 13.734 9.82C13.734 9.324 13.59 8.932 13.302 8.644C13.022 8.356 12.646 8.212 12.174 8.212H10.434V11.428Z" fill="var(--color-text)" id="icon-1024-text"></path></svg><span>Name</span></a>
-<a href="Providers.RangeSlider.NoUiSlider-1.Enum.ProviderInfo.html#Version" class="tsd-index-link tsd-kind-enum-member tsd-parent-kind-enum"><svg class="tsd-kind-icon" width="24" height="24" viewBox="0 0 24 24"><use href="#icon-1024-path"></use><use href="#icon-1024-text"></use></svg><span>Version</span></a>
-</div></section></div></details></section></section>
-<section class="tsd-panel-group tsd-member-group">
-<h2>Enumeration Members</h2>
-<section class="tsd-panel tsd-member tsd-kind-enum-member tsd-parent-kind-enum"><a id="Name" class="tsd-anchor"></a>
-<h3 class="tsd-anchor-link"><span>Name</span><a href="#Name" aria-label="Permalink" class="tsd-anchor-icon"><svg class="icon icon-tabler icon-tabler-link" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round"><path stroke="none" d="M0 0h24v24H0z" fill="none" id="icon-anchor-a"></path><path d="M10 14a3.5 3.5 0 0 0 5 0l4 -4a3.5 3.5 0 0 0 -5 -5l-.5 .5" id="icon-anchor-b"></path><path d="M14 10a3.5 3.5 0 0 0 -5 0l-4 4a3.5 3.5 0 0 0 5 5l.5 -.5" id="icon-anchor-c"></path></svg></a></h3>
-<div class="tsd-signature">Name<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">&quot;noUISlider&quot;</span></div><aside class="tsd-sources">
-<ul>
-<li>Defined in <a href="https://github.com/OutSystems/outsystems-ui/blob/19049a0/src/scripts/Providers/RangeSlider/NoUISlider/NoUiSliderEnum.ts#L4">Providers/RangeSlider/NoUISlider/NoUiSliderEnum.ts:4</a></li></ul></aside></section>
-<section class="tsd-panel tsd-member tsd-kind-enum-member tsd-parent-kind-enum"><a id="Version" class="tsd-anchor"></a>
-<h3 class="tsd-anchor-link"><span>Version</span><a href="#Version" aria-label="Permalink" class="tsd-anchor-icon"><svg class="icon icon-tabler icon-tabler-link" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round"><use href="#icon-anchor-a"></use><use href="#icon-anchor-b"></use><use href="#icon-anchor-c"></use></svg></a></h3>
-<div class="tsd-signature">Version<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">&quot;15.6.0&quot;</span></div><aside class="tsd-sources">
-<ul>
-<li>Defined in <a href="https://github.com/OutSystems/outsystems-ui/blob/19049a0/src/scripts/Providers/RangeSlider/NoUISlider/NoUiSliderEnum.ts#L5">Providers/RangeSlider/NoUISlider/NoUiSliderEnum.ts:5</a></li></ul></aside></section></section></div>
-<div class="col-4 col-menu menu-sticky-wrap menu-highlight">
-<div class="tsd-navigation settings">
-<details class="tsd-index-accordion"><summary class="tsd-accordion-summary">
-<h3><svg width="20" height="20" viewBox="0 0 24 24" fill="none"><path d="M4.93896 8.531L12 15.591L19.061 8.531L16.939 6.409L12 11.349L7.06098 6.409L4.93896 8.531Z" fill="var(--color-text)"></path></svg> Settings</h3></summary>
-<div class="tsd-accordion-details">
-<div class="tsd-filter-visibility">
-<h4 class="uppercase">Member Visibility</h4><form>
-<ul id="tsd-filter-options">
-<li class="tsd-filter-item"><label class="tsd-filter-input"><input type="checkbox" id="tsd-filter-protected" name="protected"/><svg width="32" height="32" viewBox="0 0 32 32" aria-hidden="true"><rect class="tsd-checkbox-background" width="30" height="30" x="1" y="1" rx="6" fill="none"></rect><path class="tsd-checkbox-checkmark" d="M8.35422 16.8214L13.2143 21.75L24.6458 10.25" stroke="none" stroke-width="3.5" stroke-linejoin="round" fill="none"></path></svg><span>Protected</span></label></li>
-<li class="tsd-filter-item"><label class="tsd-filter-input"><input type="checkbox" id="tsd-filter-private" name="private"/><svg width="32" height="32" viewBox="0 0 32 32" aria-hidden="true"><rect class="tsd-checkbox-background" width="30" height="30" x="1" y="1" rx="6" fill="none"></rect><path class="tsd-checkbox-checkmark" d="M8.35422 16.8214L13.2143 21.75L24.6458 10.25" stroke="none" stroke-width="3.5" stroke-linejoin="round" fill="none"></path></svg><span>Private</span></label></li>
-<li class="tsd-filter-item"><label class="tsd-filter-input"><input type="checkbox" id="tsd-filter-inherited" name="inherited" checked/><svg width="32" height="32" viewBox="0 0 32 32" aria-hidden="true"><rect class="tsd-checkbox-background" width="30" height="30" x="1" y="1" rx="6" fill="none"></rect><path class="tsd-checkbox-checkmark" d="M8.35422 16.8214L13.2143 21.75L24.6458 10.25" stroke="none" stroke-width="3.5" stroke-linejoin="round" fill="none"></path></svg><span>Inherited</span></label></li>
-<li class="tsd-filter-item"><label class="tsd-filter-input"><input type="checkbox" id="tsd-filter-external" name="external"/><svg width="32" height="32" viewBox="0 0 32 32" aria-hidden="true"><rect class="tsd-checkbox-background" width="30" height="30" x="1" y="1" rx="6" fill="none"></rect><path class="tsd-checkbox-checkmark" d="M8.35422 16.8214L13.2143 21.75L24.6458 10.25" stroke="none" stroke-width="3.5" stroke-linejoin="round" fill="none"></path></svg><span>External</span></label></li></ul></form></div>
-<div class="tsd-theme-toggle">
-<h4 class="uppercase">Theme</h4><select id="theme"><option value="os">OS</option><option value="light">Light</option><option value="dark">Dark</option></select></div></div></details></div>
-<nav class="tsd-navigation primary">
-<details class="tsd-index-accordion" open><summary class="tsd-accordion-summary">
-<h3><svg width="20" height="20" viewBox="0 0 24 24" fill="none"><path d="M4.93896 8.531L12 15.591L19.061 8.531L16.939 6.409L12 11.349L7.06098 6.409L4.93896 8.531Z" fill="var(--color-text)"></path></svg> Modules</h3></summary>
-<div class="tsd-accordion-details">
-<ul>
-<li class="current"><a href="../modules.html">outsystems-<wbr/>ui -<wbr/> v2.14.0</a>
-<ul>
-<li class="tsd-kind-namespace"><a href="../modules/OSFramework.html">OSFramework</a>
-<ul>
-<li class="tsd-kind-namespace tsd-parent-kind-namespace"><a href="../modules/OSFramework.Behaviors.html">Behaviors</a></li>
-<li class="tsd-kind-namespace tsd-parent-kind-namespace"><a href="../modules/OSFramework.Constants.html">Constants</a></li>
-<li class="tsd-kind-namespace tsd-parent-kind-namespace"><a href="../modules/OSFramework.ErrorCodes.html">Error<wbr/>Codes</a></li>
-<li class="tsd-kind-namespace tsd-parent-kind-namespace"><a href="../modules/OSFramework.Event.html">Event</a>
-<ul>
-<li class="tsd-kind-namespace tsd-parent-kind-namespace"><a href="../modules/OSFramework.Event.GestureEvent.html">Gesture<wbr/>Event</a>
-<ul>
-<li class="tsd-kind-namespace tsd-parent-kind-namespace"><a href="../modules/OSFramework.Event.GestureEvent.Callbacks.html">Callbacks</a></li></ul></li>
-<li class="tsd-kind-namespace tsd-parent-kind-namespace"><a href="../modules/OSFramework.Event.ProviderEvents.html">Provider<wbr/>Events</a></li></ul></li>
-<li class="tsd-kind-namespace tsd-parent-kind-namespace"><a href="../modules/OSFramework.GlobalCallbacks.html">Global<wbr/>Callbacks</a></li>
-<li class="tsd-kind-namespace tsd-parent-kind-namespace"><a href="../modules/OSFramework.GlobalEnum.html">Global<wbr/>Enum</a></li>
-<li class="tsd-kind-namespace tsd-parent-kind-namespace"><a href="../modules/OSFramework.Helper.html">Helper</a>
-<ul>
-<li class="tsd-kind-namespace tsd-parent-kind-namespace"><a href="../modules/OSFramework.Helper.MapOperation.html">Map<wbr/>Operation</a></li></ul></li>
-<li class="tsd-kind-namespace tsd-parent-kind-namespace"><a href="../modules/OSFramework.Interface.html">Interface</a></li>
-<li class="tsd-kind-namespace tsd-parent-kind-namespace"><a href="../modules/OSFramework.Patterns.html">Patterns</a>
-<ul>
-<li class="tsd-kind-namespace tsd-parent-kind-namespace"><a href="../modules/OSFramework.Patterns.Accordion.html">Accordion</a>
-<ul>
-<li class="tsd-kind-namespace tsd-parent-kind-namespace"><a href="../modules/OSFramework.Patterns.Accordion.Enum.html">Enum</a></li></ul></li>
-<li class="tsd-kind-namespace tsd-parent-kind-namespace"><a href="../modules/OSFramework.Patterns.AccordionItem.html">Accordion<wbr/>Item</a>
-<ul>
-<li class="tsd-kind-namespace tsd-parent-kind-namespace"><a href="../modules/OSFramework.Patterns.AccordionItem.Enum.html">Enum</a></li></ul></li>
-<li class="tsd-kind-namespace tsd-parent-kind-namespace"><a href="../modules/OSFramework.Patterns.AnimatedLabel.html">Animated<wbr/>Label</a>
-<ul>
-<li class="tsd-kind-namespace tsd-parent-kind-namespace"><a href="../modules/OSFramework.Patterns.AnimatedLabel.Enum.html">Enum</a></li></ul></li>
-<li class="tsd-kind-namespace tsd-parent-kind-namespace"><a href="../modules/OSFramework.Patterns.BottomSheet.html">Bottom<wbr/>Sheet</a>
-<ul>
-<li class="tsd-kind-namespace tsd-parent-kind-namespace"><a href="../modules/OSFramework.Patterns.BottomSheet.Callbacks.html">Callbacks</a></li>
-<li class="tsd-kind-namespace tsd-parent-kind-namespace"><a href="../modules/OSFramework.Patterns.BottomSheet.Enum.html">Enum</a></li></ul></li>
-<li class="tsd-kind-namespace tsd-parent-kind-namespace"><a href="../modules/OSFramework.Patterns.ButtonLoading.html">Button<wbr/>Loading</a>
-<ul>
-<li class="tsd-kind-namespace tsd-parent-kind-namespace"><a href="../modules/OSFramework.Patterns.ButtonLoading.Enum.html">Enum</a></li></ul></li>
-<li class="tsd-kind-namespace tsd-parent-kind-namespace"><a href="../modules/OSFramework.Patterns.Carousel.html">Carousel</a>
-<ul>
-<li class="tsd-kind-namespace tsd-parent-kind-namespace"><a href="../modules/OSFramework.Patterns.Carousel.Callbacks.html">Callbacks</a></li>
-<li class="tsd-kind-namespace tsd-parent-kind-namespace"><a href="../modules/OSFramework.Patterns.Carousel.Factory.html">Factory</a></li>
-<li class="tsd-kind-namespace tsd-parent-kind-namespace"><a href="../modules/OSFramework.Patterns.Carousel.Enum.html">Enum</a></li></ul></li>
-<li class="tsd-kind-namespace tsd-parent-kind-namespace"><a href="../modules/OSFramework.Patterns.DatePicker.html">Date<wbr/>Picker</a>
-<ul>
-<li class="tsd-kind-namespace tsd-parent-kind-namespace"><a href="../modules/OSFramework.Patterns.DatePicker.Callbacks.html">Callbacks</a></li>
-<li class="tsd-kind-namespace tsd-parent-kind-namespace"><a href="../modules/OSFramework.Patterns.DatePicker.Factory.html">Factory</a></li>
-<li class="tsd-kind-namespace tsd-parent-kind-namespace"><a href="../modules/OSFramework.Patterns.DatePicker.Enum.html">Enum</a></li></ul></li>
-<li class="tsd-kind-namespace tsd-parent-kind-namespace"><a href="../modules/OSFramework.Patterns.Dropdown.html">Dropdown</a>
-<ul>
-<li class="tsd-kind-namespace tsd-parent-kind-namespace"><a href="../modules/OSFramework.Patterns.Dropdown.Callbacks.html">Callbacks</a></li>
-<li class="tsd-kind-namespace tsd-parent-kind-namespace"><a href="../modules/OSFramework.Patterns.Dropdown.Factory.html">Factory</a></li>
-<li class="tsd-kind-namespace tsd-parent-kind-namespace"><a href="../modules/OSFramework.Patterns.Dropdown.Enum.html">Enum</a></li>
-<li class="tsd-kind-namespace tsd-parent-kind-namespace"><a href="../modules/OSFramework.Patterns.Dropdown.ServerSide.html">Server<wbr/>Side</a>
-<ul>
-<li class="tsd-kind-namespace tsd-parent-kind-namespace"><a href="../modules/OSFramework.Patterns.Dropdown.ServerSide.Enum.html">Enum</a></li></ul></li></ul></li>
-<li class="tsd-kind-namespace tsd-parent-kind-namespace"><a href="../modules/OSFramework.Patterns.DropdownServerSideItem.html">Dropdown<wbr/>Server<wbr/>Side<wbr/>Item</a>
-<ul>
-<li class="tsd-kind-namespace tsd-parent-kind-namespace"><a href="../modules/OSFramework.Patterns.DropdownServerSideItem.Callbacks.html">Callbacks</a></li>
-<li class="tsd-kind-namespace tsd-parent-kind-namespace"><a href="../modules/OSFramework.Patterns.DropdownServerSideItem.Enum.html">Enum</a></li></ul></li>
-<li class="tsd-kind-namespace tsd-parent-kind-namespace"><a href="../modules/OSFramework.Patterns.FlipContent.html">Flip<wbr/>Content</a>
-<ul>
-<li class="tsd-kind-namespace tsd-parent-kind-namespace"><a href="../modules/OSFramework.Patterns.FlipContent.Callbacks.html">Callbacks</a></li>
-<li class="tsd-kind-namespace tsd-parent-kind-namespace"><a href="../modules/OSFramework.Patterns.FlipContent.Enum.html">Enum</a></li></ul></li>
-<li class="tsd-kind-namespace tsd-parent-kind-namespace"><a href="../modules/OSFramework.Patterns.Gallery.html">Gallery</a>
-<ul>
-<li class="tsd-kind-namespace tsd-parent-kind-namespace"><a href="../modules/OSFramework.Patterns.Gallery.Enum.html">Enum</a></li></ul></li>
-<li class="tsd-kind-namespace tsd-parent-kind-namespace"><a href="../modules/OSFramework.Patterns.MonthPicker.html">Month<wbr/>Picker</a>
-<ul>
-<li class="tsd-kind-namespace tsd-parent-kind-namespace"><a href="../modules/OSFramework.Patterns.MonthPicker.Callbacks.html">Callbacks</a></li>
-<li class="tsd-kind-namespace tsd-parent-kind-namespace"><a href="../modules/OSFramework.Patterns.MonthPicker.Enum.html">Enum</a></li>
-<li class="tsd-kind-namespace tsd-parent-kind-namespace"><a href="../modules/OSFramework.Patterns.MonthPicker.Factory.html">Factory</a></li></ul></li>
-<li class="tsd-kind-namespace tsd-parent-kind-namespace"><a href="../modules/OSFramework.Patterns.Notification.html">Notification</a>
-<ul>
-<li class="tsd-kind-namespace tsd-parent-kind-namespace"><a href="../modules/OSFramework.Patterns.Notification.Callbacks.html">Callbacks</a></li>
-<li class="tsd-kind-namespace tsd-parent-kind-namespace"><a href="../modules/OSFramework.Patterns.Notification.Enum.html">Enum</a></li></ul></li>
-<li class="tsd-kind-namespace tsd-parent-kind-namespace"><a href="../modules/OSFramework.Patterns.Progress.html">Progress</a>
-<ul>
-<li class="tsd-kind-namespace tsd-parent-kind-namespace"><a href="../modules/OSFramework.Patterns.Progress.Bar.html">Bar</a></li>
-<li class="tsd-kind-namespace tsd-parent-kind-namespace"><a href="../modules/OSFramework.Patterns.Progress.Circle.html">Circle</a>
-<ul>
-<li class="tsd-kind-namespace tsd-parent-kind-namespace"><a href="../modules/OSFramework.Patterns.Progress.Circle.Enum.html">Enum</a></li></ul></li>
-<li class="tsd-kind-namespace tsd-parent-kind-namespace"><a href="../modules/OSFramework.Patterns.Progress.ProgressEnum.html">Progress<wbr/>Enum</a></li>
-<li class="tsd-kind-namespace tsd-parent-kind-namespace"><a href="../modules/OSFramework.Patterns.Progress.Factory.html">Factory</a></li></ul></li>
-<li class="tsd-kind-namespace tsd-parent-kind-namespace"><a href="../modules/OSFramework.Patterns.RangeSlider.html">Range<wbr/>Slider</a>
-<ul>
-<li class="tsd-kind-namespace tsd-parent-kind-namespace"><a href="../modules/OSFramework.Patterns.RangeSlider.Callbacks.html">Callbacks</a></li>
-<li class="tsd-kind-namespace tsd-parent-kind-namespace"><a href="../modules/OSFramework.Patterns.RangeSlider.Enum.html">Enum</a></li>
-<li class="tsd-kind-namespace tsd-parent-kind-namespace"><a href="../modules/OSFramework.Patterns.RangeSlider.Factory.html">Factory</a></li></ul></li>
-<li class="tsd-kind-namespace tsd-parent-kind-namespace"><a href="../modules/OSFramework.Patterns.Rating.html">Rating</a>
-<ul>
-<li class="tsd-kind-namespace tsd-parent-kind-namespace"><a href="../modules/OSFramework.Patterns.Rating.Callbacks.html">Callbacks</a></li>
-<li class="tsd-kind-namespace tsd-parent-kind-namespace"><a href="../modules/OSFramework.Patterns.Rating.Enum.html">Enum</a></li></ul></li>
-<li class="tsd-kind-namespace tsd-parent-kind-namespace"><a href="../modules/OSFramework.Patterns.SectionIndex.html">Section<wbr/>Index</a>
-<ul>
-<li class="tsd-kind-namespace tsd-parent-kind-namespace"><a href="../modules/OSFramework.Patterns.SectionIndex.Enum.html">Enum</a></li></ul></li>
-<li class="tsd-kind-namespace tsd-parent-kind-namespace"><a href="../modules/OSFramework.Patterns.SectionIndexItem.html">Section<wbr/>Index<wbr/>Item</a>
-<ul>
-<li class="tsd-kind-namespace tsd-parent-kind-namespace"><a href="../modules/OSFramework.Patterns.SectionIndexItem.Enum.html">Enum</a></li></ul></li>
-<li class="tsd-kind-namespace tsd-parent-kind-namespace"><a href="../modules/OSFramework.Patterns.Sidebar.html">Sidebar</a>
-<ul>
-<li class="tsd-kind-namespace tsd-parent-kind-namespace"><a href="../modules/OSFramework.Patterns.Sidebar.Callbacks.html">Callbacks</a></li>
-<li class="tsd-kind-namespace tsd-parent-kind-namespace"><a href="../modules/OSFramework.Patterns.Sidebar.Enum.html">Enum</a></li></ul></li>
-<li class="tsd-kind-namespace tsd-parent-kind-namespace"><a href="../modules/OSFramework.Patterns.Submenu.html">Submenu</a>
-<ul>
-<li class="tsd-kind-namespace tsd-parent-kind-namespace"><a href="../modules/OSFramework.Patterns.Submenu.Enum.html">Enum</a></li></ul></li>
-<li class="tsd-kind-namespace tsd-parent-kind-namespace"><a href="../modules/OSFramework.Patterns.SwipeEvents.html">Swipe<wbr/>Events</a>
-<ul>
-<li class="tsd-kind-namespace tsd-parent-kind-namespace"><a href="../modules/OSFramework.Patterns.SwipeEvents.Enum.html">Enum</a></li></ul></li>
-<li class="tsd-kind-namespace tsd-parent-kind-namespace"><a href="../modules/OSFramework.Patterns.Tabs.html">Tabs</a>
-<ul>
-<li class="tsd-kind-namespace tsd-parent-kind-namespace"><a href="../modules/OSFramework.Patterns.Tabs.Callbacks.html">Callbacks</a></li>
-<li class="tsd-kind-namespace tsd-parent-kind-namespace"><a href="../modules/OSFramework.Patterns.Tabs.Enum.html">Enum</a></li></ul></li>
-<li class="tsd-kind-namespace tsd-parent-kind-namespace"><a href="../modules/OSFramework.Patterns.TabsContentItem.html">Tabs<wbr/>Content<wbr/>Item</a></li>
-<li class="tsd-kind-namespace tsd-parent-kind-namespace"><a href="../modules/OSFramework.Patterns.TabsHeaderItem.html">Tabs<wbr/>Header<wbr/>Item</a></li>
-<li class="tsd-kind-namespace tsd-parent-kind-namespace"><a href="../modules/OSFramework.Patterns.TimePicker.html">Time<wbr/>Picker</a>
-<ul>
-<li class="tsd-kind-namespace tsd-parent-kind-namespace"><a href="../modules/OSFramework.Patterns.TimePicker.Callbacks.html">Callbacks</a></li>
-<li class="tsd-kind-namespace tsd-parent-kind-namespace"><a href="../modules/OSFramework.Patterns.TimePicker.Enum.html">Enum</a></li>
-<li class="tsd-kind-namespace tsd-parent-kind-namespace"><a href="../modules/OSFramework.Patterns.TimePicker.Factory.html">Factory</a></li></ul></li>
-<li class="tsd-kind-namespace tsd-parent-kind-namespace"><a href="../modules/OSFramework.Patterns.Tooltip.html">Tooltip</a>
-<ul>
-<li class="tsd-kind-namespace tsd-parent-kind-namespace"><a href="../modules/OSFramework.Patterns.Tooltip.Enum.html">Enum</a></li></ul></li>
-<li class="tsd-kind-namespace tsd-parent-kind-namespace"><a href="../modules/OSFramework.Patterns.TouchEvents.html">Touch<wbr/>Events</a>
-<ul>
-<li class="tsd-kind-namespace tsd-parent-kind-namespace"><a href="../modules/OSFramework.Patterns.TouchEvents.Enum.html">Enum</a></li></ul></li></ul></li></ul></li>
-<li class="tsd-kind-namespace"><a href="../modules/OutSystems.html">Out<wbr/>Systems</a>
-<ul>
-<li class="tsd-kind-namespace tsd-parent-kind-namespace"><a href="../modules/OutSystems.OSUI.html">OSUI</a>
-<ul>
-<li class="tsd-kind-namespace tsd-parent-kind-namespace"><a href="../modules/OutSystems.OSUI.ErrorCodes.html">Error<wbr/>Codes</a></li>
-<li class="tsd-kind-namespace tsd-parent-kind-namespace"><a href="../modules/OutSystems.OSUI.Patterns.html">Patterns</a>
-<ul>
-<li class="tsd-kind-namespace tsd-parent-kind-namespace"><a href="../modules/OutSystems.OSUI.Patterns.AccordionAPI.html">AccordionAPI</a></li>
-<li class="tsd-kind-namespace tsd-parent-kind-namespace"><a href="../modules/OutSystems.OSUI.Patterns.AccordionItemAPI.html">Accordion<wbr/>ItemAPI</a></li>
-<li class="tsd-kind-namespace tsd-parent-kind-namespace"><a href="../modules/OutSystems.OSUI.Patterns.AnimatedLabelAPI.html">Animated<wbr/>LabelAPI</a></li>
-<li class="tsd-kind-namespace tsd-parent-kind-namespace"><a href="../modules/OutSystems.OSUI.Patterns.BottomSheetAPI.html">Bottom<wbr/>SheetAPI</a></li>
-<li class="tsd-kind-namespace tsd-parent-kind-namespace"><a href="../modules/OutSystems.OSUI.Patterns.ButtonLoadingAPI.html">Button<wbr/>LoadingAPI</a></li>
-<li class="tsd-kind-namespace tsd-parent-kind-namespace"><a href="../modules/OutSystems.OSUI.Patterns.CarouselAPI.html">CarouselAPI</a></li>
-<li class="tsd-kind-namespace tsd-parent-kind-namespace"><a href="../modules/OutSystems.OSUI.Patterns.DatePickerAPI.html">Date<wbr/>PickerAPI</a></li>
-<li class="tsd-kind-namespace tsd-parent-kind-namespace"><a href="../modules/OutSystems.OSUI.Patterns.DropdownAPI.html">DropdownAPI</a></li>
-<li class="tsd-kind-namespace tsd-parent-kind-namespace"><a href="../modules/OutSystems.OSUI.Patterns.DropdownServerSideItemAPI.html">Dropdown<wbr/>Server<wbr/>Side<wbr/>ItemAPI</a></li>
-<li class="tsd-kind-namespace tsd-parent-kind-namespace"><a href="../modules/OutSystems.OSUI.Patterns.FlipContentAPI.html">Flip<wbr/>ContentAPI</a></li>
-<li class="tsd-kind-namespace tsd-parent-kind-namespace"><a href="../modules/OutSystems.OSUI.Patterns.GalleryAPI.html">GalleryAPI</a></li>
-<li class="tsd-kind-namespace tsd-parent-kind-namespace"><a href="../modules/OutSystems.OSUI.Patterns.MonthPickerAPI.html">Month<wbr/>PickerAPI</a></li>
-<li class="tsd-kind-namespace tsd-parent-kind-namespace"><a href="../modules/OutSystems.OSUI.Patterns.NotificationAPI.html">NotificationAPI</a></li>
-<li class="tsd-kind-namespace tsd-parent-kind-namespace"><a href="../modules/OutSystems.OSUI.Patterns.ProgressAPI.html">ProgressAPI</a></li>
-<li class="tsd-kind-namespace tsd-parent-kind-namespace"><a href="../modules/OutSystems.OSUI.Patterns.RangeSliderAPI.html">Range<wbr/>SliderAPI</a></li>
-<li class="tsd-kind-namespace tsd-parent-kind-namespace"><a href="../modules/OutSystems.OSUI.Patterns.RatingAPI.html">RatingAPI</a></li>
-<li class="tsd-kind-namespace tsd-parent-kind-namespace"><a href="../modules/OutSystems.OSUI.Patterns.SectionIndexAPI.html">Section<wbr/>IndexAPI</a></li>
-<li class="tsd-kind-namespace tsd-parent-kind-namespace"><a href="../modules/OutSystems.OSUI.Patterns.SectionIndexItemAPI.html">Section<wbr/>Index<wbr/>ItemAPI</a></li>
-<li class="tsd-kind-namespace tsd-parent-kind-namespace"><a href="../modules/OutSystems.OSUI.Patterns.SidebarAPI.html">SidebarAPI</a></li>
-<li class="tsd-kind-namespace tsd-parent-kind-namespace"><a href="../modules/OutSystems.OSUI.Patterns.SubmenuAPI.html">SubmenuAPI</a></li>
-<li class="tsd-kind-namespace tsd-parent-kind-namespace"><a href="../modules/OutSystems.OSUI.Patterns.SwipeEventsAPI.html">Swipe<wbr/>EventsAPI</a></li>
-<li class="tsd-kind-namespace tsd-parent-kind-namespace"><a href="../modules/OutSystems.OSUI.Patterns.TabsAPI.html">TabsAPI</a></li>
-<li class="tsd-kind-namespace tsd-parent-kind-namespace"><a href="../modules/OutSystems.OSUI.Patterns.TabsContentItemAPI.html">Tabs<wbr/>Content<wbr/>ItemAPI</a></li>
-<li class="tsd-kind-namespace tsd-parent-kind-namespace"><a href="../modules/OutSystems.OSUI.Patterns.TabsHeaderItemAPI.html">Tabs<wbr/>Header<wbr/>ItemAPI</a></li>
-<li class="tsd-kind-namespace tsd-parent-kind-namespace"><a href="../modules/OutSystems.OSUI.Patterns.TimePickerAPI.html">Time<wbr/>PickerAPI</a></li>
-<li class="tsd-kind-namespace tsd-parent-kind-namespace"><a href="../modules/OutSystems.OSUI.Patterns.TooltipAPI.html">TooltipAPI</a></li>
-<li class="tsd-kind-namespace tsd-parent-kind-namespace"><a href="../modules/OutSystems.OSUI.Patterns.TouchEventsAPI.html">Touch<wbr/>EventsAPI</a></li></ul></li>
-<li class="tsd-kind-namespace tsd-parent-kind-namespace"><a href="../modules/OutSystems.OSUI.Utils.html">Utils</a>
-<ul>
-<li class="tsd-kind-namespace tsd-parent-kind-namespace"><a href="../modules/OutSystems.OSUI.Utils.Accessibility.html">Accessibility</a></li>
-<li class="tsd-kind-namespace tsd-parent-kind-namespace"><a href="../modules/OutSystems.OSUI.Utils.Application.html">Application</a></li>
-<li class="tsd-kind-namespace tsd-parent-kind-namespace"><a href="../modules/OutSystems.OSUI.Utils.DeviceDetection.html">Device<wbr/>Detection</a></li>
-<li class="tsd-kind-namespace tsd-parent-kind-namespace"><a href="../modules/OutSystems.OSUI.Utils.InvalidInputs.html">Invalid<wbr/>Inputs</a></li>
-<li class="tsd-kind-namespace tsd-parent-kind-namespace"><a href="../modules/OutSystems.OSUI.Utils.HideOnScroll.html">Hide<wbr/>On<wbr/>Scroll</a></li>
-<li class="tsd-kind-namespace tsd-parent-kind-namespace"><a href="../modules/OutSystems.OSUI.Utils.LayoutPrivate.html">Layout<wbr/>Private</a></li>
-<li class="tsd-kind-namespace tsd-parent-kind-namespace"><a href="../modules/OutSystems.OSUI.Utils.Menu.html">Menu</a></li>
-<li class="tsd-kind-namespace tsd-parent-kind-namespace"><a href="../modules/OutSystems.OSUI.Utils.Network.html">Network</a></li></ul></li>
-<li class="tsd-kind-namespace tsd-parent-kind-namespace"><a href="../modules/OutSystems.OSUI.Dates.html">Dates</a></li>
-<li class="tsd-kind-namespace tsd-parent-kind-namespace"><a href="../modules/OutSystems.OSUI.Language.html">Language</a></li></ul></li></ul></li>
-<li class="current tsd-kind-namespace"><a href="../modules/Providers.html">Providers</a>
-<ul>
-<li class="tsd-kind-namespace tsd-parent-kind-namespace"><a href="../modules/Providers.Carousel.html">Carousel</a>
-<ul>
-<li class="tsd-kind-namespace tsd-parent-kind-namespace"><a href="../modules/Providers.Carousel.Splide.html">Splide</a>
-<ul>
-<li class="tsd-kind-namespace tsd-parent-kind-namespace"><a href="../modules/Providers.Carousel.Splide.Enum.html">Enum</a></li></ul></li></ul></li>
-<li class="tsd-kind-namespace tsd-parent-kind-namespace"><a href="../modules/Providers.Datepicker.html">Datepicker</a>
-<ul>
-<li class="tsd-kind-namespace tsd-parent-kind-namespace"><a href="../modules/Providers.Datepicker.Flatpickr.html">Flatpickr</a>
-<ul>
-<li class="tsd-kind-namespace tsd-parent-kind-namespace"><a href="../modules/Providers.Datepicker.Flatpickr.Enum.html">Enum</a></li>
-<li class="tsd-kind-namespace tsd-parent-kind-namespace"><a href="../modules/Providers.Datepicker.Flatpickr.Factory.html">Factory</a></li>
-<li class="tsd-kind-namespace tsd-parent-kind-namespace"><a href="../modules/Providers.Datepicker.Flatpickr.RangeDate.html">Range<wbr/>Date</a>
-<ul>
-<li class="tsd-kind-namespace tsd-parent-kind-namespace"><a href="../modules/Providers.Datepicker.Flatpickr.RangeDate.Enum.html">Enum</a></li></ul></li>
-<li class="tsd-kind-namespace tsd-parent-kind-namespace"><a href="../modules/Providers.Datepicker.Flatpickr.SingleDate.html">Single<wbr/>Date</a>
-<ul>
-<li class="tsd-kind-namespace tsd-parent-kind-namespace"><a href="../modules/Providers.Datepicker.Flatpickr.SingleDate.Enum.html">Enum</a></li></ul></li>
-<li class="tsd-kind-namespace tsd-parent-kind-namespace"><a href="../modules/Providers.Datepicker.Flatpickr.l10ns.html">l10ns</a></li></ul></li></ul></li>
-<li class="tsd-kind-namespace tsd-parent-kind-namespace"><a href="../modules/Providers.Dropdown.html">Dropdown</a>
-<ul>
-<li class="tsd-kind-namespace tsd-parent-kind-namespace"><a href="../modules/Providers.Dropdown.VirtualSelect.html">Virtual<wbr/>Select</a>
-<ul>
-<li class="tsd-kind-namespace tsd-parent-kind-namespace"><a href="../modules/Providers.Dropdown.VirtualSelect.Enum.html">Enum</a></li>
-<li class="tsd-kind-namespace tsd-parent-kind-namespace"><a href="../modules/Providers.Dropdown.VirtualSelect.Search.html">Search</a>
-<ul>
-<li class="tsd-kind-namespace tsd-parent-kind-namespace"><a href="../modules/Providers.Dropdown.VirtualSelect.Search.Enum.html">Enum</a></li></ul></li>
-<li class="tsd-kind-namespace tsd-parent-kind-namespace"><a href="../modules/Providers.Dropdown.VirtualSelect.Tags.html">Tags</a></li>
-<li class="tsd-kind-namespace tsd-parent-kind-namespace"><a href="../modules/Providers.Dropdown.VirtualSelect.Factory.html">Factory</a></li></ul></li></ul></li>
-<li class="tsd-kind-namespace tsd-parent-kind-namespace"><a href="../modules/Providers.MonthPicker.html">Month<wbr/>Picker</a>
-<ul>
-<li class="tsd-kind-namespace tsd-parent-kind-namespace"><a href="../modules/Providers.MonthPicker.Flatpickr.html">Flatpickr</a></li></ul></li>
-<li class="current tsd-kind-namespace tsd-parent-kind-namespace"><a href="../modules/Providers.RangeSlider.html">Range<wbr/>Slider</a>
-<ul>
-<li class="tsd-kind-namespace tsd-parent-kind-namespace"><a href="../modules/Providers.RangeSlider.NoUISlider.html">NoUISlider</a>
-<ul>
-<li class="tsd-kind-namespace tsd-parent-kind-namespace"><a href="../modules/Providers.RangeSlider.NoUISlider.IntervalSlider.html">Interval<wbr/>Slider</a></li>
-<li class="tsd-kind-namespace tsd-parent-kind-namespace"><a href="../modules/Providers.RangeSlider.NoUISlider.SliderInterval.html">Slider<wbr/>Interval</a></li>
-<li class="tsd-kind-namespace tsd-parent-kind-namespace"><a href="../modules/Providers.RangeSlider.NoUISlider.SingleSlider.html">Single<wbr/>Slider</a></li>
-<li class="tsd-kind-namespace tsd-parent-kind-namespace"><a href="../modules/Providers.RangeSlider.NoUISlider.SliderSingle.html">Slider<wbr/>Single</a></li></ul></li>
-<li class="current tsd-kind-namespace tsd-parent-kind-namespace"><a href="../modules/Providers.RangeSlider.NoUiSlider-1.html">No<wbr/>Ui<wbr/>Slider</a>
-<ul>
-<li class="current tsd-kind-namespace tsd-parent-kind-namespace"><a href="../modules/Providers.RangeSlider.NoUiSlider-1.Enum.html">Enum</a></li>
-<li class="tsd-kind-namespace tsd-parent-kind-namespace"><a href="../modules/Providers.RangeSlider.NoUiSlider-1.Factory.html">Factory</a></li></ul></li></ul></li>
-<li class="tsd-kind-namespace tsd-parent-kind-namespace"><a href="../modules/Providers.SharedProviderResources.html">Shared<wbr/>Provider<wbr/>Resources</a>
-<ul>
-<li class="tsd-kind-namespace tsd-parent-kind-namespace"><a href="../modules/Providers.SharedProviderResources.Flatpickr.html">Flatpickr</a>
-<ul>
-<li class="tsd-kind-namespace tsd-parent-kind-namespace"><a href="../modules/Providers.SharedProviderResources.Flatpickr.Enum.html">Enum</a></li></ul></li></ul></li>
-<li class="tsd-kind-namespace tsd-parent-kind-namespace"><a href="../modules/Providers.TimePicker.html">Time<wbr/>Picker</a>
-<ul>
-<li class="tsd-kind-namespace tsd-parent-kind-namespace"><a href="../modules/Providers.TimePicker.Flatpickr.html">Flatpickr</a>
-<ul>
-<li class="tsd-kind-namespace tsd-parent-kind-namespace"><a href="../modules/Providers.TimePicker.Flatpickr.Enum.html">Enum</a></li></ul></li></ul></li></ul></li></ul></li></ul></div></details></nav>
-<nav class="tsd-navigation secondary menu-sticky">
-<ul>
-<li class="current tsd-kind-enum tsd-parent-kind-namespace"><a href="Providers.RangeSlider.NoUiSlider-1.Enum.ProviderInfo.html" class="tsd-index-link"><svg class="tsd-kind-icon" width="24" height="24" viewBox="0 0 24 24"><rect fill="var(--color-icon-background)" stroke="var(--color-ts-enum)" stroke-width="1.5" x="1" y="1" width="22" height="22" rx="6" id="icon-8-path"></rect><path d="M9.45 16V7.24H14.49V8.224H10.518V10.936H14.07V11.908H10.518V15.016H14.49V16H9.45Z" fill="var(--color-text)" id="icon-8-text"></path></svg><span>Provider<wbr/>Info</span></a>
-<ul>
-<li class="tsd-kind-enum-member tsd-parent-kind-enum"><a href="Providers.RangeSlider.NoUiSlider-1.Enum.ProviderInfo.html#Name" class="tsd-index-link"><svg class="tsd-kind-icon" width="24" height="24" viewBox="0 0 24 24"><use href="#icon-1024-path"></use><use href="#icon-1024-text"></use></svg>Name</a></li>
-<li class="tsd-kind-enum-member tsd-parent-kind-enum"><a href="Providers.RangeSlider.NoUiSlider-1.Enum.ProviderInfo.html#Version" class="tsd-index-link"><svg class="tsd-kind-icon" width="24" height="24" viewBox="0 0 24 24"><use href="#icon-1024-path"></use><use href="#icon-1024-text"></use></svg>Version</a></li></ul></li></ul></nav></div></div>
-<div class="overlay"></div><script src="../assets/main.js"></script></body></html>
+<!DOCTYPE html>
+<html class="default" lang="en">
+
+<head>
+    <meta charSet="utf-8" />
+    <meta http-equiv="x-ua-compatible" content="IE=edge" />
+    <title>ProviderInfo | outsystems-ui - v2.14.0</title>
+    <meta name="description" content="Documentation for outsystems-ui - v2.14.0" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <link rel="stylesheet" href="../assets/style.css" />
+    <link rel="stylesheet" href="../assets/highlight.css" />
+    <script async src="../assets/search.js" id="search-script"></script>
+</head>
+
+<body>
+    <script>document.documentElement.dataset.theme = localStorage.getItem("tsd-theme") || "os"</script>
+    <header class="tsd-page-toolbar">
+        <div class="tsd-toolbar-contents container">
+            <div class="table-cell" id="tsd-search" data-base="..">
+                <div class="field"><label for="tsd-search-field" class="tsd-widget search no-caption"><svg width="16"
+                            height="16" viewBox="0 0 16 16" fill="none">
+                            <path
+                                d="M15.7824 13.833L12.6666 10.7177C12.5259 10.5771 12.3353 10.499 12.1353 10.499H11.6259C12.4884 9.39596 13.001 8.00859 13.001 6.49937C13.001 2.90909 10.0914 0 6.50048 0C2.90959 0 0 2.90909 0 6.49937C0 10.0896 2.90959 12.9987 6.50048 12.9987C8.00996 12.9987 9.39756 12.4863 10.5008 11.6239V12.1332C10.5008 12.3332 10.5789 12.5238 10.7195 12.6644L13.8354 15.7797C14.1292 16.0734 14.6042 16.0734 14.8948 15.7797L15.7793 14.8954C16.0731 14.6017 16.0731 14.1267 15.7824 13.833ZM6.50048 10.499C4.29094 10.499 2.50018 8.71165 2.50018 6.49937C2.50018 4.29021 4.28781 2.49976 6.50048 2.49976C8.71001 2.49976 10.5008 4.28708 10.5008 6.49937C10.5008 8.70852 8.71314 10.499 6.50048 10.499Z"
+                                fill="var(--color-text)"></path>
+                        </svg></label><input type="text" id="tsd-search-field" aria-label="Search" /></div>
+                <ul class="results">
+                    <li class="state loading">Preparing search index...</li>
+                    <li class="state failure">The search index is not available</li>
+                </ul><a href="../index.html" class="title">outsystems-ui - v2.14.0</a>
+            </div>
+            <div class="table-cell" id="tsd-widgets"><a href="#" class="tsd-widget menu no-caption" data-toggle="menu"
+                    aria-label="Menu"><svg width="16" height="16" viewBox="0 0 16 16" fill="none">
+                        <rect x="1" y="3" width="14" height="2" fill="var(--color-text)"></rect>
+                        <rect x="1" y="7" width="14" height="2" fill="var(--color-text)"></rect>
+                        <rect x="1" y="11" width="14" height="2" fill="var(--color-text)"></rect>
+                    </svg></a></div>
+        </div>
+    </header>
+    <div class="container container-main">
+        <div class="col-8 col-content">
+            <div class="tsd-page-title">
+                <ul class="tsd-breadcrumb">
+                    <li><a href="../modules.html">outsystems-ui - v2.14.0</a></li>
+                    <li><a href="../modules/Providers.html">Providers</a></li>
+                    <li><a href="../modules/Providers.RangeSlider.html">RangeSlider</a></li>
+                    <li><a href="../modules/Providers.RangeSlider.NoUiSlider-1.html">NoUiSlider</a></li>
+                    <li><a href="../modules/Providers.RangeSlider.NoUiSlider-1.Enum.html">Enum</a></li>
+                    <li><a href="Providers.RangeSlider.NoUiSlider-1.Enum.ProviderInfo.html">ProviderInfo</a></li>
+                </ul>
+                <h1>Enumeration ProviderInfo</h1>
+            </div>
+            <aside class="tsd-sources">
+                <ul>
+                    <li>Defined in <a
+                            href="https://github.com/OutSystems/outsystems-ui/blob/19049a0/src/scripts/Providers/RangeSlider/NoUISlider/NoUiSliderEnum.ts#L3">Providers/RangeSlider/NoUISlider/NoUiSliderEnum.ts:3</a>
+                    </li>
+                </ul>
+            </aside>
+            <section class="tsd-panel-group tsd-index-group">
+                <section class="tsd-panel tsd-index-panel">
+                    <details class="tsd-index-content tsd-index-accordion" open>
+                        <summary class="tsd-accordion-summary tsd-index-summary">
+                            <h5 class="tsd-index-heading uppercase" role="button" aria-expanded="false" tabIndex=0><svg
+                                    width="16" height="16" viewBox="0 0 16 16" fill="none">
+                                    <path
+                                        d="M1.5 5.50969L8 11.6609L14.5 5.50969L12.5466 3.66086L8 7.96494L3.45341 3.66086L1.5 5.50969Z"
+                                        fill="var(--color-text)"></path>
+                                </svg> Index</h5>
+                        </summary>
+                        <div class="tsd-accordion-details">
+                            <section class="tsd-index-section">
+                                <h3 class="tsd-index-heading">Enumeration Members</h3>
+                                <div class="tsd-index-list"><a
+                                        href="Providers.RangeSlider.NoUiSlider-1.Enum.ProviderInfo.html#Name"
+                                        class="tsd-index-link tsd-kind-enum-member tsd-parent-kind-enum"><svg
+                                            class="tsd-kind-icon" width="24" height="24" viewBox="0 0 24 24">
+                                            <rect fill="var(--color-icon-background)" stroke="#FF984D"
+                                                stroke-width="1.5" x="1" y="1" width="22" height="22" rx="12"
+                                                id="icon-1024-path"></rect>
+                                            <path
+                                                d="M9.354 16V7.24H12.174C12.99 7.24 13.638 7.476 14.118 7.948C14.606 8.412 14.85 9.036 14.85 9.82C14.85 10.604 14.606 11.232 14.118 11.704C13.638 12.168 12.99 12.4 12.174 12.4H10.434V16H9.354ZM10.434 11.428H12.174C12.646 11.428 13.022 11.284 13.302 10.996C13.59 10.7 13.734 10.308 13.734 9.82C13.734 9.324 13.59 8.932 13.302 8.644C13.022 8.356 12.646 8.212 12.174 8.212H10.434V11.428Z"
+                                                fill="var(--color-text)" id="icon-1024-text"></path>
+                                        </svg><span>Name</span></a>
+                                    <a href="Providers.RangeSlider.NoUiSlider-1.Enum.ProviderInfo.html#Version"
+                                        class="tsd-index-link tsd-kind-enum-member tsd-parent-kind-enum"><svg
+                                            class="tsd-kind-icon" width="24" height="24" viewBox="0 0 24 24">
+                                            <use href="#icon-1024-path"></use>
+                                            <use href="#icon-1024-text"></use>
+                                        </svg><span>Version</span></a>
+                                </div>
+                            </section>
+                        </div>
+                    </details>
+                </section>
+            </section>
+            <section class="tsd-panel-group tsd-member-group">
+                <h2>Enumeration Members</h2>
+                <section class="tsd-panel tsd-member tsd-kind-enum-member tsd-parent-kind-enum"><a id="Name"
+                        class="tsd-anchor"></a>
+                    <h3 class="tsd-anchor-link"><span>Name</span><a href="#Name" aria-label="Permalink"
+                            class="tsd-anchor-icon"><svg class="icon icon-tabler icon-tabler-link" viewBox="0 0 24 24"
+                                stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round"
+                                stroke-linejoin="round">
+                                <path stroke="none" d="M0 0h24v24H0z" fill="none" id="icon-anchor-a"></path>
+                                <path d="M10 14a3.5 3.5 0 0 0 5 0l4 -4a3.5 3.5 0 0 0 -5 -5l-.5 .5" id="icon-anchor-b">
+                                </path>
+                                <path d="M14 10a3.5 3.5 0 0 0 -5 0l-4 4a3.5 3.5 0 0 0 5 5l.5 -.5" id="icon-anchor-c">
+                                </path>
+                            </svg></a></h3>
+                    <div class="tsd-signature">Name<span class="tsd-signature-symbol">:</span> <span
+                            class="tsd-signature-type">&quot;noUISlider&quot;</span></div>
+                    <aside class="tsd-sources">
+                        <ul>
+                            <li>Defined in <a
+                                    href="https://github.com/OutSystems/outsystems-ui/blob/19049a0/src/scripts/Providers/RangeSlider/NoUISlider/NoUiSliderEnum.ts#L4">Providers/RangeSlider/NoUISlider/NoUiSliderEnum.ts:4</a>
+                            </li>
+                        </ul>
+                    </aside>
+                </section>
+                <section class="tsd-panel tsd-member tsd-kind-enum-member tsd-parent-kind-enum"><a id="Version"
+                        class="tsd-anchor"></a>
+                    <h3 class="tsd-anchor-link"><span>Version</span><a href="#Version" aria-label="Permalink"
+                            class="tsd-anchor-icon"><svg class="icon icon-tabler icon-tabler-link" viewBox="0 0 24 24"
+                                stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round"
+                                stroke-linejoin="round">
+                                <use href="#icon-anchor-a"></use>
+                                <use href="#icon-anchor-b"></use>
+                                <use href="#icon-anchor-c"></use>
+                            </svg></a></h3>
+                    <div class="tsd-signature">Version<span class="tsd-signature-symbol">:</span> <span
+                            class="tsd-signature-type">&quot;15.6.1&quot;</span></div>
+                    <aside class="tsd-sources">
+                        <ul>
+                            <li>Defined in <a
+                                    href="https://github.com/OutSystems/outsystems-ui/blob/19049a0/src/scripts/Providers/RangeSlider/NoUISlider/NoUiSliderEnum.ts#L5">Providers/RangeSlider/NoUISlider/NoUiSliderEnum.ts:5</a>
+                            </li>
+                        </ul>
+                    </aside>
+                </section>
+            </section>
+        </div>
+        <div class="col-4 col-menu menu-sticky-wrap menu-highlight">
+            <div class="tsd-navigation settings">
+                <details class="tsd-index-accordion">
+                    <summary class="tsd-accordion-summary">
+                        <h3><svg width="20" height="20" viewBox="0 0 24 24" fill="none">
+                                <path
+                                    d="M4.93896 8.531L12 15.591L19.061 8.531L16.939 6.409L12 11.349L7.06098 6.409L4.93896 8.531Z"
+                                    fill="var(--color-text)"></path>
+                            </svg> Settings</h3>
+                    </summary>
+                    <div class="tsd-accordion-details">
+                        <div class="tsd-filter-visibility">
+                            <h4 class="uppercase">Member Visibility</h4>
+                            <form>
+                                <ul id="tsd-filter-options">
+                                    <li class="tsd-filter-item"><label class="tsd-filter-input"><input type="checkbox"
+                                                id="tsd-filter-protected" name="protected" /><svg width="32" height="32"
+                                                viewBox="0 0 32 32" aria-hidden="true">
+                                                <rect class="tsd-checkbox-background" width="30" height="30" x="1" y="1"
+                                                    rx="6" fill="none"></rect>
+                                                <path class="tsd-checkbox-checkmark"
+                                                    d="M8.35422 16.8214L13.2143 21.75L24.6458 10.25" stroke="none"
+                                                    stroke-width="3.5" stroke-linejoin="round" fill="none"></path>
+                                            </svg><span>Protected</span></label></li>
+                                    <li class="tsd-filter-item"><label class="tsd-filter-input"><input type="checkbox"
+                                                id="tsd-filter-private" name="private" /><svg width="32" height="32"
+                                                viewBox="0 0 32 32" aria-hidden="true">
+                                                <rect class="tsd-checkbox-background" width="30" height="30" x="1" y="1"
+                                                    rx="6" fill="none"></rect>
+                                                <path class="tsd-checkbox-checkmark"
+                                                    d="M8.35422 16.8214L13.2143 21.75L24.6458 10.25" stroke="none"
+                                                    stroke-width="3.5" stroke-linejoin="round" fill="none"></path>
+                                            </svg><span>Private</span></label></li>
+                                    <li class="tsd-filter-item"><label class="tsd-filter-input"><input type="checkbox"
+                                                id="tsd-filter-inherited" name="inherited" checked /><svg width="32"
+                                                height="32" viewBox="0 0 32 32" aria-hidden="true">
+                                                <rect class="tsd-checkbox-background" width="30" height="30" x="1" y="1"
+                                                    rx="6" fill="none"></rect>
+                                                <path class="tsd-checkbox-checkmark"
+                                                    d="M8.35422 16.8214L13.2143 21.75L24.6458 10.25" stroke="none"
+                                                    stroke-width="3.5" stroke-linejoin="round" fill="none"></path>
+                                            </svg><span>Inherited</span></label></li>
+                                    <li class="tsd-filter-item"><label class="tsd-filter-input"><input type="checkbox"
+                                                id="tsd-filter-external" name="external" /><svg width="32" height="32"
+                                                viewBox="0 0 32 32" aria-hidden="true">
+                                                <rect class="tsd-checkbox-background" width="30" height="30" x="1" y="1"
+                                                    rx="6" fill="none"></rect>
+                                                <path class="tsd-checkbox-checkmark"
+                                                    d="M8.35422 16.8214L13.2143 21.75L24.6458 10.25" stroke="none"
+                                                    stroke-width="3.5" stroke-linejoin="round" fill="none"></path>
+                                            </svg><span>External</span></label></li>
+                                </ul>
+                            </form>
+                        </div>
+                        <div class="tsd-theme-toggle">
+                            <h4 class="uppercase">Theme</h4><select id="theme">
+                                <option value="os">OS</option>
+                                <option value="light">Light</option>
+                                <option value="dark">Dark</option>
+                            </select>
+                        </div>
+                    </div>
+                </details>
+            </div>
+            <nav class="tsd-navigation primary">
+                <details class="tsd-index-accordion" open>
+                    <summary class="tsd-accordion-summary">
+                        <h3><svg width="20" height="20" viewBox="0 0 24 24" fill="none">
+                                <path
+                                    d="M4.93896 8.531L12 15.591L19.061 8.531L16.939 6.409L12 11.349L7.06098 6.409L4.93896 8.531Z"
+                                    fill="var(--color-text)"></path>
+                            </svg> Modules</h3>
+                    </summary>
+                    <div class="tsd-accordion-details">
+                        <ul>
+                            <li class="current"><a href="../modules.html">outsystems-<wbr/>ui -<wbr/> v2.14.0</a>
+                                <ul>
+                                    <li class="tsd-kind-namespace"><a href="../modules/OSFramework.html">OSFramework</a>
+                                        <ul>
+                                            <li class="tsd-kind-namespace tsd-parent-kind-namespace"><a
+                                                    href="../modules/OSFramework.Behaviors.html">Behaviors</a></li>
+                                            <li class="tsd-kind-namespace tsd-parent-kind-namespace"><a
+                                                    href="../modules/OSFramework.Constants.html">Constants</a></li>
+                                            <li class="tsd-kind-namespace tsd-parent-kind-namespace"><a
+                                                    href="../modules/OSFramework.ErrorCodes.html">Error<wbr/>Codes</a>
+                                            </li>
+                                            <li class="tsd-kind-namespace tsd-parent-kind-namespace"><a
+                                                    href="../modules/OSFramework.Event.html">Event</a>
+                                                <ul>
+                                                    <li class="tsd-kind-namespace tsd-parent-kind-namespace"><a
+                                                            href="../modules/OSFramework.Event.GestureEvent.html">Gesture<wbr/>Event</a>
+                                                        <ul>
+                                                            <li class="tsd-kind-namespace tsd-parent-kind-namespace"><a
+                                                                    href="../modules/OSFramework.Event.GestureEvent.Callbacks.html">Callbacks</a>
+                                                            </li>
+                                                        </ul>
+                                                    </li>
+                                                    <li class="tsd-kind-namespace tsd-parent-kind-namespace"><a
+                                                            href="../modules/OSFramework.Event.ProviderEvents.html">Provider<wbr/>Events</a>
+                                                    </li>
+                                                </ul>
+                                            </li>
+                                            <li class="tsd-kind-namespace tsd-parent-kind-namespace"><a
+                                                    href="../modules/OSFramework.GlobalCallbacks.html">Global<wbr/>Callbacks</a>
+                                            </li>
+                                            <li class="tsd-kind-namespace tsd-parent-kind-namespace"><a
+                                                    href="../modules/OSFramework.GlobalEnum.html">Global<wbr/>Enum</a>
+                                            </li>
+                                            <li class="tsd-kind-namespace tsd-parent-kind-namespace"><a
+                                                    href="../modules/OSFramework.Helper.html">Helper</a>
+                                                <ul>
+                                                    <li class="tsd-kind-namespace tsd-parent-kind-namespace"><a
+                                                            href="../modules/OSFramework.Helper.MapOperation.html">Map<wbr/>Operation</a>
+                                                    </li>
+                                                </ul>
+                                            </li>
+                                            <li class="tsd-kind-namespace tsd-parent-kind-namespace"><a
+                                                    href="../modules/OSFramework.Interface.html">Interface</a></li>
+                                            <li class="tsd-kind-namespace tsd-parent-kind-namespace"><a
+                                                    href="../modules/OSFramework.Patterns.html">Patterns</a>
+                                                <ul>
+                                                    <li class="tsd-kind-namespace tsd-parent-kind-namespace"><a
+                                                            href="../modules/OSFramework.Patterns.Accordion.html">Accordion</a>
+                                                        <ul>
+                                                            <li class="tsd-kind-namespace tsd-parent-kind-namespace"><a
+                                                                    href="../modules/OSFramework.Patterns.Accordion.Enum.html">Enum</a>
+                                                            </li>
+                                                        </ul>
+                                                    </li>
+                                                    <li class="tsd-kind-namespace tsd-parent-kind-namespace"><a
+                                                            href="../modules/OSFramework.Patterns.AccordionItem.html">Accordion<wbr/>Item</a>
+                                                        <ul>
+                                                            <li class="tsd-kind-namespace tsd-parent-kind-namespace"><a
+                                                                    href="../modules/OSFramework.Patterns.AccordionItem.Enum.html">Enum</a>
+                                                            </li>
+                                                        </ul>
+                                                    </li>
+                                                    <li class="tsd-kind-namespace tsd-parent-kind-namespace"><a
+                                                            href="../modules/OSFramework.Patterns.AnimatedLabel.html">Animated<wbr/>Label</a>
+                                                        <ul>
+                                                            <li class="tsd-kind-namespace tsd-parent-kind-namespace"><a
+                                                                    href="../modules/OSFramework.Patterns.AnimatedLabel.Enum.html">Enum</a>
+                                                            </li>
+                                                        </ul>
+                                                    </li>
+                                                    <li class="tsd-kind-namespace tsd-parent-kind-namespace"><a
+                                                            href="../modules/OSFramework.Patterns.BottomSheet.html">Bottom<wbr/>Sheet</a>
+                                                        <ul>
+                                                            <li class="tsd-kind-namespace tsd-parent-kind-namespace"><a
+                                                                    href="../modules/OSFramework.Patterns.BottomSheet.Callbacks.html">Callbacks</a>
+                                                            </li>
+                                                            <li class="tsd-kind-namespace tsd-parent-kind-namespace"><a
+                                                                    href="../modules/OSFramework.Patterns.BottomSheet.Enum.html">Enum</a>
+                                                            </li>
+                                                        </ul>
+                                                    </li>
+                                                    <li class="tsd-kind-namespace tsd-parent-kind-namespace"><a
+                                                            href="../modules/OSFramework.Patterns.ButtonLoading.html">Button<wbr/>Loading</a>
+                                                        <ul>
+                                                            <li class="tsd-kind-namespace tsd-parent-kind-namespace"><a
+                                                                    href="../modules/OSFramework.Patterns.ButtonLoading.Enum.html">Enum</a>
+                                                            </li>
+                                                        </ul>
+                                                    </li>
+                                                    <li class="tsd-kind-namespace tsd-parent-kind-namespace"><a
+                                                            href="../modules/OSFramework.Patterns.Carousel.html">Carousel</a>
+                                                        <ul>
+                                                            <li class="tsd-kind-namespace tsd-parent-kind-namespace"><a
+                                                                    href="../modules/OSFramework.Patterns.Carousel.Callbacks.html">Callbacks</a>
+                                                            </li>
+                                                            <li class="tsd-kind-namespace tsd-parent-kind-namespace"><a
+                                                                    href="../modules/OSFramework.Patterns.Carousel.Factory.html">Factory</a>
+                                                            </li>
+                                                            <li class="tsd-kind-namespace tsd-parent-kind-namespace"><a
+                                                                    href="../modules/OSFramework.Patterns.Carousel.Enum.html">Enum</a>
+                                                            </li>
+                                                        </ul>
+                                                    </li>
+                                                    <li class="tsd-kind-namespace tsd-parent-kind-namespace"><a
+                                                            href="../modules/OSFramework.Patterns.DatePicker.html">Date<wbr/>Picker</a>
+                                                        <ul>
+                                                            <li class="tsd-kind-namespace tsd-parent-kind-namespace"><a
+                                                                    href="../modules/OSFramework.Patterns.DatePicker.Callbacks.html">Callbacks</a>
+                                                            </li>
+                                                            <li class="tsd-kind-namespace tsd-parent-kind-namespace"><a
+                                                                    href="../modules/OSFramework.Patterns.DatePicker.Factory.html">Factory</a>
+                                                            </li>
+                                                            <li class="tsd-kind-namespace tsd-parent-kind-namespace"><a
+                                                                    href="../modules/OSFramework.Patterns.DatePicker.Enum.html">Enum</a>
+                                                            </li>
+                                                        </ul>
+                                                    </li>
+                                                    <li class="tsd-kind-namespace tsd-parent-kind-namespace"><a
+                                                            href="../modules/OSFramework.Patterns.Dropdown.html">Dropdown</a>
+                                                        <ul>
+                                                            <li class="tsd-kind-namespace tsd-parent-kind-namespace"><a
+                                                                    href="../modules/OSFramework.Patterns.Dropdown.Callbacks.html">Callbacks</a>
+                                                            </li>
+                                                            <li class="tsd-kind-namespace tsd-parent-kind-namespace"><a
+                                                                    href="../modules/OSFramework.Patterns.Dropdown.Factory.html">Factory</a>
+                                                            </li>
+                                                            <li class="tsd-kind-namespace tsd-parent-kind-namespace"><a
+                                                                    href="../modules/OSFramework.Patterns.Dropdown.Enum.html">Enum</a>
+                                                            </li>
+                                                            <li class="tsd-kind-namespace tsd-parent-kind-namespace"><a
+                                                                    href="../modules/OSFramework.Patterns.Dropdown.ServerSide.html">Server<wbr/>Side</a>
+                                                                <ul>
+                                                                    <li
+                                                                        class="tsd-kind-namespace tsd-parent-kind-namespace">
+                                                                        <a
+                                                                            href="../modules/OSFramework.Patterns.Dropdown.ServerSide.Enum.html">Enum</a>
+                                                                    </li>
+                                                                </ul>
+                                                            </li>
+                                                        </ul>
+                                                    </li>
+                                                    <li class="tsd-kind-namespace tsd-parent-kind-namespace"><a
+                                                            href="../modules/OSFramework.Patterns.DropdownServerSideItem.html">Dropdown<wbr/>Server<wbr/>Side<wbr/>Item</a>
+                                                        <ul>
+                                                            <li class="tsd-kind-namespace tsd-parent-kind-namespace"><a
+                                                                    href="../modules/OSFramework.Patterns.DropdownServerSideItem.Callbacks.html">Callbacks</a>
+                                                            </li>
+                                                            <li class="tsd-kind-namespace tsd-parent-kind-namespace"><a
+                                                                    href="../modules/OSFramework.Patterns.DropdownServerSideItem.Enum.html">Enum</a>
+                                                            </li>
+                                                        </ul>
+                                                    </li>
+                                                    <li class="tsd-kind-namespace tsd-parent-kind-namespace"><a
+                                                            href="../modules/OSFramework.Patterns.FlipContent.html">Flip<wbr/>Content</a>
+                                                        <ul>
+                                                            <li class="tsd-kind-namespace tsd-parent-kind-namespace"><a
+                                                                    href="../modules/OSFramework.Patterns.FlipContent.Callbacks.html">Callbacks</a>
+                                                            </li>
+                                                            <li class="tsd-kind-namespace tsd-parent-kind-namespace"><a
+                                                                    href="../modules/OSFramework.Patterns.FlipContent.Enum.html">Enum</a>
+                                                            </li>
+                                                        </ul>
+                                                    </li>
+                                                    <li class="tsd-kind-namespace tsd-parent-kind-namespace"><a
+                                                            href="../modules/OSFramework.Patterns.Gallery.html">Gallery</a>
+                                                        <ul>
+                                                            <li class="tsd-kind-namespace tsd-parent-kind-namespace"><a
+                                                                    href="../modules/OSFramework.Patterns.Gallery.Enum.html">Enum</a>
+                                                            </li>
+                                                        </ul>
+                                                    </li>
+                                                    <li class="tsd-kind-namespace tsd-parent-kind-namespace"><a
+                                                            href="../modules/OSFramework.Patterns.MonthPicker.html">Month<wbr/>Picker</a>
+                                                        <ul>
+                                                            <li class="tsd-kind-namespace tsd-parent-kind-namespace"><a
+                                                                    href="../modules/OSFramework.Patterns.MonthPicker.Callbacks.html">Callbacks</a>
+                                                            </li>
+                                                            <li class="tsd-kind-namespace tsd-parent-kind-namespace"><a
+                                                                    href="../modules/OSFramework.Patterns.MonthPicker.Enum.html">Enum</a>
+                                                            </li>
+                                                            <li class="tsd-kind-namespace tsd-parent-kind-namespace"><a
+                                                                    href="../modules/OSFramework.Patterns.MonthPicker.Factory.html">Factory</a>
+                                                            </li>
+                                                        </ul>
+                                                    </li>
+                                                    <li class="tsd-kind-namespace tsd-parent-kind-namespace"><a
+                                                            href="../modules/OSFramework.Patterns.Notification.html">Notification</a>
+                                                        <ul>
+                                                            <li class="tsd-kind-namespace tsd-parent-kind-namespace"><a
+                                                                    href="../modules/OSFramework.Patterns.Notification.Callbacks.html">Callbacks</a>
+                                                            </li>
+                                                            <li class="tsd-kind-namespace tsd-parent-kind-namespace"><a
+                                                                    href="../modules/OSFramework.Patterns.Notification.Enum.html">Enum</a>
+                                                            </li>
+                                                        </ul>
+                                                    </li>
+                                                    <li class="tsd-kind-namespace tsd-parent-kind-namespace"><a
+                                                            href="../modules/OSFramework.Patterns.Progress.html">Progress</a>
+                                                        <ul>
+                                                            <li class="tsd-kind-namespace tsd-parent-kind-namespace"><a
+                                                                    href="../modules/OSFramework.Patterns.Progress.Bar.html">Bar</a>
+                                                            </li>
+                                                            <li class="tsd-kind-namespace tsd-parent-kind-namespace"><a
+                                                                    href="../modules/OSFramework.Patterns.Progress.Circle.html">Circle</a>
+                                                                <ul>
+                                                                    <li
+                                                                        class="tsd-kind-namespace tsd-parent-kind-namespace">
+                                                                        <a
+                                                                            href="../modules/OSFramework.Patterns.Progress.Circle.Enum.html">Enum</a>
+                                                                    </li>
+                                                                </ul>
+                                                            </li>
+                                                            <li class="tsd-kind-namespace tsd-parent-kind-namespace"><a
+                                                                    href="../modules/OSFramework.Patterns.Progress.ProgressEnum.html">Progress<wbr/>Enum</a>
+                                                            </li>
+                                                            <li class="tsd-kind-namespace tsd-parent-kind-namespace"><a
+                                                                    href="../modules/OSFramework.Patterns.Progress.Factory.html">Factory</a>
+                                                            </li>
+                                                        </ul>
+                                                    </li>
+                                                    <li class="tsd-kind-namespace tsd-parent-kind-namespace"><a
+                                                            href="../modules/OSFramework.Patterns.RangeSlider.html">Range<wbr/>Slider</a>
+                                                        <ul>
+                                                            <li class="tsd-kind-namespace tsd-parent-kind-namespace"><a
+                                                                    href="../modules/OSFramework.Patterns.RangeSlider.Callbacks.html">Callbacks</a>
+                                                            </li>
+                                                            <li class="tsd-kind-namespace tsd-parent-kind-namespace"><a
+                                                                    href="../modules/OSFramework.Patterns.RangeSlider.Enum.html">Enum</a>
+                                                            </li>
+                                                            <li class="tsd-kind-namespace tsd-parent-kind-namespace"><a
+                                                                    href="../modules/OSFramework.Patterns.RangeSlider.Factory.html">Factory</a>
+                                                            </li>
+                                                        </ul>
+                                                    </li>
+                                                    <li class="tsd-kind-namespace tsd-parent-kind-namespace"><a
+                                                            href="../modules/OSFramework.Patterns.Rating.html">Rating</a>
+                                                        <ul>
+                                                            <li class="tsd-kind-namespace tsd-parent-kind-namespace"><a
+                                                                    href="../modules/OSFramework.Patterns.Rating.Callbacks.html">Callbacks</a>
+                                                            </li>
+                                                            <li class="tsd-kind-namespace tsd-parent-kind-namespace"><a
+                                                                    href="../modules/OSFramework.Patterns.Rating.Enum.html">Enum</a>
+                                                            </li>
+                                                        </ul>
+                                                    </li>
+                                                    <li class="tsd-kind-namespace tsd-parent-kind-namespace"><a
+                                                            href="../modules/OSFramework.Patterns.SectionIndex.html">Section<wbr/>Index</a>
+                                                        <ul>
+                                                            <li class="tsd-kind-namespace tsd-parent-kind-namespace"><a
+                                                                    href="../modules/OSFramework.Patterns.SectionIndex.Enum.html">Enum</a>
+                                                            </li>
+                                                        </ul>
+                                                    </li>
+                                                    <li class="tsd-kind-namespace tsd-parent-kind-namespace"><a
+                                                            href="../modules/OSFramework.Patterns.SectionIndexItem.html">Section<wbr/>Index<wbr/>Item</a>
+                                                        <ul>
+                                                            <li class="tsd-kind-namespace tsd-parent-kind-namespace"><a
+                                                                    href="../modules/OSFramework.Patterns.SectionIndexItem.Enum.html">Enum</a>
+                                                            </li>
+                                                        </ul>
+                                                    </li>
+                                                    <li class="tsd-kind-namespace tsd-parent-kind-namespace"><a
+                                                            href="../modules/OSFramework.Patterns.Sidebar.html">Sidebar</a>
+                                                        <ul>
+                                                            <li class="tsd-kind-namespace tsd-parent-kind-namespace"><a
+                                                                    href="../modules/OSFramework.Patterns.Sidebar.Callbacks.html">Callbacks</a>
+                                                            </li>
+                                                            <li class="tsd-kind-namespace tsd-parent-kind-namespace"><a
+                                                                    href="../modules/OSFramework.Patterns.Sidebar.Enum.html">Enum</a>
+                                                            </li>
+                                                        </ul>
+                                                    </li>
+                                                    <li class="tsd-kind-namespace tsd-parent-kind-namespace"><a
+                                                            href="../modules/OSFramework.Patterns.Submenu.html">Submenu</a>
+                                                        <ul>
+                                                            <li class="tsd-kind-namespace tsd-parent-kind-namespace"><a
+                                                                    href="../modules/OSFramework.Patterns.Submenu.Enum.html">Enum</a>
+                                                            </li>
+                                                        </ul>
+                                                    </li>
+                                                    <li class="tsd-kind-namespace tsd-parent-kind-namespace"><a
+                                                            href="../modules/OSFramework.Patterns.SwipeEvents.html">Swipe<wbr/>Events</a>
+                                                        <ul>
+                                                            <li class="tsd-kind-namespace tsd-parent-kind-namespace"><a
+                                                                    href="../modules/OSFramework.Patterns.SwipeEvents.Enum.html">Enum</a>
+                                                            </li>
+                                                        </ul>
+                                                    </li>
+                                                    <li class="tsd-kind-namespace tsd-parent-kind-namespace"><a
+                                                            href="../modules/OSFramework.Patterns.Tabs.html">Tabs</a>
+                                                        <ul>
+                                                            <li class="tsd-kind-namespace tsd-parent-kind-namespace"><a
+                                                                    href="../modules/OSFramework.Patterns.Tabs.Callbacks.html">Callbacks</a>
+                                                            </li>
+                                                            <li class="tsd-kind-namespace tsd-parent-kind-namespace"><a
+                                                                    href="../modules/OSFramework.Patterns.Tabs.Enum.html">Enum</a>
+                                                            </li>
+                                                        </ul>
+                                                    </li>
+                                                    <li class="tsd-kind-namespace tsd-parent-kind-namespace"><a
+                                                            href="../modules/OSFramework.Patterns.TabsContentItem.html">Tabs<wbr/>Content<wbr/>Item</a>
+                                                    </li>
+                                                    <li class="tsd-kind-namespace tsd-parent-kind-namespace"><a
+                                                            href="../modules/OSFramework.Patterns.TabsHeaderItem.html">Tabs<wbr/>Header<wbr/>Item</a>
+                                                    </li>
+                                                    <li class="tsd-kind-namespace tsd-parent-kind-namespace"><a
+                                                            href="../modules/OSFramework.Patterns.TimePicker.html">Time<wbr/>Picker</a>
+                                                        <ul>
+                                                            <li class="tsd-kind-namespace tsd-parent-kind-namespace"><a
+                                                                    href="../modules/OSFramework.Patterns.TimePicker.Callbacks.html">Callbacks</a>
+                                                            </li>
+                                                            <li class="tsd-kind-namespace tsd-parent-kind-namespace"><a
+                                                                    href="../modules/OSFramework.Patterns.TimePicker.Enum.html">Enum</a>
+                                                            </li>
+                                                            <li class="tsd-kind-namespace tsd-parent-kind-namespace"><a
+                                                                    href="../modules/OSFramework.Patterns.TimePicker.Factory.html">Factory</a>
+                                                            </li>
+                                                        </ul>
+                                                    </li>
+                                                    <li class="tsd-kind-namespace tsd-parent-kind-namespace"><a
+                                                            href="../modules/OSFramework.Patterns.Tooltip.html">Tooltip</a>
+                                                        <ul>
+                                                            <li class="tsd-kind-namespace tsd-parent-kind-namespace"><a
+                                                                    href="../modules/OSFramework.Patterns.Tooltip.Enum.html">Enum</a>
+                                                            </li>
+                                                        </ul>
+                                                    </li>
+                                                    <li class="tsd-kind-namespace tsd-parent-kind-namespace"><a
+                                                            href="../modules/OSFramework.Patterns.TouchEvents.html">Touch<wbr/>Events</a>
+                                                        <ul>
+                                                            <li class="tsd-kind-namespace tsd-parent-kind-namespace"><a
+                                                                    href="../modules/OSFramework.Patterns.TouchEvents.Enum.html">Enum</a>
+                                                            </li>
+                                                        </ul>
+                                                    </li>
+                                                </ul>
+                                            </li>
+                                        </ul>
+                                    </li>
+                                    <li class="tsd-kind-namespace"><a
+                                            href="../modules/OutSystems.html">Out<wbr/>Systems</a>
+                                        <ul>
+                                            <li class="tsd-kind-namespace tsd-parent-kind-namespace"><a
+                                                    href="../modules/OutSystems.OSUI.html">OSUI</a>
+                                                <ul>
+                                                    <li class="tsd-kind-namespace tsd-parent-kind-namespace"><a
+                                                            href="../modules/OutSystems.OSUI.ErrorCodes.html">Error<wbr/>Codes</a>
+                                                    </li>
+                                                    <li class="tsd-kind-namespace tsd-parent-kind-namespace"><a
+                                                            href="../modules/OutSystems.OSUI.Patterns.html">Patterns</a>
+                                                        <ul>
+                                                            <li class="tsd-kind-namespace tsd-parent-kind-namespace"><a
+                                                                    href="../modules/OutSystems.OSUI.Patterns.AccordionAPI.html">AccordionAPI</a>
+                                                            </li>
+                                                            <li class="tsd-kind-namespace tsd-parent-kind-namespace"><a
+                                                                    href="../modules/OutSystems.OSUI.Patterns.AccordionItemAPI.html">Accordion<wbr/>ItemAPI</a>
+                                                            </li>
+                                                            <li class="tsd-kind-namespace tsd-parent-kind-namespace"><a
+                                                                    href="../modules/OutSystems.OSUI.Patterns.AnimatedLabelAPI.html">Animated<wbr/>LabelAPI</a>
+                                                            </li>
+                                                            <li class="tsd-kind-namespace tsd-parent-kind-namespace"><a
+                                                                    href="../modules/OutSystems.OSUI.Patterns.BottomSheetAPI.html">Bottom<wbr/>SheetAPI</a>
+                                                            </li>
+                                                            <li class="tsd-kind-namespace tsd-parent-kind-namespace"><a
+                                                                    href="../modules/OutSystems.OSUI.Patterns.ButtonLoadingAPI.html">Button<wbr/>LoadingAPI</a>
+                                                            </li>
+                                                            <li class="tsd-kind-namespace tsd-parent-kind-namespace"><a
+                                                                    href="../modules/OutSystems.OSUI.Patterns.CarouselAPI.html">CarouselAPI</a>
+                                                            </li>
+                                                            <li class="tsd-kind-namespace tsd-parent-kind-namespace"><a
+                                                                    href="../modules/OutSystems.OSUI.Patterns.DatePickerAPI.html">Date<wbr/>PickerAPI</a>
+                                                            </li>
+                                                            <li class="tsd-kind-namespace tsd-parent-kind-namespace"><a
+                                                                    href="../modules/OutSystems.OSUI.Patterns.DropdownAPI.html">DropdownAPI</a>
+                                                            </li>
+                                                            <li class="tsd-kind-namespace tsd-parent-kind-namespace"><a
+                                                                    href="../modules/OutSystems.OSUI.Patterns.DropdownServerSideItemAPI.html">Dropdown<wbr/>Server<wbr/>Side<wbr/>ItemAPI</a>
+                                                            </li>
+                                                            <li class="tsd-kind-namespace tsd-parent-kind-namespace"><a
+                                                                    href="../modules/OutSystems.OSUI.Patterns.FlipContentAPI.html">Flip<wbr/>ContentAPI</a>
+                                                            </li>
+                                                            <li class="tsd-kind-namespace tsd-parent-kind-namespace"><a
+                                                                    href="../modules/OutSystems.OSUI.Patterns.GalleryAPI.html">GalleryAPI</a>
+                                                            </li>
+                                                            <li class="tsd-kind-namespace tsd-parent-kind-namespace"><a
+                                                                    href="../modules/OutSystems.OSUI.Patterns.MonthPickerAPI.html">Month<wbr/>PickerAPI</a>
+                                                            </li>
+                                                            <li class="tsd-kind-namespace tsd-parent-kind-namespace"><a
+                                                                    href="../modules/OutSystems.OSUI.Patterns.NotificationAPI.html">NotificationAPI</a>
+                                                            </li>
+                                                            <li class="tsd-kind-namespace tsd-parent-kind-namespace"><a
+                                                                    href="../modules/OutSystems.OSUI.Patterns.ProgressAPI.html">ProgressAPI</a>
+                                                            </li>
+                                                            <li class="tsd-kind-namespace tsd-parent-kind-namespace"><a
+                                                                    href="../modules/OutSystems.OSUI.Patterns.RangeSliderAPI.html">Range<wbr/>SliderAPI</a>
+                                                            </li>
+                                                            <li class="tsd-kind-namespace tsd-parent-kind-namespace"><a
+                                                                    href="../modules/OutSystems.OSUI.Patterns.RatingAPI.html">RatingAPI</a>
+                                                            </li>
+                                                            <li class="tsd-kind-namespace tsd-parent-kind-namespace"><a
+                                                                    href="../modules/OutSystems.OSUI.Patterns.SectionIndexAPI.html">Section<wbr/>IndexAPI</a>
+                                                            </li>
+                                                            <li class="tsd-kind-namespace tsd-parent-kind-namespace"><a
+                                                                    href="../modules/OutSystems.OSUI.Patterns.SectionIndexItemAPI.html">Section<wbr/>Index<wbr/>ItemAPI</a>
+                                                            </li>
+                                                            <li class="tsd-kind-namespace tsd-parent-kind-namespace"><a
+                                                                    href="../modules/OutSystems.OSUI.Patterns.SidebarAPI.html">SidebarAPI</a>
+                                                            </li>
+                                                            <li class="tsd-kind-namespace tsd-parent-kind-namespace"><a
+                                                                    href="../modules/OutSystems.OSUI.Patterns.SubmenuAPI.html">SubmenuAPI</a>
+                                                            </li>
+                                                            <li class="tsd-kind-namespace tsd-parent-kind-namespace"><a
+                                                                    href="../modules/OutSystems.OSUI.Patterns.SwipeEventsAPI.html">Swipe<wbr/>EventsAPI</a>
+                                                            </li>
+                                                            <li class="tsd-kind-namespace tsd-parent-kind-namespace"><a
+                                                                    href="../modules/OutSystems.OSUI.Patterns.TabsAPI.html">TabsAPI</a>
+                                                            </li>
+                                                            <li class="tsd-kind-namespace tsd-parent-kind-namespace"><a
+                                                                    href="../modules/OutSystems.OSUI.Patterns.TabsContentItemAPI.html">Tabs<wbr/>Content<wbr/>ItemAPI</a>
+                                                            </li>
+                                                            <li class="tsd-kind-namespace tsd-parent-kind-namespace"><a
+                                                                    href="../modules/OutSystems.OSUI.Patterns.TabsHeaderItemAPI.html">Tabs<wbr/>Header<wbr/>ItemAPI</a>
+                                                            </li>
+                                                            <li class="tsd-kind-namespace tsd-parent-kind-namespace"><a
+                                                                    href="../modules/OutSystems.OSUI.Patterns.TimePickerAPI.html">Time<wbr/>PickerAPI</a>
+                                                            </li>
+                                                            <li class="tsd-kind-namespace tsd-parent-kind-namespace"><a
+                                                                    href="../modules/OutSystems.OSUI.Patterns.TooltipAPI.html">TooltipAPI</a>
+                                                            </li>
+                                                            <li class="tsd-kind-namespace tsd-parent-kind-namespace"><a
+                                                                    href="../modules/OutSystems.OSUI.Patterns.TouchEventsAPI.html">Touch<wbr/>EventsAPI</a>
+                                                            </li>
+                                                        </ul>
+                                                    </li>
+                                                    <li class="tsd-kind-namespace tsd-parent-kind-namespace"><a
+                                                            href="../modules/OutSystems.OSUI.Utils.html">Utils</a>
+                                                        <ul>
+                                                            <li class="tsd-kind-namespace tsd-parent-kind-namespace"><a
+                                                                    href="../modules/OutSystems.OSUI.Utils.Accessibility.html">Accessibility</a>
+                                                            </li>
+                                                            <li class="tsd-kind-namespace tsd-parent-kind-namespace"><a
+                                                                    href="../modules/OutSystems.OSUI.Utils.Application.html">Application</a>
+                                                            </li>
+                                                            <li class="tsd-kind-namespace tsd-parent-kind-namespace"><a
+                                                                    href="../modules/OutSystems.OSUI.Utils.DeviceDetection.html">Device<wbr/>Detection</a>
+                                                            </li>
+                                                            <li class="tsd-kind-namespace tsd-parent-kind-namespace"><a
+                                                                    href="../modules/OutSystems.OSUI.Utils.InvalidInputs.html">Invalid<wbr/>Inputs</a>
+                                                            </li>
+                                                            <li class="tsd-kind-namespace tsd-parent-kind-namespace"><a
+                                                                    href="../modules/OutSystems.OSUI.Utils.HideOnScroll.html">Hide<wbr/>On<wbr/>Scroll</a>
+                                                            </li>
+                                                            <li class="tsd-kind-namespace tsd-parent-kind-namespace"><a
+                                                                    href="../modules/OutSystems.OSUI.Utils.LayoutPrivate.html">Layout<wbr/>Private</a>
+                                                            </li>
+                                                            <li class="tsd-kind-namespace tsd-parent-kind-namespace"><a
+                                                                    href="../modules/OutSystems.OSUI.Utils.Menu.html">Menu</a>
+                                                            </li>
+                                                            <li class="tsd-kind-namespace tsd-parent-kind-namespace"><a
+                                                                    href="../modules/OutSystems.OSUI.Utils.Network.html">Network</a>
+                                                            </li>
+                                                        </ul>
+                                                    </li>
+                                                    <li class="tsd-kind-namespace tsd-parent-kind-namespace"><a
+                                                            href="../modules/OutSystems.OSUI.Dates.html">Dates</a></li>
+                                                    <li class="tsd-kind-namespace tsd-parent-kind-namespace"><a
+                                                            href="../modules/OutSystems.OSUI.Language.html">Language</a>
+                                                    </li>
+                                                </ul>
+                                            </li>
+                                        </ul>
+                                    </li>
+                                    <li class="current tsd-kind-namespace"><a
+                                            href="../modules/Providers.html">Providers</a>
+                                        <ul>
+                                            <li class="tsd-kind-namespace tsd-parent-kind-namespace"><a
+                                                    href="../modules/Providers.Carousel.html">Carousel</a>
+                                                <ul>
+                                                    <li class="tsd-kind-namespace tsd-parent-kind-namespace"><a
+                                                            href="../modules/Providers.Carousel.Splide.html">Splide</a>
+                                                        <ul>
+                                                            <li class="tsd-kind-namespace tsd-parent-kind-namespace"><a
+                                                                    href="../modules/Providers.Carousel.Splide.Enum.html">Enum</a>
+                                                            </li>
+                                                        </ul>
+                                                    </li>
+                                                </ul>
+                                            </li>
+                                            <li class="tsd-kind-namespace tsd-parent-kind-namespace"><a
+                                                    href="../modules/Providers.Datepicker.html">Datepicker</a>
+                                                <ul>
+                                                    <li class="tsd-kind-namespace tsd-parent-kind-namespace"><a
+                                                            href="../modules/Providers.Datepicker.Flatpickr.html">Flatpickr</a>
+                                                        <ul>
+                                                            <li class="tsd-kind-namespace tsd-parent-kind-namespace"><a
+                                                                    href="../modules/Providers.Datepicker.Flatpickr.Enum.html">Enum</a>
+                                                            </li>
+                                                            <li class="tsd-kind-namespace tsd-parent-kind-namespace"><a
+                                                                    href="../modules/Providers.Datepicker.Flatpickr.Factory.html">Factory</a>
+                                                            </li>
+                                                            <li class="tsd-kind-namespace tsd-parent-kind-namespace"><a
+                                                                    href="../modules/Providers.Datepicker.Flatpickr.RangeDate.html">Range<wbr/>Date</a>
+                                                                <ul>
+                                                                    <li
+                                                                        class="tsd-kind-namespace tsd-parent-kind-namespace">
+                                                                        <a
+                                                                            href="../modules/Providers.Datepicker.Flatpickr.RangeDate.Enum.html">Enum</a>
+                                                                    </li>
+                                                                </ul>
+                                                            </li>
+                                                            <li class="tsd-kind-namespace tsd-parent-kind-namespace"><a
+                                                                    href="../modules/Providers.Datepicker.Flatpickr.SingleDate.html">Single<wbr/>Date</a>
+                                                                <ul>
+                                                                    <li
+                                                                        class="tsd-kind-namespace tsd-parent-kind-namespace">
+                                                                        <a
+                                                                            href="../modules/Providers.Datepicker.Flatpickr.SingleDate.Enum.html">Enum</a>
+                                                                    </li>
+                                                                </ul>
+                                                            </li>
+                                                            <li class="tsd-kind-namespace tsd-parent-kind-namespace"><a
+                                                                    href="../modules/Providers.Datepicker.Flatpickr.l10ns.html">l10ns</a>
+                                                            </li>
+                                                        </ul>
+                                                    </li>
+                                                </ul>
+                                            </li>
+                                            <li class="tsd-kind-namespace tsd-parent-kind-namespace"><a
+                                                    href="../modules/Providers.Dropdown.html">Dropdown</a>
+                                                <ul>
+                                                    <li class="tsd-kind-namespace tsd-parent-kind-namespace"><a
+                                                            href="../modules/Providers.Dropdown.VirtualSelect.html">Virtual<wbr/>Select</a>
+                                                        <ul>
+                                                            <li class="tsd-kind-namespace tsd-parent-kind-namespace"><a
+                                                                    href="../modules/Providers.Dropdown.VirtualSelect.Enum.html">Enum</a>
+                                                            </li>
+                                                            <li class="tsd-kind-namespace tsd-parent-kind-namespace"><a
+                                                                    href="../modules/Providers.Dropdown.VirtualSelect.Search.html">Search</a>
+                                                                <ul>
+                                                                    <li
+                                                                        class="tsd-kind-namespace tsd-parent-kind-namespace">
+                                                                        <a
+                                                                            href="../modules/Providers.Dropdown.VirtualSelect.Search.Enum.html">Enum</a>
+                                                                    </li>
+                                                                </ul>
+                                                            </li>
+                                                            <li class="tsd-kind-namespace tsd-parent-kind-namespace"><a
+                                                                    href="../modules/Providers.Dropdown.VirtualSelect.Tags.html">Tags</a>
+                                                            </li>
+                                                            <li class="tsd-kind-namespace tsd-parent-kind-namespace"><a
+                                                                    href="../modules/Providers.Dropdown.VirtualSelect.Factory.html">Factory</a>
+                                                            </li>
+                                                        </ul>
+                                                    </li>
+                                                </ul>
+                                            </li>
+                                            <li class="tsd-kind-namespace tsd-parent-kind-namespace"><a
+                                                    href="../modules/Providers.MonthPicker.html">Month<wbr/>Picker</a>
+                                                <ul>
+                                                    <li class="tsd-kind-namespace tsd-parent-kind-namespace"><a
+                                                            href="../modules/Providers.MonthPicker.Flatpickr.html">Flatpickr</a>
+                                                    </li>
+                                                </ul>
+                                            </li>
+                                            <li class="current tsd-kind-namespace tsd-parent-kind-namespace"><a
+                                                    href="../modules/Providers.RangeSlider.html">Range<wbr/>Slider</a>
+                                                <ul>
+                                                    <li class="tsd-kind-namespace tsd-parent-kind-namespace"><a
+                                                            href="../modules/Providers.RangeSlider.NoUISlider.html">NoUISlider</a>
+                                                        <ul>
+                                                            <li class="tsd-kind-namespace tsd-parent-kind-namespace"><a
+                                                                    href="../modules/Providers.RangeSlider.NoUISlider.IntervalSlider.html">Interval<wbr/>Slider</a>
+                                                            </li>
+                                                            <li class="tsd-kind-namespace tsd-parent-kind-namespace"><a
+                                                                    href="../modules/Providers.RangeSlider.NoUISlider.SliderInterval.html">Slider<wbr/>Interval</a>
+                                                            </li>
+                                                            <li class="tsd-kind-namespace tsd-parent-kind-namespace"><a
+                                                                    href="../modules/Providers.RangeSlider.NoUISlider.SingleSlider.html">Single<wbr/>Slider</a>
+                                                            </li>
+                                                            <li class="tsd-kind-namespace tsd-parent-kind-namespace"><a
+                                                                    href="../modules/Providers.RangeSlider.NoUISlider.SliderSingle.html">Slider<wbr/>Single</a>
+                                                            </li>
+                                                        </ul>
+                                                    </li>
+                                                    <li class="current tsd-kind-namespace tsd-parent-kind-namespace"><a
+                                                            href="../modules/Providers.RangeSlider.NoUiSlider-1.html">No<wbr/>Ui<wbr/>Slider</a>
+                                                        <ul>
+                                                            <li
+                                                                class="current tsd-kind-namespace tsd-parent-kind-namespace">
+                                                                <a
+                                                                    href="../modules/Providers.RangeSlider.NoUiSlider-1.Enum.html">Enum</a>
+                                                            </li>
+                                                            <li class="tsd-kind-namespace tsd-parent-kind-namespace"><a
+                                                                    href="../modules/Providers.RangeSlider.NoUiSlider-1.Factory.html">Factory</a>
+                                                            </li>
+                                                        </ul>
+                                                    </li>
+                                                </ul>
+                                            </li>
+                                            <li class="tsd-kind-namespace tsd-parent-kind-namespace"><a
+                                                    href="../modules/Providers.SharedProviderResources.html">Shared<wbr/>Provider<wbr/>Resources</a>
+                                                <ul>
+                                                    <li class="tsd-kind-namespace tsd-parent-kind-namespace"><a
+                                                            href="../modules/Providers.SharedProviderResources.Flatpickr.html">Flatpickr</a>
+                                                        <ul>
+                                                            <li class="tsd-kind-namespace tsd-parent-kind-namespace"><a
+                                                                    href="../modules/Providers.SharedProviderResources.Flatpickr.Enum.html">Enum</a>
+                                                            </li>
+                                                        </ul>
+                                                    </li>
+                                                </ul>
+                                            </li>
+                                            <li class="tsd-kind-namespace tsd-parent-kind-namespace"><a
+                                                    href="../modules/Providers.TimePicker.html">Time<wbr/>Picker</a>
+                                                <ul>
+                                                    <li class="tsd-kind-namespace tsd-parent-kind-namespace"><a
+                                                            href="../modules/Providers.TimePicker.Flatpickr.html">Flatpickr</a>
+                                                        <ul>
+                                                            <li class="tsd-kind-namespace tsd-parent-kind-namespace"><a
+                                                                    href="../modules/Providers.TimePicker.Flatpickr.Enum.html">Enum</a>
+                                                            </li>
+                                                        </ul>
+                                                    </li>
+                                                </ul>
+                                            </li>
+                                        </ul>
+                                    </li>
+                                </ul>
+                            </li>
+                        </ul>
+                    </div>
+                </details>
+            </nav>
+            <nav class="tsd-navigation secondary menu-sticky">
+                <ul>
+                    <li class="current tsd-kind-enum tsd-parent-kind-namespace"><a
+                            href="Providers.RangeSlider.NoUiSlider-1.Enum.ProviderInfo.html" class="tsd-index-link"><svg
+                                class="tsd-kind-icon" width="24" height="24" viewBox="0 0 24 24">
+                                <rect fill="var(--color-icon-background)" stroke="var(--color-ts-enum)"
+                                    stroke-width="1.5" x="1" y="1" width="22" height="22" rx="6" id="icon-8-path">
+                                </rect>
+                                <path
+                                    d="M9.45 16V7.24H14.49V8.224H10.518V10.936H14.07V11.908H10.518V15.016H14.49V16H9.45Z"
+                                    fill="var(--color-text)" id="icon-8-text"></path>
+                            </svg><span>Provider<wbr/>Info</span></a>
+                        <ul>
+                            <li class="tsd-kind-enum-member tsd-parent-kind-enum"><a
+                                    href="Providers.RangeSlider.NoUiSlider-1.Enum.ProviderInfo.html#Name"
+                                    class="tsd-index-link"><svg class="tsd-kind-icon" width="24" height="24"
+                                        viewBox="0 0 24 24">
+                                        <use href="#icon-1024-path"></use>
+                                        <use href="#icon-1024-text"></use>
+                                    </svg>Name</a></li>
+                            <li class="tsd-kind-enum-member tsd-parent-kind-enum"><a
+                                    href="Providers.RangeSlider.NoUiSlider-1.Enum.ProviderInfo.html#Version"
+                                    class="tsd-index-link"><svg class="tsd-kind-icon" width="24" height="24"
+                                        viewBox="0 0 24 24">
+                                        <use href="#icon-1024-path"></use>
+                                        <use href="#icon-1024-text"></use>
+                                    </svg>Version</a></li>
+                        </ul>
+                    </li>
+                </ul>
+            </nav>
+        </div>
+    </div>
+    <div class="overlay"></div>
+    <script src="../assets/main.js"></script>
+</body>
+
+</html>

--- a/package-lock.json
+++ b/package-lock.json
@@ -27,7 +27,7 @@
 				"gulp-sass": "^5.1.0",
 				"gulp-sourcemaps": "^3.0.0",
 				"gulp-typescript": "^6.0.0-alpha.1",
-				"nouislider": "^15.6.0",
+				"nouislider": "^15.6.1",
 				"postcss": "^8.4.5",
 				"postcss-discard-comments": "^5.0.1",
 				"prettier-eslint": "^12.0.0",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
 		"gulp-sass": "^5.1.0",
 		"gulp-sourcemaps": "^3.0.0",
 		"gulp-typescript": "^6.0.0-alpha.1",
-		"nouislider": "^15.6.0",
+		"nouislider": "^15.6.1",
 		"postcss": "^8.4.5",
 		"postcss-discard-comments": "^5.0.1",
 		"prettier-eslint": "^12.0.0",

--- a/src/scripts/Providers/RangeSlider/NoUISlider/NoUiSliderEnum.ts
+++ b/src/scripts/Providers/RangeSlider/NoUISlider/NoUiSliderEnum.ts
@@ -2,7 +2,7 @@
 namespace Providers.RangeSlider.NoUiSlider.Enum {
 	export enum ProviderInfo {
 		Name = 'noUISlider',
-		Version = '15.6.0',
+		Version = '15.6.1',
 	}
 
 	export enum NoUISliderLabels {

--- a/src/scripts/Providers/RangeSlider/NoUISlider/README.md
+++ b/src/scripts/Providers/RangeSlider/NoUISlider/README.md
@@ -1,3 +1,3 @@
-# noUiSlider · ![nouislider version](https://img.shields.io/badge/version-v15.6.0-informational)
+# noUiSlider · ![nouislider version](https://img.shields.io/badge/version-v15.6.1-informational)
 
 All info about this Provider <a href="https://refreshless.com/nouislider/">here</a>.


### PR DESCRIPTION
This PR is for raising the version of NoUiSlider from v15.6.0 to v15.6.1.

### Checklist
-   [X] tested locally
-   [X] documented the code
-   [X] clean all warnings and errors of eslint
-   [ ] requires changes in OutSystems (if so, provide a module with changes)
-   [ ] requires new sample page in OutSystems (if so, provide a module with changes)
