### PR TITLE
ROU-4048-2: Fix sidebar not closing when clicking on overlay

### DIFF
--- a/dist/OutSystemsUI.css
+++ b/dist/OutSystemsUI.css
@@ -1253,7 +1253,7 @@ body,
 .desktop .layout.layout-native.layout-side.aside-expandable .app-menu-content{
   padding-top:calc(var(--header-size) + var(--header-size-content) + var(--os-safe-area-top));
 }
-.desktop .layout-side.layout-native.aside-expandable.hide-header-on-scroll:not(.header-is--visible) .app-menu-content{
+.desktop .layout.layout-native.layout-side.aside-expandable.hide-header-on-scroll:not(.header-is--visible) .app-menu-content{
   padding-top:var(--header-size-content);
 }
 .desktop .layout-native.aside-visible .app-menu-content, .desktop .layout-native.aside-expandable .app-menu-content{
@@ -11897,8 +11897,10 @@ html[data-uieditorversion^="1"] .wizard-wrapper-item{
           transition-duration:0.35s;
 }
 .osui-progress-bar__value{
+  border-radius:calc(var(--shape) / 2);
   height:var(--thickness);
   left:0;
+  overflow:hidden;
   position:absolute;
   right:0;
 }
@@ -11906,7 +11908,7 @@ html[data-uieditorversion^="1"] .wizard-wrapper-item{
   -servicestudio-height:var(--thickness, 8px);
 }
 .osui-progress-bar__value:after, .osui-progress-bar__value:before{
-  border-radius:var(--shape);
+  border-radius:calc(var(--shape) / 2);
   content:"";
   height:100%;
   left:0;
@@ -11952,7 +11954,7 @@ html[data-uieditorversion^="1"] .wizard-wrapper-item{
 }
 /*! 6.5.4.2 Progress Circle */
 [data-block*=ProgressCircle]{
-  display:block;
+  display:inline-block;
 }
 .osui-progress-circle{
   -webkit-box-align:center;

--- a/dist/OutSystemsUI.d.ts
+++ b/dist/OutSystemsUI.d.ts
@@ -283,6 +283,7 @@ declare namespace OSFramework.OSUI.GlobalEnum {
         Click = "click",
         Focus = "focus",
         keyDown = "keydown",
+        MouseDown = "mousedown",
         MouseEnter = "mouseenter",
         MouseLeave = "mouseleave",
         MouseUp = "mouseup",
@@ -549,6 +550,12 @@ declare namespace OSFramework.OSUI.Event {
     }
 }
 declare namespace OSFramework.OSUI.Event {
+    class BodyOnMouseDown extends Event.AbstractEvent<string> {
+        constructor();
+        private _bodyTrigger;
+    }
+}
+declare namespace OSFramework.OSUI.Event {
     class BodyOnScroll extends Event.AbstractEvent<string> {
         constructor();
         private _bodyTrigger;
@@ -558,6 +565,7 @@ declare namespace OSFramework.OSUI.Event {
     enum Type {
         BodyOnClick = "body.onclick",
         BodyOnScroll = "body.onscroll",
+        BodyOnMouseDown = "body.mousedown",
         OrientationChange = "window.onorientationchange",
         WindowResize = "window.onresize"
     }
@@ -2250,13 +2258,15 @@ declare namespace OSFramework.OSUI.Patterns.Progress.Circle.Enum {
         StrokeDashoffset = "--stroke-dashoffset"
     }
     enum DefaultValues {
-        PercentualSize = "100%"
+        DefaultSize = "auto"
     }
 }
 declare namespace OSFramework.OSUI.Patterns.Progress.Circle {
     class Circle extends Progress.AbstractProgress<ProgressCircleConfig> {
+        private _blockParent;
         private _circleCircumference;
         private _circleSize;
+        private _needsResizeObserver;
         private _resizeObserver;
         private _strokeDasharray;
         private _strokeDashoffset;
@@ -2264,6 +2274,7 @@ declare namespace OSFramework.OSUI.Patterns.Progress.Circle {
         private _addResizeOberser;
         private _checkResizeObserver;
         private _progressToOffset;
+        private _removeResizeOberver;
         private _setCssVariables;
         private _updateCircleProps;
         private _updateProgressValue;
@@ -2607,8 +2618,10 @@ declare namespace OSFramework.OSUI.Patterns.Sidebar {
 declare namespace OSFramework.OSUI.Patterns.Sidebar {
     class Sidebar extends AbstractPattern<SidebarConfig> implements ISidebar, Interface.IDragEvent {
         private _animateOnDragInstance;
+        private _clickOutsideToClose;
         private _currentDirectionCssClass;
         private _eventOverlayClick;
+        private _eventOverlayMouseDown;
         private _eventSidebarKeypress;
         private _focusTrapInstance;
         private _gestureEventInstance;
@@ -2625,6 +2638,7 @@ declare namespace OSFramework.OSUI.Patterns.Sidebar {
         private _onGestureStart;
         private _openSidebar;
         private _overlayClickCallback;
+        private _overlayMouseDownCallback;
         private _removeEvents;
         private _setDirection;
         private _setHasOverlay;

--- a/src/scripts/OSFramework/OSUI/Pattern/Sidebar/Sidebar.ts
+++ b/src/scripts/OSFramework/OSUI/Pattern/Sidebar/Sidebar.ts
@@ -200,7 +200,7 @@ namespace OSFramework.OSUI.Patterns.Sidebar {
 			if (this.configs.HasOverlay && alreadyHasOverlayClass === false) {
 				Helper.Dom.Styles.AddClass(this.selfElement, Enum.CssClass.HasOverlay);
 				if (this._isOpen) {
-					Event.GlobalEventManager.Instance.removeHandler(
+					Event.GlobalEventManager.Instance.addHandler(
 						Event.Type.BodyOnMouseDown,
 						this._eventOverlayMouseDown
 					);


### PR DESCRIPTION
This PR is for fix sidebar not closing by clicking on overlay when it starts opened. 

### What was happening
- The MouseDown event handler was being removed instead of added when the sidebar starts open.

### Test Steps
1. Go to a page with a sidebar with IsOpen and HasOverlay parameter set to true.
2. Check if it is possible to close the Sidebar by clicking on the overlay.

### Checklist

-   [x] tested locally
-   [x] documented the code
-   [x] clean all warnings and errors of eslint
-   [ ] requires changes in OutSystems (if so, provide a module with changes)
-   [ ] requires new sample page in OutSystems (if so, provide a module with changes)
