### PR TITLE
ROU-4098: fix DatePicker disabled inputs

### DIFF
--- a/src/scripts/Providers/OSUI/Datepicker/Flatpickr/AbstractFlatpickr.ts
+++ b/src/scripts/Providers/OSUI/Datepicker/Flatpickr/AbstractFlatpickr.ts
@@ -40,6 +40,14 @@ namespace Providers.OSUI.Datepicker.Flatpickr {
 					OSFramework.OSUI.GlobalEnum.HTMLAttributes.DataInput,
 					''
 				);
+
+				// If the provider cloned a disabled platform input, remove the disable attribute form the provider input
+				if (this._flatpickrInputElem.disabled) {
+					OSFramework.OSUI.Helper.Dom.Attribute.Remove(
+						this._flatpickrInputElem,
+						OSFramework.OSUI.GlobalEnum.HTMLAttributes.Disabled
+					);
+				}
 			}
 		}
 


### PR DESCRIPTION
This PR is to fix toggling the disabled attribute on the DatePicker platform input.

### Checklist

-   [x] tested locally
-   [x] documented the code
-   [x] clean all warnings and errors of eslint
-   [x] requires changes in OutSystems (if so, provide a module with changes)
-   [ ] requires new sample page in OutSystems (if so, provide a module with changes)
