### PR TITLE
ROU-3966: Update SplideJs library to version v4.1.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
 			"name": "outsystems-ui",
 			"version": "2.14.0",
 			"devDependencies": {
-				"@splidejs/splide": "^4.0.7",
+				"@splidejs/splide": "4.1.3",
 				"@typescript-eslint/eslint-plugin": "^5.45.0",
 				"@typescript-eslint/parser": "^5.45.0",
 				"browser-sync": "^2.27.7",
@@ -722,9 +722,9 @@
 			"dev": true
 		},
 		"node_modules/@splidejs/splide": {
-			"version": "4.0.7",
-			"resolved": "https://registry.npmjs.org/@splidejs/splide/-/splide-4.0.7.tgz",
-			"integrity": "sha512-aJAOGJN2lwjwou3mxQofc3uhe+RXpw9in0WfysFX7AMT/mj7wSqoetfm41s7J8jU6FJ3ZWaLYgSJIpBAQ5wyqw==",
+			"version": "4.1.3",
+			"resolved": "https://registry.npmjs.org/@splidejs/splide/-/splide-4.1.3.tgz",
+			"integrity": "sha512-nmexLBzGy2vLR25uDSnFMk54dFMkSalmIdKY7fNkJZY8MO/x0n8PS9SW6VajiNTTV8Yo1IXsNCBczc2uj7kzBA==",
 			"dev": true
 		},
 		"node_modules/@stylelint/postcss-css-in-js": {
@@ -12160,9 +12160,9 @@
 			"dev": true
 		},
 		"@splidejs/splide": {
-			"version": "4.0.7",
-			"resolved": "https://registry.npmjs.org/@splidejs/splide/-/splide-4.0.7.tgz",
-			"integrity": "sha512-aJAOGJN2lwjwou3mxQofc3uhe+RXpw9in0WfysFX7AMT/mj7wSqoetfm41s7J8jU6FJ3ZWaLYgSJIpBAQ5wyqw==",
+			"version": "4.1.3",
+			"resolved": "https://registry.npmjs.org/@splidejs/splide/-/splide-4.1.3.tgz",
+			"integrity": "sha512-nmexLBzGy2vLR25uDSnFMk54dFMkSalmIdKY7fNkJZY8MO/x0n8PS9SW6VajiNTTV8Yo1IXsNCBczc2uj7kzBA==",
 			"dev": true
 		},
 		"@stylelint/postcss-css-in-js": {

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
 	},
 	"author": "UI Components Team",
 	"devDependencies": {
-		"@splidejs/splide": "^4.0.7",
+		"@splidejs/splide": "4.1.3",
 		"@typescript-eslint/eslint-plugin": "^5.45.0",
 		"@typescript-eslint/parser": "^5.45.0",
 		"browser-sync": "^2.27.7",

--- a/src/scripts/Providers/Carousel/Splide/Enum.ts
+++ b/src/scripts/Providers/Carousel/Splide/Enum.ts
@@ -38,7 +38,7 @@ namespace Providers.Carousel.Splide.Enum {
 	 */
 	export enum ProviderInfo {
 		Name = 'Splide',
-		Version = '4.0',
+		Version = '4.1.3',
 	}
 
 	/**

--- a/src/scripts/Providers/Carousel/Splide/README.md
+++ b/src/scripts/Providers/Carousel/Splide/README.md
@@ -1,3 +1,3 @@
-# <img alt="Splide" src="https://raw.githubusercontent.com/Splidejs/splide/master/images/logo.svg" width="24"> Splide · ![splidejs version](https://img.shields.io/badge/version-v4.0.7-informational)
+# <img alt="Splide" src="https://raw.githubusercontent.com/Splidejs/splide/master/images/logo.svg" width="24"> Splide · ![splidejs version](https://img.shields.io/badge/version-v4.1.3-informational)
 
 All info about this Provider <a href="https://splidejs.com/">here</a>.

--- a/src/scripts/Providers/Carousel/Splide/scss/splide-core.scss
+++ b/src/scripts/Providers/Carousel/Splide/scss/splide-core.scss
@@ -3,7 +3,6 @@
 	position: relative;
 }
 .splide__list {
-	-webkit-backface-visibility: hidden;
 	backface-visibility: hidden;
 	display: -ms-flexbox;
 	display: flex;
@@ -33,6 +32,9 @@
 	margin: 0;
 	pointer-events: auto;
 }
+.splide:not(.is-overflow) .splide__pagination {
+	display: none;
+}
 .splide__progress__bar {
 	width: 0;
 }
@@ -45,7 +47,6 @@
 	visibility: visible;
 }
 .splide__slide {
-	-webkit-backface-visibility: hidden;
 	backface-visibility: hidden;
 	box-sizing: border-box;
 	-ms-flex-negative: 0;
@@ -109,19 +110,13 @@
 	-ms-user-select: none;
 	user-select: none;
 }
-.splide__track--fade > .splide__list {
-	display: block;
-}
 .splide__track--fade > .splide__list > .splide__slide {
-	left: 0;
+	margin: 0 !important;
 	opacity: 0;
-	position: absolute;
-	top: 0;
 	z-index: 0;
 }
 .splide__track--fade > .splide__list > .splide__slide.is-active {
 	opacity: 1;
-	position: relative;
 	z-index: 1;
 }
 .splide--rtl {
@@ -221,7 +216,7 @@
 	height: 3px;
 }
 .splide__slide {
-	-webkit-tap-highlight-color: transparent;
+	-webkit-tap-highlight-color: rgba(0, 0, 0, 0);
 }
 .splide__slide:focus {
 	outline: 0;


### PR DESCRIPTION
This PR is for update SplideJs library to version v4.1.3

### What was done
- Updated the SplideJs to version 4.1.3. 
- Updated splide-core.scss
- Updated all the references to the Splide version

### Checklist

-   [x] tested locally
-   [x] documented the code
-   [x] clean all warnings and errors of eslint
-   [x] requires changes in OutSystems (if so, provide a module with changes)
-   [ ] requires new sample page in OutSystems (if so, provide a module with changes)
