### PR TITLE
ROU-4030: Tabs - Vertical tab indicator with wrong size

### DIFF
--- a/src/scripts/OSFramework/Pattern/Tabs/Tabs.ts
+++ b/src/scripts/OSFramework/Pattern/Tabs/Tabs.ts
@@ -297,7 +297,7 @@ namespace OSFramework.Patterns.Tabs {
 						Helper.Dom.Styles.SetStyleAttribute(
 							this._tabsIndicatorElement,
 							Enum.CssProperty.TabsIndicatorScale,
-							newScaleValue
+							Math.floor(newScaleValue)
 						);
 					} else {
 						cancelAnimationFrame(this._requestAnimationFrameOnIndicatorResize);

--- a/src/scripts/OSFramework/Pattern/Tabs/scss/_tabs.scss
+++ b/src/scripts/OSFramework/Pattern/Tabs/scss/_tabs.scss
@@ -59,7 +59,7 @@
 		& > .osui-tabs__header {
 			align-content: start;
 			grid-template-rows: repeat(var(--tabs-header-items), var(--header-item-alignment));
-			overflow-y: auto;
+			overflow-y: hidden;
 			overflow-x: hidden;
 
 			.osui-tabs__header-item {
@@ -67,7 +67,7 @@
 			}
 
 			& > .osui-tabs__header__indicator {
-				min-height: var(--tabs-indicator-size);
+				height: var(--tabs-indicator-size);
 				position: absolute;
 				top: 0;
 				transform: translateY(var(--tabs-indicator-transform)) translateX(0) translateZ(0)


### PR DESCRIPTION
This PR is for fix the indicator size in vertical tabs when inside other tab.

### What was happening
- The height of the indicator size was initially 2px instead of 1px, so the final size of the tab indicator after scale was bigger than expected.
- When the last vertical tab was selected, a scrollbar appeared.

### What was done
- Overwrite the height of the vertical indicator tabs, so it is always 1px.
- Applied Math.floor() to the newScaleValue to avoid the indicator size become bigger than the button height
- For Chrome, the solution above was not enough, so overflow-y was changed for "hidden" instead of "auto".

### Test Steps
1. Add a vertical tab inside a tab
2. Check if the indicator size is the expected.

### Checklist

-   [x] tested locally
-   [x] documented the code
-   [x] clean all warnings and errors of eslint
-   [ ] requires changes in OutSystems (if so, provide a module with changes)
-   [ ] requires new sample page in OutSystems (if so, provide a module with changes)
