### PR TITLE
ROU-4057: fix ProgressCircle auto size 

### DIFF
--- a/src/scripts/OSFramework/OSUI/Pattern/Progress/Circle/Enum.ts
+++ b/src/scripts/OSFramework/OSUI/Pattern/Progress/Circle/Enum.ts
@@ -20,6 +20,6 @@ namespace OSFramework.OSUI.Patterns.Progress.Circle.Enum {
 	}
 
 	export enum DefaultValues {
-		PercentualSize = '100%',
+		DefaultSize = 'auto',
 	}
 }

--- a/src/scripts/OSFramework/OSUI/Pattern/Progress/Circle/scss/_progresscircle.scss
+++ b/src/scripts/OSFramework/OSUI/Pattern/Progress/Circle/scss/_progresscircle.scss
@@ -4,7 +4,7 @@
 /// Patterns - Numbers - ProgressCircle
 
 [data-block*='ProgressCircle'] {
-	display: block;
+	display: inline-block;
 }
 
 ///


### PR DESCRIPTION
This PR is for fixing the ProgressCircle auto size mechanism and overall display properties.

- Now the pattern will look to the lower size (height or width) of the block parent (before was looking at the higher). This would cause the pattern to overflow the parent in some situations.
- Changed block display to inline-block, to correctly align with the expected size of the child and allow other elements to be added at the progressCircle side.
- Improved mechanism to only add observer when needed.
- Improved use-case where the progressCircle is ready at the same time of the parent, making sure that the initial animation is only triggered after the resize is finished.


### Checklist

-   [x] tested locally
-   [x] documented the code
-   [x] clean all warnings and errors of eslint
-   [x] requires changes in OutSystems (if so, provide a module with changes)
-   [ ] requires new sample page in OutSystems (if so, provide a module with changes)
