### PR TITLE
Fix tabs display on servicestudio only

### DIFF
--- a/src/scripts/OSFramework/Pattern/Tabs/scss/_tabs.scss
+++ b/src/scripts/OSFramework/Pattern/Tabs/scss/_tabs.scss
@@ -243,6 +243,9 @@
 			-servicestudio-border: 1px dashed var(--color-neutral-5);
 			-servicestudio-width: 100%;
 		}
+		.osui-tabs__content-item .display-contents {
+			-servicestudio-display: block;
+		}
 	}
 }
 


### PR DESCRIPTION
This PR is for fixing the preview inside service studio when using tabs

### What was happening
- When using the tabs. Is not possible to drag and drop items inside the tabs if not on the widget tree. The IDE doesn't interpret the display: contents well.

### What was done
- adds the -servicestudio-display tag to change the display only inside the servicestudio

### Test Steps
1. Drag the tabs to a screen
2. Drag a different pattern to the tabs content placeholder. (it can be a simple text, expression or container)

### Screenshots
![image](https://user-images.githubusercontent.com/38037527/219365887-d431068d-e653-480c-b6dc-ea1794a0ee5a.png)

### Checklist
-   [x] tested locally
-   [ ] documented the code
-   [ ] clean all warnings and errors of eslint
-   [ ] requires changes in OutSystems (if so, provide a module with changes)
-   [ ] requires new sample page in OutSystems (if so, provide a module with changes)
