### PR TITLE
ROU-4084: Improve sectionIndex without main-content

### DIFF
--- a/dist/OutSystemsUI.d.ts
+++ b/dist/OutSystemsUI.d.ts
@@ -2493,17 +2493,20 @@ declare namespace OSFramework.OSUI.Patterns.SectionIndex.Enum {
 }
 declare namespace OSFramework.OSUI.Patterns.SectionIndex {
     interface ISectionIndex extends Interface.IParent {
+        contentPaddingTop: string | number;
     }
 }
 declare namespace OSFramework.OSUI.Patterns.SectionIndex {
     class SectionIndex extends AbstractParent<SectionIndexConfig, SectionIndexItem.ISectionIndexItem> implements ISectionIndex {
         private _activeSectionIndexItem;
+        private _contentPaddingTop;
         private _mainScrollContainerElement;
         private _navigateOnClick;
         private _scrollTimeout;
         constructor(uniqueId: string, configs: JSON);
         private _addSectionIndexItem;
         private _childItemHasBeenClicked;
+        private _getContentPaddingTop;
         private _removeSectionIndexItem;
         private _setActiveChildOnClick;
         private _setActiveChildOnScroll;
@@ -2517,6 +2520,7 @@ declare namespace OSFramework.OSUI.Patterns.SectionIndex {
         build(): void;
         changeProperty(propertyName: string, propertyValue: unknown): void;
         dispose(): void;
+        get contentPaddingTop(): string | number;
     }
 }
 declare namespace OSFramework.OSUI.Patterns.SectionIndex {

--- a/dist/OutSystemsUI.js
+++ b/dist/OutSystemsUI.js
@@ -7302,6 +7302,12 @@ var OSFramework;
                             throw new Error(`${OSUI.ErrorCodes.SectionIndex.FailChildItemClicked}: The ${OSUI.GlobalEnum.PatternName.SectionIndexItem} under uniqueId: '${childId}' does not exist as an SectionIndexItem from ${OSUI.GlobalEnum.PatternName.SectionIndex} with Id: ${this.widgetId}.`);
                         }
                     }
+                    _getContentPaddingTop() {
+                        const _mainContent = OSUI.Helper.Dom.ClassSelector(document, OSUI.GlobalEnum.CssClassElements.MainContent);
+                        this._contentPaddingTop = _mainContent
+                            ? parseFloat(window.getComputedStyle(_mainContent).getPropertyValue(OSUI.GlobalEnum.CssProperties.PaddingTop))
+                            : 0;
+                    }
                     _removeSectionIndexItem(childId) {
                         if (this.getChild(childId)) {
                             this.unsetChild(childId);
@@ -7344,10 +7350,7 @@ var OSFramework;
                                 headerHeight =
                                     OSUI.Helper.Dom.ClassSelector(document, OSUI.GlobalEnum.CssClassElements.Header).offsetHeight || 0;
                             }
-                            const contentPaddingTop = window
-                                .getComputedStyle(OSUI.Helper.Dom.ClassSelector(document, OSUI.GlobalEnum.CssClassElements.MainContent))
-                                .getPropertyValue(OSUI.GlobalEnum.CssProperties.PaddingTop) || 0;
-                            OSUI.Helper.Dom.Styles.SetStyleAttribute(this.selfElement, SectionIndex_1.Enum.CssVariable.TopPosition, 'calc(' + headerHeight + 'px + ' + contentPaddingTop + ')');
+                            OSUI.Helper.Dom.Styles.SetStyleAttribute(this.selfElement, SectionIndex_1.Enum.CssVariable.TopPosition, 'calc(' + headerHeight + 'px + ' + this._contentPaddingTop + 'px)');
                             OSUI.Helper.Dom.Styles.AddClass(this.selfElement, SectionIndex_1.Enum.CssClass.IsSticky);
                         }
                         else {
@@ -7397,6 +7400,7 @@ var OSFramework;
                     build() {
                         super.build();
                         this.setHtmlElements();
+                        this._getContentPaddingTop();
                         this._toggleIsFixed();
                         this.finishBuild();
                     }
@@ -7413,6 +7417,9 @@ var OSFramework;
                     dispose() {
                         this.unsetHtmlElements();
                         super.dispose();
+                    }
+                    get contentPaddingTop() {
+                        return this._contentPaddingTop;
                     }
                 }
                 SectionIndex_1.SectionIndex = SectionIndex;
@@ -7546,10 +7553,8 @@ var OSFramework;
                     _setTargetOffsetInfo() {
                         this._setTargetElement();
                         this._setHeaderSize();
-                        const contentPaddingTop = parseFloat(window
-                            .getComputedStyle(OSUI.Helper.Dom.ClassSelector(document, OSUI.GlobalEnum.CssClassElements.MainContent))
-                            .getPropertyValue(OSUI.GlobalEnum.CssProperties.PaddingTop)) || 0;
-                        this._targetElementOffset.top = this._targetElement.offsetTop + this._headerHeight + contentPaddingTop;
+                        this._targetElementOffset.top =
+                            this._targetElement.offsetTop + this._headerHeight + this.parentObject.contentPaddingTop;
                     }
                     _setUpEvents() {
                         this.selfElement.addEventListener(OSUI.GlobalEnum.HTMLEvent.Click, this._eventOnClick);

--- a/src/scripts/OSFramework/OSUI/Pattern/SectionIndex/ISectionIndex.ts
+++ b/src/scripts/OSFramework/OSUI/Pattern/SectionIndex/ISectionIndex.ts
@@ -7,5 +7,7 @@ namespace OSFramework.OSUI.Patterns.SectionIndex {
 	 * @interface ISectionIndex
 	 * @extends {Interface.IPattern}
 	 */
-	export interface ISectionIndex extends Interface.IParent {}
+	export interface ISectionIndex extends Interface.IParent {
+		contentPaddingTop: string | number;
+	}
 }

--- a/src/scripts/OSFramework/OSUI/Pattern/SectionIndex/SectionIndex.ts
+++ b/src/scripts/OSFramework/OSUI/Pattern/SectionIndex/SectionIndex.ts
@@ -14,6 +14,8 @@ namespace OSFramework.OSUI.Patterns.SectionIndex {
 	{
 		// Store the current active sectionIndexItem
 		private _activeSectionIndexItem: SectionIndexItem.ISectionIndexItem;
+		// Store the contentPaddingTop
+		private _contentPaddingTop: string | number;
 		// Store the mainContent reference - The one that will have the scroll
 		private _mainScrollContainerElement: HTMLElement;
 
@@ -48,6 +50,15 @@ namespace OSFramework.OSUI.Patterns.SectionIndex {
 					`${ErrorCodes.SectionIndex.FailChildItemClicked}: The ${GlobalEnum.PatternName.SectionIndexItem} under uniqueId: '${childId}' does not exist as an SectionIndexItem from ${GlobalEnum.PatternName.SectionIndex} with Id: ${this.widgetId}.`
 				);
 			}
+		}
+
+		private _getContentPaddingTop(): void {
+			const _mainContent = Helper.Dom.ClassSelector(document, GlobalEnum.CssClassElements.MainContent);
+			this._contentPaddingTop = _mainContent
+				? parseFloat(
+						window.getComputedStyle(_mainContent).getPropertyValue(GlobalEnum.CssProperties.PaddingTop)
+				  )
+				: 0;
 		}
 
 		// Method used to remove a given SectionIndexItem from sectionIndexItems list, it's triggered by SectionIndexItem
@@ -125,18 +136,11 @@ namespace OSFramework.OSUI.Patterns.SectionIndex {
 					headerHeight =
 						Helper.Dom.ClassSelector(document, GlobalEnum.CssClassElements.Header).offsetHeight || 0;
 				}
-
-				// Get (if exist) the paddingTop value for the mainContent (the one with Scroll)
-				const contentPaddingTop =
-					window
-						.getComputedStyle(Helper.Dom.ClassSelector(document, GlobalEnum.CssClassElements.MainContent))
-						.getPropertyValue(GlobalEnum.CssProperties.PaddingTop) || 0;
-
 				// Set inline css variable that will affect the pattern sticky position top value
 				Helper.Dom.Styles.SetStyleAttribute(
 					this.selfElement,
 					Enum.CssVariable.TopPosition,
-					'calc(' + headerHeight + 'px + ' + contentPaddingTop + ')'
+					'calc(' + headerHeight + 'px + ' + this._contentPaddingTop + 'px)'
 				);
 
 				// Set the Sticky class
@@ -255,6 +259,8 @@ namespace OSFramework.OSUI.Patterns.SectionIndex {
 
 			this.setHtmlElements();
 
+			this._getContentPaddingTop();
+
 			this._toggleIsFixed();
 
 			this.finishBuild();
@@ -287,6 +293,17 @@ namespace OSFramework.OSUI.Patterns.SectionIndex {
 			this.unsetHtmlElements();
 			//Destroying the base of pattern
 			super.dispose();
+		}
+
+		/**
+		 * Getter of the contentPaddingTop property
+		 *
+		 * @readonly
+		 * @type {(string | number)}
+		 * @memberof SectionIndex
+		 */
+		public get contentPaddingTop(): string | number {
+			return this._contentPaddingTop;
 		}
 	}
 }

--- a/src/scripts/OSFramework/OSUI/Pattern/SectionIndexItem/SectionIndexItem.ts
+++ b/src/scripts/OSFramework/OSUI/Pattern/SectionIndexItem/SectionIndexItem.ts
@@ -141,16 +141,9 @@ namespace OSFramework.OSUI.Patterns.SectionIndexItem {
 			// Takes into account the headerSize
 			this._setHeaderSize();
 
-			// Get the MainContent paddingTop value in order to remove it's value from the calcs
-			const contentPaddingTop =
-				parseFloat(
-					window
-						.getComputedStyle(Helper.Dom.ClassSelector(document, GlobalEnum.CssClassElements.MainContent))
-						.getPropertyValue(GlobalEnum.CssProperties.PaddingTop)
-				) || 0;
-
 			// Set the target element offset top values
-			this._targetElementOffset.top = this._targetElement.offsetTop + this._headerHeight + contentPaddingTop;
+			this._targetElementOffset.top =
+				this._targetElement.offsetTop + this._headerHeight + (this.parentObject.contentPaddingTop as number);
 		}
 
 		// Method to set the event listeners


### PR DESCRIPTION
This PR is for improving the SectionIndex behaviour when the class .main-content is not present.

### Checklist

-   [x] tested locally
-   [x] documented the code
-   [x] clean all warnings and errors of eslint
-   [x] requires changes in OutSystems (if so, provide a module with changes)
-   [ ] requires new sample page in OutSystems (if so, provide a module with changes)
