### PR TITLE
ROU-2772: Improve SS preview for Layouts within IFs

### DIFF
--- a/src/scss/02-layout/_layout.scss
+++ b/src/scss/02-layout/_layout.scss
@@ -22,11 +22,6 @@ body,
 	display: flex;
 	min-height: 100vh;
 
-	& .layout {
-		// Service Studio Preview
-		-servicestudio-min-width: calc(100vw - (var(--space-xl) * 2));
-	}
-
 	&.layout {
 		&-top,
 		&-side:not(.layout-native) {


### PR DESCRIPTION
This PR is to improve SS preview for Layouts within IFs.

### What was happening

- In design time when having Layout blocks enclosed on IFs the size was not adapted:
![image](https://user-images.githubusercontent.com/29493222/209338730-5c37681d-61a0-43cd-8949-c1bd1d3d3375.png)


### What was done

- Added new CSS rules for Service Studio in order to improve this.

### Test Steps

1. Go to Service Studio on a module
2. Enclose on an IF a layout on a screen
3. Add another layout inside the layout content and enclose it also on an IF

### Screenshots

- Now it looks like this:
![image](https://user-images.githubusercontent.com/29493222/209338852-8070c0b0-13eb-4efb-ad00-9a71c4098d4f.png)


### Checklist

-   [X] tested locally
-   [X] documented the code
-   [X] clean all warnings and errors of eslint
-   [ ] requires changes in OutSystems (if so, provide a module with changes)
-   [ ] requires new sample page in OutSystems (if so, provide a module with changes)
