### PR TITLE
ROU-4048: Sidebar issue when selecting text and with overlay it closes the sidebar

### DIFF
--- a/src/scripts/OSFramework/OSUI/Event/BodyOnMouseDown.ts
+++ b/src/scripts/OSFramework/OSUI/Event/BodyOnMouseDown.ts
@@ -1,0 +1,20 @@
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+namespace OSFramework.OSUI.Event {
+	/**
+	 * Class that represents the mousedown on the body event.
+	 *
+	 * @export
+	 * @class BodyOnMouseDown
+	 * @extends {Event.AbstractEvent<string>}
+	 */
+	export class BodyOnMouseDown extends Event.AbstractEvent<string> {
+		constructor() {
+			super();
+			document.body.addEventListener(GlobalEnum.HTMLEvent.MouseDown, this._bodyTrigger.bind(this));
+		}
+
+		private _bodyTrigger(evt: PointerEvent): void {
+			this.trigger(GlobalEnum.HTMLEvent.MouseDown, evt);
+		}
+	}
+}

--- a/src/scripts/OSFramework/OSUI/Event/EventEnum.ts
+++ b/src/scripts/OSFramework/OSUI/Event/EventEnum.ts
@@ -3,6 +3,7 @@ namespace OSFramework.OSUI.Event {
 	export enum Type {
 		BodyOnClick = 'body.onclick',
 		BodyOnScroll = 'body.onscroll',
+		BodyOnMouseDown = 'body.mousedown',
 		OrientationChange = 'window.onorientationchange',
 		WindowResize = 'window.onresize',
 	}

--- a/src/scripts/OSFramework/OSUI/Event/EventManager.ts
+++ b/src/scripts/OSFramework/OSUI/Event/EventManager.ts
@@ -7,6 +7,8 @@ namespace OSFramework.OSUI.Event {
 					return new Event.BodyOnClick();
 				case Type.BodyOnScroll:
 					return new Event.BodyOnScroll();
+				case Type.BodyOnMouseDown:
+					return new Event.BodyOnMouseDown();
 				case Type.WindowResize:
 					return new Event.WindowResize();
 				case Type.OrientationChange:

--- a/src/scripts/OSFramework/OSUI/GlobalEnum.ts
+++ b/src/scripts/OSFramework/OSUI/GlobalEnum.ts
@@ -168,6 +168,7 @@ namespace OSFramework.OSUI.GlobalEnum {
 		Click = 'click',
 		Focus = 'focus',
 		keyDown = 'keydown',
+		MouseDown = 'mousedown',
 		MouseEnter = 'mouseenter',
 		MouseLeave = 'mouseleave',
 		MouseUp = 'mouseup',

--- a/src/scripts/OSFramework/OSUI/Pattern/Sidebar/Sidebar.ts
+++ b/src/scripts/OSFramework/OSUI/Pattern/Sidebar/Sidebar.ts
@@ -137,7 +137,6 @@ namespace OSFramework.OSUI.Patterns.Sidebar {
 			if (this.isBuilt) {
 				//let's only change the property and trigger the OS event IF the pattern is already built.
 				this._isOpen = true;
-				this._clickOutsideToClose = false;
 				this._triggerOnToggleEvent();
 
 				if (this.configs.HasOverlay) {
@@ -172,6 +171,7 @@ namespace OSFramework.OSUI.Patterns.Sidebar {
 			const targetElem = e.target as HTMLElement;
 			this._clickOutsideToClose = true;
 			if (targetElem.closest('.osui-sidebar__header') || targetElem.closest('.osui-sidebar__content')) {
+				// If the click was inside the side bar, then change the flag to false.
 				this._clickOutsideToClose = false;
 			}
 		}

--- a/src/scripts/OSFramework/OSUI/Pattern/Sidebar/Sidebar.ts
+++ b/src/scripts/OSFramework/OSUI/Pattern/Sidebar/Sidebar.ts
@@ -11,10 +11,14 @@ namespace OSFramework.OSUI.Patterns.Sidebar {
 	export class Sidebar extends AbstractPattern<SidebarConfig> implements ISidebar, Interface.IDragEvent {
 		// Hold the animateOnDrag intance, that helps transition the sidebar on drag
 		private _animateOnDragInstance: Behaviors.AnimateOnDrag;
+		// Store if the click was outside the sidebar
+		private _clickOutsideToClose: boolean;
 		// Store the Sidebar direction
 		private _currentDirectionCssClass: string;
 		// Store the click event with bind(this)
 		private _eventOverlayClick: GlobalCallbacks.Generic;
+		// Store the mousedown event with bind(this)
+		private _eventOverlayMouseDown: GlobalCallbacks.Generic;
 		// Store the keypress event with bind(this)
 		private _eventSidebarKeypress: GlobalCallbacks.Generic;
 		// Store focus trap instance
@@ -55,6 +59,10 @@ namespace OSFramework.OSUI.Patterns.Sidebar {
 				Helper.A11Y.SetElementsTabIndex(this._isOpen, this._focusTrapInstance.focusableElements);
 
 				if (this.configs.HasOverlay) {
+					Event.GlobalEventManager.Instance.removeHandler(
+						Event.Type.BodyOnMouseDown,
+						this._eventOverlayMouseDown
+					);
 					Event.GlobalEventManager.Instance.removeHandler(Event.Type.BodyOnClick, this._eventOverlayClick);
 				}
 			}
@@ -129,9 +137,14 @@ namespace OSFramework.OSUI.Patterns.Sidebar {
 			if (this.isBuilt) {
 				//let's only change the property and trigger the OS event IF the pattern is already built.
 				this._isOpen = true;
+				this._clickOutsideToClose = false;
 				this._triggerOnToggleEvent();
 
 				if (this.configs.HasOverlay) {
+					Event.GlobalEventManager.Instance.addHandler(
+						Event.Type.BodyOnMouseDown,
+						this._eventOverlayMouseDown
+					);
 					Event.GlobalEventManager.Instance.addHandler(Event.Type.BodyOnClick, this._eventOverlayClick);
 				}
 			}
@@ -145,18 +158,28 @@ namespace OSFramework.OSUI.Patterns.Sidebar {
 
 		// Overlay onClick event to close the Sidebar
 		private _overlayClickCallback(_args: string, e: MouseEvent): void {
-			if (this.selfElement === e.target) {
-				if (this._isOpen) {
-					this.close();
-				}
+			// If the sidebar is opened and the mouse down event occured outside the sidebar, close it.
+			if (this._isOpen && this._clickOutsideToClose) {
+				this.close();
 			}
 
 			e.stopPropagation();
 		}
 
+		// Method to check if the mouse down event happened outside the sidebar
+		// This is required to cover the cases when selecting text and moving the cursor to the sidebar's overlay.
+		private _overlayMouseDownCallback(_args: string, e: MouseEvent): void {
+			const targetElem = e.target as HTMLElement;
+			this._clickOutsideToClose = true;
+			if (targetElem.closest('.osui-sidebar__header') || targetElem.closest('.osui-sidebar__content')) {
+				this._clickOutsideToClose = false;
+			}
+		}
+
 		// Method to remove the event listeners
 		private _removeEvents(): void {
 			this.selfElement.removeEventListener(GlobalEnum.HTMLEvent.keyDown, this._eventSidebarKeypress);
+			Event.GlobalEventManager.Instance.removeHandler(Event.Type.BodyOnMouseDown, this._eventOverlayMouseDown);
 			Event.GlobalEventManager.Instance.removeHandler(Event.Type.BodyOnClick, this._eventOverlayClick);
 		}
 
@@ -177,11 +200,19 @@ namespace OSFramework.OSUI.Patterns.Sidebar {
 			if (this.configs.HasOverlay && alreadyHasOverlayClass === false) {
 				Helper.Dom.Styles.AddClass(this.selfElement, Enum.CssClass.HasOverlay);
 				if (this._isOpen) {
+					Event.GlobalEventManager.Instance.removeHandler(
+						Event.Type.BodyOnMouseDown,
+						this._eventOverlayMouseDown
+					);
 					Event.GlobalEventManager.Instance.addHandler(Event.Type.BodyOnClick, this._eventOverlayClick);
 				}
 			} else if (this.isBuilt) {
 				Helper.Dom.Styles.RemoveClass(this.selfElement, Enum.CssClass.HasOverlay);
 				if (this._isOpen) {
+					Event.GlobalEventManager.Instance.removeHandler(
+						Event.Type.BodyOnMouseDown,
+						this._eventOverlayMouseDown
+					);
 					Event.GlobalEventManager.Instance.removeHandler(Event.Type.BodyOnClick, this._eventOverlayClick);
 				}
 			}
@@ -266,6 +297,7 @@ namespace OSFramework.OSUI.Patterns.Sidebar {
 		protected setCallbacks(): void {
 			this._eventSidebarKeypress = this._sidebarKeypressCallback.bind(this);
 			this._eventOverlayClick = this._overlayClickCallback.bind(this);
+			this._eventOverlayMouseDown = this._overlayMouseDownCallback.bind(this);
 		}
 
 		/**
@@ -291,6 +323,7 @@ namespace OSFramework.OSUI.Patterns.Sidebar {
 
 			this._eventSidebarKeypress = undefined;
 			this._eventOverlayClick = undefined;
+			this._eventOverlayMouseDown = undefined;
 		}
 
 		/**


### PR DESCRIPTION
This PR is fix Sidebar closing when selecting text and moving the cursor to the overlay.

### What was happening
- The Sidebar closed when selecting text and moving the cursor to the overlay.

### What was done
- Added the mousedown event to the body to check if the mouse click started inside the sidebar or not.
- If it started inside the sidebar, it should remain open.

### Test Steps
1. Go to a page with a sidebar.
2. Start selecting the text inside the sidebar and move the cursor to the sidebar overlay.
3. The Sidebar should not close.

### Checklist
-   [x] tested locally
-   [x] documented the code
-   [x] clean all warnings and errors of eslint
-   [ ] requires changes in OutSystems (if so, provide a module with changes)
-   [ ] requires new sample page in OutSystems (if so, provide a module with changes)
