### PR TITLE
ROU-4036: fix tabs inside old tabs

### DIFF
--- a/src/scripts/OSFramework/OSUI/Pattern/Tabs/Tabs.ts
+++ b/src/scripts/OSFramework/OSUI/Pattern/Tabs/Tabs.ts
@@ -308,7 +308,7 @@ namespace OSFramework.OSUI.Patterns.Tabs {
 
 				// If at this moment the active item has no size (NaN), set an observer to run this method when its size is changed
 				// This happens, as an example, when there're tabs inside tabs, and inner one has no size when it's built, due to being on a non-active tab
-				if (isNaN(newScaleValue)) {
+				if (isNaN(newScaleValue) || newScaleValue === 0) {
 					const resizeObserver = new ResizeObserver((entries) => {
 						for (const entry of entries) {
 							if (entry.contentBoxSize) {

--- a/src/scripts/OSFramework/OSUI/Pattern/Tabs/scss/_tabs.scss
+++ b/src/scripts/OSFramework/OSUI/Pattern/Tabs/scss/_tabs.scss
@@ -59,8 +59,7 @@
 		& > .osui-tabs__header {
 			align-content: start;
 			grid-template-rows: repeat(var(--tabs-header-items), var(--header-item-alignment));
-			overflow-y: hidden;
-			overflow-x: hidden;
+			overflow: hidden;
 
 			.osui-tabs__header-item {
 				flex: none;


### PR DESCRIPTION
This PR is for fixing the Tabs indicator, when sued inside the DEPRECATED_Tabs and the orientation vertical.

### Checklist

-   [x] tested locally
-   [x] documented the code
-   [x] clean all warnings and errors of eslint
-   [ ] requires changes in OutSystems (if so, provide a module with changes)
-   [ ] requires new sample page in OutSystems (if so, provide a module with changes)
