### PR TITLE
RDUCP 219 - Implement Post Message and Preview styling

### DIFF
--- a/src/scripts/OSFramework/Event/EventEnum.ts
+++ b/src/scripts/OSFramework/Event/EventEnum.ts
@@ -6,5 +6,6 @@ namespace OSFramework.Event {
 		OrientationChange = 'window.onorientationchange',
 		SubmenuOpen = 'submenu.open',
 		WindowResize = 'window.onresize',
+		WindowMessage = 'window.message',
 	}
 }

--- a/src/scripts/OSFramework/Event/EventManager.ts
+++ b/src/scripts/OSFramework/Event/EventManager.ts
@@ -13,6 +13,8 @@ namespace OSFramework.Event {
 					return new Event.WindowResize();
 				case Type.OrientationChange:
 					return new Event.OrientationChange();
+				case Type.WindowMessage:
+					return new Event.WindowMessage();
 				default:
 					throw new Error(`The event ${eventType} is not supported.`);
 			}

--- a/src/scripts/OSFramework/Event/WindowOnMessage.ts
+++ b/src/scripts/OSFramework/Event/WindowOnMessage.ts
@@ -10,13 +10,9 @@ namespace OSFramework.Event {
 	export class WindowMessage extends Event.AbstractEvent<string> {
 		constructor() {
 			super();
-			if (this._windowIsInsideIframe()) {
+			if (window.self !== window.top) {
 				window.addEventListener(GlobalEnum.HTMLEvent.Message, this._windowTrigger.bind(this), true);
 			}
-		}
-
-		private _windowIsInsideIframe(): boolean {
-			return window.self !== window.top;
 		}
 
 		private _windowTrigger(evt: MessageEvent): void {

--- a/src/scripts/OSFramework/Event/WindowOnMessage.ts
+++ b/src/scripts/OSFramework/Event/WindowOnMessage.ts
@@ -1,0 +1,26 @@
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+namespace OSFramework.Event {
+	/**
+	 * Class that represents the Post Message on the Window.
+	 *
+	 * @export
+	 * @class WindowMessage
+	 * @extends {Event.AbstractEvent<string>}
+	 */
+	export class WindowMessage extends Event.AbstractEvent<string> {
+		constructor() {
+			super();
+			if (this._windowIsInsideIframe()) {
+				window.addEventListener(GlobalEnum.HTMLEvent.Message, this._windowTrigger.bind(this), true);
+			}
+		}
+
+		private _windowIsInsideIframe(): boolean {
+			return window.self !== window.top;
+		}
+
+		private _windowTrigger(evt: MessageEvent): void {
+			this.trigger(Event.Type.WindowMessage, evt);
+		}
+	}
+}

--- a/src/scripts/OSFramework/GlobalEnum.ts
+++ b/src/scripts/OSFramework/GlobalEnum.ts
@@ -170,6 +170,7 @@ namespace OSFramework.GlobalEnum {
 		TouchMove = 'touchmove',
 		TouchStart = 'touchstart',
 		TransitionEnd = 'transitionend',
+		Message = 'message',
 	}
 
 	/**

--- a/src/scripts/OSFramework/Helper/Device.ts
+++ b/src/scripts/OSFramework/Helper/Device.ts
@@ -130,8 +130,8 @@ namespace OSFramework.Helper {
 			const cleanedUserAgent = userAgent.replace(' ', '');
 
 			if (cleanedUserAgent === '') {
-				if (sessionStorage.userAgent) {
-					return sessionStorage.userAgent.toLowerCase();
+				if (sessionStorage.previewDevicesUserAgent) {
+					return sessionStorage.previewDevicesUserAgent.toLowerCase();
 				}
 				return window.navigator.userAgent.toLowerCase();
 			} else {
@@ -342,7 +342,10 @@ namespace OSFramework.Helper {
 		public static get IsIphoneWithNotch(): boolean {
 			if (DeviceInfo._isIphoneWithNotch === undefined) {
 				// get the device pixel ratio
-				const ratio = (sessionStorage.pixelRatio ? sessionStorage.pixelRatio : window.devicePixelRatio) || 1;
+				const ratio =
+					(sessionStorage.previewDevicesPixelRatio
+						? sessionStorage.previewDevicesPixelRatio
+						: window.devicePixelRatio) || 1;
 				const currScreen: iphoneDetails = {
 					width: window.visualViewport.width * ratio,
 					height: window.visualViewport.height * ratio,

--- a/src/scripts/OSFramework/Helper/Device.ts
+++ b/src/scripts/OSFramework/Helper/Device.ts
@@ -127,9 +127,16 @@ namespace OSFramework.Helper {
 		 * @memberof DeviceInfo
 		 */
 		private static _getUserAgent(userAgent = ''): string {
-			return userAgent.replace(' ', '') === ''
-				? window.navigator.userAgent.toLowerCase()
-				: userAgent.toLowerCase();
+			const cleanedUserAgent = userAgent.replace(' ', '');
+
+			if (cleanedUserAgent === '') {
+				if (sessionStorage.userAgent) {
+					return sessionStorage.userAgent.toLowerCase();
+				}
+				return window.navigator.userAgent.toLowerCase();
+			} else {
+				return userAgent.toLowerCase();
+			}
 		}
 
 		/**
@@ -335,10 +342,10 @@ namespace OSFramework.Helper {
 		public static get IsIphoneWithNotch(): boolean {
 			if (DeviceInfo._isIphoneWithNotch === undefined) {
 				// get the device pixel ratio
-				const ratio = window.devicePixelRatio || 1;
+				const ratio = (sessionStorage.pixelRatio ? sessionStorage.pixelRatio : window.devicePixelRatio) || 1;
 				const currScreen: iphoneDetails = {
-					width: window.screen.width * ratio,
-					height: window.screen.height * ratio,
+					width: window.visualViewport.width * ratio,
+					height: window.visualViewport.height * ratio,
 					description: '',
 				};
 

--- a/src/scripts/OutSystems/OSUI/Utils/LayoutPrivateOnPostMessage.ts
+++ b/src/scripts/OutSystems/OSUI/Utils/LayoutPrivateOnPostMessage.ts
@@ -70,15 +70,15 @@ namespace OutSystems.OSUI.Utils.LayoutPrivate {
 			} else if (OSFramework.Helper.DeviceInfo.IsTablet) {
 				OnPostMessage._createTabletPreviewStyle();
 			}
-			sessionStorage.setItem('userAgent', evt.data.userAgent);
-			sessionStorage.setItem('pixelRatio', evt.data.pixelRatio);
+			sessionStorage.setItem('previewDevicesUserAgent', evt.data.userAgent);
+			sessionStorage.setItem('previewDevicesPixelRatio', evt.data.pixelRatio);
 			OnPostMessage.Unset();
 			evt.source.postMessage('received', { targetOrigin: evt.origin });
 			SetDeviceClass(false);
 		}
 
 		/**
-		 * Function used to set the orientation event
+		 * Function used to set the message event
 		 */
 		public static Set(): void {
 			if (window.self !== window.top) {
@@ -90,7 +90,7 @@ namespace OutSystems.OSUI.Utils.LayoutPrivate {
 		}
 
 		/**
-		 * Function used to unset the orientation event
+		 * Function used to unset the message event
 		 */
 		public static Unset(): void {
 			OSFramework.Event.GlobalEventManager.Instance.removeHandler(
@@ -100,5 +100,6 @@ namespace OutSystems.OSUI.Utils.LayoutPrivate {
 		}
 	}
 
+	// Invoke the event register
 	OnPostMessage.Set();
 }

--- a/src/scripts/OutSystems/OSUI/Utils/LayoutPrivateOnPostMessage.ts
+++ b/src/scripts/OutSystems/OSUI/Utils/LayoutPrivateOnPostMessage.ts
@@ -1,0 +1,104 @@
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+namespace OutSystems.OSUI.Utils.LayoutPrivate {
+	abstract class OnPostMessage {
+		private static _createPhonePreviewStyle(notchValue: number) {
+			if (!notchValue) {
+				return;
+			}
+
+			const style = document.createElement('style');
+
+			style.textContent = `
+				body * {
+					user-select: none !important
+				}
+	
+				body.is-phone.android.portrait {
+					--status-bar-height: ${notchValue}px;
+				} 
+				
+				body.portrait.is-phone {
+					--os-safe-area-top: ${notchValue}px;
+				} 
+				
+				body.landscape.is-phone {
+					--os-safe-area-right: ${notchValue}px;
+					--os-safe-area-left: ${notchValue}px;
+				}
+	
+				.is-phone .active-screen.screen-container::-webkit-scrollbar, html::-webkit-scrollbar,
+				.is-phone.ios .active-screen.screen-container .content::-webkit-scrollbar, html::-webkit-scrollbar {
+					display: none;
+				}
+			`;
+
+			// Adds the is phone class to apply the correct styling
+			// because platform is replacing phone with tablet when we rotate the phone device
+			document.body.classList.add('is-phone');
+			document.body.setAttribute('data-status-bar-height', `${notchValue}px`);
+			document.head.appendChild(style);
+		}
+
+		private static _createTabletPreviewStyle() {
+			const style = document.createElement('style');
+			style.textContent = `
+				body * {
+					user-select: none !important
+				}
+				
+				.tablet .active-screen.screen-container::-webkit-scrollbar, html::-webkit-scrollbar,
+				.tablet.ios .active-screen.screen-container .content::-webkit-scrollbar, html::-webkit-scrollbar {
+					display: none;
+				}
+			`;
+
+			document.head.appendChild(style);
+		}
+
+		private static _message(evtName, evt) {
+			if (
+				OSFramework.Event.Type.WindowMessage === evtName &&
+				(evt.origin.includes('outsystems.app') || evt.origin.includes('outsystems.dev'))
+			) {
+				OnPostMessage._messageFromPreview(evt);
+			}
+		}
+
+		private static _messageFromPreview(evt): void {
+			if (OSFramework.Helper.DeviceInfo.IsPhone) {
+				OnPostMessage._createPhonePreviewStyle(evt.data.notchValue);
+			} else if (OSFramework.Helper.DeviceInfo.IsTablet) {
+				OnPostMessage._createTabletPreviewStyle();
+			}
+			sessionStorage.setItem('userAgent', evt.data.userAgent);
+			sessionStorage.setItem('pixelRatio', evt.data.pixelRatio);
+			OnPostMessage.Unset();
+			evt.source.postMessage('received', { targetOrigin: evt.origin });
+			SetDeviceClass(false);
+		}
+
+		/**
+		 * Function used to set the orientation event
+		 */
+		public static Set(): void {
+			if (window.self !== window.top) {
+				OSFramework.Event.GlobalEventManager.Instance.addHandler(
+					OSFramework.Event.Type.WindowMessage,
+					OnPostMessage._message
+				);
+			}
+		}
+
+		/**
+		 * Function used to unset the orientation event
+		 */
+		public static Unset(): void {
+			OSFramework.Event.GlobalEventManager.Instance.removeHandler(
+				OSFramework.Event.Type.WindowMessage,
+				OnPostMessage._message
+			);
+		}
+	}
+
+	OnPostMessage.Set();
+}


### PR DESCRIPTION
This PR is for implementing the PostMessage Capability on OutsystemsUI to handle the ODC preview application use case.

### What was happening

- N/A

### What was done

- Implemented the PostMessage listener to the window;
- Handle the message that comes from the ODC preview to add the styling for the preview devices;

### Test Steps

1. Open the app preview;
2. Check if the default device is presenting the content correctly with the notch space;
3. Change the device type;
4. Check that the previewed app notch space is being shown correctly;

### Screenshots

(prefer animated gif)

### Checklist

-   [x] tested locally
-   [x] documented the code
-   [x] clean all warnings and errors of eslint
-   [ ] requires changes in OutSystems (if so, provide a module with changes)
-   [ ] requires new sample page in OutSystems (if so, provide a module with changes)
