### PR TITLE
ROU-3862: Extensibility - Missing extensibility features for VirtualSelect

### DIFF
--- a/src/scripts/OutSystems/OSUI/Utils/NormalizeProviderConfigs.ts
+++ b/src/scripts/OutSystems/OSUI/Utils/NormalizeProviderConfigs.ts
@@ -15,7 +15,7 @@ namespace OutSystems.OSUI.Utils {
 			let keyValue = providerConfigs[keyName];
 
 			if (typeof keyValue !== 'string') {
-				break;
+				continue;
 			}
 
 			keyValue = keyValue.toLowerCase().trim();

--- a/src/scripts/Providers/OSUI/Dropdown/VirtualSelect/AbstractVirtualSelectConfig.ts
+++ b/src/scripts/Providers/OSUI/Dropdown/VirtualSelect/AbstractVirtualSelectConfig.ts
@@ -29,7 +29,7 @@ namespace Providers.OSUI.Dropdown.VirtualSelect {
 			let hasImage = Enum.FigureType.None;
 
 			// Check if image_url_or_class filed has info
-			if (!!option.image_url_or_class) {
+			if (!!option && !!option.image_url_or_class) {
 				// The given info doesn't have spaces on it, check if it's a valid URL
 				hasImage = OSFramework.OSUI.Helper.URL.IsImage(option.image_url_or_class)
 					? Enum.FigureType.Image


### PR DESCRIPTION
This PR is for implement the missing extensibility configs: allowNewOption, hideClearButton, selectAllOnlyVisible, disabledOptions, minValues


### What was happening
- The for loop in NormalizeProviderConfigs was breaking when an object attribute was not a string.
- Since we are now allowing a new option to be added to the dropdown in runtime, the _checkForFigType() can receive an undefined value.

### What was done
- Changed the break to continue when the attribute object is not a string in NormalizeProviderConfigs.
- Added a new condition to handle the case os an undefined value in _checkForFigType().

# Tests
1. Add SetVirtualSelectConfigs to the DropdownSearch and DropdownTags Initialized event 
2. Set the desired configs
3. Check if the Dropdowns are working as expected.

### Checklist

-   [x] tested locally
-   [x] documented the code
-   [x] clean all warnings and errors of eslint
-   [x] requires changes in OutSystems (if so, provide a module with changes)
-   [ ] requires new sample page in OutSystems (if so, provide a module with changes)
