### PR TITLE
ROU-4121: fix BottomSheet drag when outside bounds

### DIFF
--- a/dist/OutSystemsUI.js
+++ b/dist/OutSystemsUI.js
@@ -586,6 +586,7 @@ var OSFramework;
                     this._dragParams.IsMoving = false;
                     OSUI.Helper.Dom.Styles.RemoveClass(this._targetElement, OSUI.Constants.NoTransition);
                     if ((offsetX === 0 && offsetY === 0) || this._dragParams.InvalidDrag) {
+                        this._targetElement.style.transform = '';
                         return;
                     }
                     const checkSwipeSpeed = (this._dragParams.VerticalDrag ? Math.abs(offsetY) : Math.abs(offsetX)) / timeTaken >
@@ -595,17 +596,13 @@ var OSFramework;
                     const swipedHalfWidth = axisToValidate < sizeThreshold;
                     this._dragParams.IsReadyToTriggerCallback = swipedHalfWidth || checkSwipeSpeed;
                     if (this._dragParams.IsReadyToTriggerCallback) {
-                        this._targetElement.style.transform = '';
                         callback();
                     }
                     else if ((springProperties === null || springProperties === void 0 ? void 0 : springProperties.addSpringAnimation) && this._dragParams.IsOpen) {
                         this._dragParams.SpringAnimation = SpringAnimation.CreateSpringAnimation(this._targetElement, offsetX, offsetY, this._dragParams.VerticalDrag ? OSUI.GlobalEnum.Orientation.Vertical : OSUI.GlobalEnum.Orientation.Horizontal, springProperties.springAnimationProperties);
                         this._dragParams.SpringAnimation.play();
-                        this._targetElement.style.transform = '';
                     }
-                    else {
-                        this._targetElement.style.transform = '';
-                    }
+                    this._targetElement.style.transform = '';
                 }
                 onDragMove(offsetX, offsetY, currentX, currentY, event) {
                     let _dragDirection;

--- a/src/scripts/OSFramework/OSUI/Behaviors/AnimateOnDrag.ts
+++ b/src/scripts/OSFramework/OSUI/Behaviors/AnimateOnDrag.ts
@@ -133,6 +133,8 @@ namespace OSFramework.OSUI.Behaviors {
 
 			// Check if just clicked or swiped in invalid direction
 			if ((offsetX === 0 && offsetY === 0) || this._dragParams.InvalidDrag) {
+				this._targetElement.style.transform = '';
+
 				return;
 			}
 
@@ -151,7 +153,6 @@ namespace OSFramework.OSUI.Behaviors {
 			this._dragParams.IsReadyToTriggerCallback = swipedHalfWidth || checkSwipeSpeed;
 
 			if (this._dragParams.IsReadyToTriggerCallback) {
-				this._targetElement.style.transform = '';
 				callback();
 			} else if (springProperties?.addSpringAnimation && this._dragParams.IsOpen) {
 				// Create the animation object
@@ -165,10 +166,9 @@ namespace OSFramework.OSUI.Behaviors {
 
 				// Play the animation
 				this._dragParams.SpringAnimation.play();
-				this._targetElement.style.transform = '';
-			} else {
-				this._targetElement.style.transform = '';
 			}
+
+			this._targetElement.style.transform = '';
 		}
 
 		/**


### PR DESCRIPTION
This PR is for fixing the BottomSheet drag when dragging outside the bounds, the transform was not being reset.
Also simplified code on moveEnd.

### Checklist

-   [x] tested locally
-   [x] documented the code
-   [x] clean all warnings and errors of eslint
-   [x] requires changes in OutSystems (if so, provide a module with changes)
-   [ ] requires new sample page in OutSystems (if so, provide a module with changes)
