### PR TITLE
RDUCP-415: Update the UserAgent information

### DIFF
--- a/src/scripts/OSFramework/Helper/Device.ts
+++ b/src/scripts/OSFramework/Helper/Device.ts
@@ -589,5 +589,15 @@ namespace OSFramework.Helper {
 
 			return localOs;
 		}
+
+		/**
+		 * Refresh the operating system information
+		 *
+		 * @static
+		 * @memberof DeviceInfo
+		 */
+		public static RefreshOperatingSystem(): void {
+			DeviceInfo._operatingSystem = DeviceInfo.GetOperatingSystem(DeviceInfo._getUserAgent());
+		}
 	}
 }

--- a/src/scripts/OutSystems/OSUI/Utils/LayoutPrivateOnPostMessage.ts
+++ b/src/scripts/OutSystems/OSUI/Utils/LayoutPrivateOnPostMessage.ts
@@ -74,6 +74,7 @@ namespace OutSystems.OSUI.Utils.LayoutPrivate {
 			sessionStorage.setItem('previewDevicesPixelRatio', evt.data.pixelRatio);
 			OnPostMessage.Unset();
 			evt.source.postMessage('received', { targetOrigin: evt.origin });
+			OSFramework.Helper.DeviceInfo.RefreshOperatingSystem();
 			SetDeviceClass(false);
 		}
 


### PR DESCRIPTION
This PR is for fixing an issue when the NDS preview updates the user agent the information wasn't being correctly updated.

[Sample page](url)

### What was happening

- In the first render of the NDS preview the ios class wasn't applied.

### What was done

- Add a method to update the user-agent information in the device when it is updated by a post message.

### Test Steps

1. Open a mobile app in the NDS preview;
2. The notch style must be applied.

### Screenshots
Error
![NotchStyleNotApplied](https://user-images.githubusercontent.com/61831687/217230545-ec41629f-7007-4898-bca8-6b3955a40549.gif)

Fix
![NotchStyleApplied](https://user-images.githubusercontent.com/61831687/217230799-d647cbdc-553c-4594-b06d-d606658adfe6.gif)

### Checklist

-   [X] tested locally
-   [X] documented the code
-   [X] clean all warnings and errors of eslint
-   [ ] requires changes in OutSystems (if so, provide a module with changes)
-   [ ] requires new sample page in OutSystems (if so, provide a module with changes)
