### PR TITLE
ROU-4116: fix dropdownServerSide in firefox

### DIFF
--- a/src/scripts/OSFramework/OSUI/Pattern/Dropdown/ServerSide/scss/_dropdown-serverside.scss
+++ b/src/scripts/OSFramework/OSUI/Pattern/Dropdown/ServerSide/scss/_dropdown-serverside.scss
@@ -334,6 +334,14 @@ $balloonMobileTopMargin: 5vh;
 	}
 }
 
+// Fallback for fierfox that don't support yet :has(), but it's already in development
+// https://bugzilla.mozilla.org/show_bug.cgi?id=418039
+.firefox {
+	.osui-dropdown-serverside__balloon-wrapper.osui-dropdown-serverside--is-opened {
+		z-index: 301;
+	}
+}
+
 // Inside Popup
 body:has(.popup-dialog):has(.osui-dropdown-serverside--is-opened) {
 	.osui-dropdown-serverside__balloon-wrapper.osui-dropdown-serverside--is-opened {


### PR DESCRIPTION
This PR is for fixing DropdownServerSide on Firefox, as this browser doesn't support :has() yet.

### Checklist

-   [x] tested locally
-   [x] documented the code
-   [x] clean all warnings and errors of eslint
-   [x] requires changes in OutSystems (if so, provide a module with changes)
-   [ ] requires new sample page in OutSystems (if so, provide a module with changes)
