### PR TITLE
ROU-2773: Improve links, buttons and menu items side by side preview in IDE

### DIFF
--- a/src/scss/02-layout/_menu-app-menu-links.scss
+++ b/src/scss/02-layout/_menu-app-menu-links.scss
@@ -12,6 +12,7 @@
 	& {
 		-servicestudio-align-items: center;
 		-servicestudio-display: flex;
+		-servicestudio-column-gap: var(--space-m);
 	}
 
 	// Service Studio Preview


### PR DESCRIPTION
This PR is for adjust the gap between menu items in preview

### What was happening
- The menu items were to near from each other.

### What was done
- Added a column gap between the items in menu.

### Checklist

-   [x] tested locally
-   [x] documented the code
-   [x] clean all warnings and errors of eslint
-   [ ] requires changes in OutSystems (if so, provide a module with changes)
-   [ ] requires new sample page in OutSystems (if so, provide a module with changes)
