### PR TITLE
ROU-4039: RangeSlider/RangeSlider interval - width 100% on vertical slider

### DIFF
--- a/src/scripts/OSFramework/Pattern/RangeSlider/scss/_rangeslider.scss
+++ b/src/scripts/OSFramework/Pattern/RangeSlider/scss/_rangeslider.scss
@@ -14,6 +14,7 @@
 
 	&--is-vertical {
 		height: var(--range-slider-size);
+		width: fit-content;
 	}
 
 	&--has-ticks {


### PR DESCRIPTION
This PR is for fix RangeSlider width when in vertical orientation.

### What was happening
- RangeSlider width was not adjusting to the content.
![image](https://user-images.githubusercontent.com/108938618/209812431-82d6bc2b-f885-4470-8fc3-066cfcf12824.png)


### What was done
- Changed vertical RangeSlider width to fit-content.
![image](https://user-images.githubusercontent.com/108938618/209812714-f5f2f224-2656-4492-adc1-d9490e891970.png)

### Checklist

-   [x] tested locally
-   [x] documented the code
-   [x] clean all warnings and errors of eslint
-   [ ] requires changes in OutSystems (if so, provide a module with changes)
-   [ ] requires new sample page in OutSystems (if so, provide a module with changes)
