### PR TITLE
ROU-4028: Carousel losing the extensibility configs when navigating to the current screen

### DIFF
--- a/src/scripts/OSFramework/Helper/MapOperation.ts
+++ b/src/scripts/OSFramework/Helper/MapOperation.ts
@@ -8,27 +8,30 @@ namespace OSFramework.Helper.MapOperation {
 	 * @return {*}  {string}
 	 */
 	export function FindInMap(
-		pattternName: string,
+		patternName: string,
 		patternId: string,
 		map: Map<string, Interface.IPattern>
 	): Interface.IPattern {
 		let pattern: Interface.IPattern;
 
-		// animatedLabelId is the UniqueId
+		// Search for patternId as the uniqueId
 		if (map.has(patternId)) {
 			pattern = map.get(patternId);
 		} else {
-			//Search for animatedLabelId
+			// Search for patternId as the widgetId.
+
+			// Sometimes we can have more than one pattern with the same widgetID, because of how the Lifecycle of the page works.
+			// In this case, we need to always get the newest one, that is, the latest one in the map.
+
 			for (const p of map.values()) {
 				if (p.equalsToID(patternId)) {
 					pattern = p;
-					break;
 				}
 			}
 		}
 
 		if (pattern === undefined) {
-			throw new Error(`The ${pattternName} with id:'${patternId}' was not found`);
+			throw new Error(`The ${patternName} with id:'${patternId}' was not found`);
 		}
 
 		return pattern;


### PR DESCRIPTION
This PR is for fix issue with pattern losing extensibility configs when navigating to the current page

### What was happening
- When clicking to go to the current page, a new pattern is created before the old one is destroyed, so for a moment we have two patterns with the same widgetId stored in the CarouselAPI's _carouselItemsMap. When SetProviderConfigs runs, it gets the old pattern to apply the extensibility configs instead of the new one, as it gets the first item in the map with the searched widgetId. The old pattern is destroyed right after it, and the new pattern remains without extensibility configs.

### What was done
- Change the FindInMap method to always the the last pattern found with the searched widgetId.

### Test Steps
1. Go to a page with a Carousel with extensibility configs applied on Initialized event.
2. Click to go to the current page
3. Check if the extensibility configs are still applied.

### Checklist

-   [x] tested locally
-   [x] documented the code
-   [x] clean all warnings and errors of eslint
-   [ ] requires changes in OutSystems (if so, provide a module with changes)
-   [ ] requires new sample page in OutSystems (if so, provide a module with changes)
