### PR TITLE
ROU-4073 - Fix issue on android when changing screen

### DIFF
--- a/src/scripts/OSFramework/OSUI/Pattern/Tabs/Tabs.ts
+++ b/src/scripts/OSFramework/OSUI/Pattern/Tabs/Tabs.ts
@@ -905,7 +905,7 @@ namespace OSFramework.OSUI.Patterns.Tabs {
 			// If there're more than one content item,
 			// then do scrollTo and change active content item
 			if (this._hasSingleContent === false) {
-				Helper.AsyncInvocation(this._changeActiveContentItem.bind(this), newTabIndex, triggeredByObserver);
+				this._changeActiveContentItem(newTabIndex, triggeredByObserver);
 			}
 
 			Helper.AsyncInvocation(this._handleTabIndicator.bind(this));


### PR DESCRIPTION
This PR is for fixing an issue that was causing the Tabs to trigger layout flickering when setting the first active content on Native Apps, as the code was async and getting too long to finish.

### Checklist

-   [x] tested locally
-   [x] documented the code
-   [x] clean all warnings and errors of eslint
-   [x] requires changes in OutSystems (if so, provide a module with changes)
-   [ ] requires new sample page in OutSystems (if so, provide a module with changes)
