### PR TITLE
ROU-4119: fix bar border-radius with high heights values

### DIFF
--- a/src/scripts/OSFramework/OSUI/Pattern/Progress/Bar/scss/_progressbar.scss
+++ b/src/scripts/OSFramework/OSUI/Pattern/Progress/Bar/scss/_progressbar.scss
@@ -50,6 +50,7 @@
 
 			&:after,
 			&:before {
+				border-radius: calc(var(--shape) / 2);
 				content: '';
 				height: 100%;
 				left: 0;

--- a/src/scripts/OSFramework/OSUI/Pattern/Progress/Bar/scss/_progressbar.scss
+++ b/src/scripts/OSFramework/OSUI/Pattern/Progress/Bar/scss/_progressbar.scss
@@ -37,8 +37,10 @@
 		}
 
 		&__value {
+			border-radius: calc(var(--shape) / 2);
 			height: var(--thickness);
 			left: 0;
+			overflow: hidden;
 			position: absolute;
 			right: 0;
 
@@ -48,7 +50,6 @@
 
 			&:after,
 			&:before {
-				border-radius: calc(var(--shape) / 2);
 				content: '';
 				height: 100%;
 				left: 0;

--- a/src/scripts/OSFramework/OSUI/Pattern/Progress/Bar/scss/_progressbar.scss
+++ b/src/scripts/OSFramework/OSUI/Pattern/Progress/Bar/scss/_progressbar.scss
@@ -48,7 +48,7 @@
 
 			&:after,
 			&:before {
-				border-radius: var(--shape);
+				border-radius: calc(var(--shape) / 2);
 				content: '';
 				height: 100%;
 				left: 0;


### PR DESCRIPTION
This PR is for fixing progressBar progress radius when the Height value is considerable high.

### Checklist

-   [x] tested locally
-   [x] documented the code
-   [x] clean all warnings and errors of eslint
-   [x] requires changes in OutSystems (if so, provide a module with changes)
-   [ ] requires new sample page in OutSystems (if so, provide a module with changes)
