### PR TITLE
ROU-4039: DropdownSearch/Tags issues with prompt and when used with DataGrid

### DIFF
--- a/src/scripts/Providers/Dropdown/VirtualSelect/AbstractVirtualSelectConfig.ts
+++ b/src/scripts/Providers/Dropdown/VirtualSelect/AbstractVirtualSelectConfig.ts
@@ -231,20 +231,8 @@ namespace Providers.Dropdown.VirtualSelect {
 			let validatedValue = undefined;
 
 			switch (key) {
-				case Enum.Properties.NoOptionsText:
-					validatedValue = this.validateString(value as string, undefined);
-					break;
-				case Enum.Properties.NoResultsText:
-					validatedValue = this.validateString(value as string, undefined);
-					break;
 				case Enum.Properties.OptionsList:
 					validatedValue = value as DropDownOption;
-					break;
-				case Enum.Properties.Prompt:
-					validatedValue = this.validateString(value as string, undefined);
-					break;
-				case Enum.Properties.SearchPrompt:
-					validatedValue = this.validateString(value as string, undefined);
 					break;
 				case Enum.Properties.StartingSelection:
 					validatedValue = value as DropDownOption;


### PR DESCRIPTION
This PR is for add the possibility to add white spaces to the text parameters NoOptionsText, NoResultText, Prompt and SearchPrompt.

### What was happening
- The validateString method did not allow a string with only white spaces to be assigned to the virtualSelect options: placeholder, searchPlaceholderText, noOptionsText and noSearchResultsText.

### What was done
- Removed the validateString method for these options.

### Test Steps
1. Add a DropdownSearch to the page.
2. Set the Prompt parameter to " ".
3. Check if the DropdownSearch Prompt does not display any message.
4. Repeat the tests for NoOptionsText, NoResultsText and SearchPrompt parameter
5. Repeat the tests for DropdownTags

### Checklist

-   [x] tested locally
-   [x] documented the code
-   [x] clean all warnings and errors of eslint
-   [x] requires changes in OutSystems (if so, provide a module with changes)
-   [x] requires new sample page in OutSystems (if so, provide a module with changes)
