### PR TITLE
[ROU-4115] - DropdownServerSide - Fix position issue when error message appears

### DIFF
--- a/src/scripts/OSFramework/OSUI/Pattern/Dropdown/ServerSide/DropdownServerSide.ts
+++ b/src/scripts/OSFramework/OSUI/Pattern/Dropdown/ServerSide/DropdownServerSide.ts
@@ -1192,6 +1192,8 @@ namespace OSFramework.OSUI.Patterns.Dropdown.ServerSide {
 			if (isValid === false) {
 				Helper.Dom.Styles.AddClass(this.selfElement, Enum.CssClass.NotValid);
 				this._addErrorMessage(validationMessage);
+				// Due to the error message text, update the balloon position
+				this._setBalloonCoordinates();
 			} else {
 				Helper.Dom.Styles.RemoveClass(this.selfElement, Enum.CssClass.NotValid);
 


### PR DESCRIPTION
This PR is for fixing an issue related with position of the balloon when Error message appears, since it was not being updated as it can be checked on the image:

![DropdownServerSide_Issue](https://user-images.githubusercontent.com/5339917/219335900-2a8fd4da-be57-4aa1-bf94-9f11970c5b43.gif)
