### PR TITLE
ROU-4144: fix Menu drag on Tablet landscape

### DIFF
--- a/dist/OutSystemsUI.d.ts
+++ b/dist/OutSystemsUI.d.ts
@@ -537,7 +537,7 @@ declare namespace OSFramework.OSUI.Event {
         constructor();
         addHandler(eventType: ET, handler: GlobalCallbacks.Generic): void;
         hasHandlers(eventType: ET): boolean;
-        removeHandler(eventType: ET, handler: GlobalCallbacks.OSGeneric): void;
+        removeHandler(eventType: ET, handler: GlobalCallbacks.Generic): void;
         trigger(eventType: ET, data?: D, ...args: unknown[]): void;
         get events(): Map<ET, IEvent<D>>;
         protected abstract getInstanceOfEventType(eventType: ET): IEvent<D>;
@@ -3974,9 +3974,11 @@ declare namespace OutSystems.OSUI.Utils {
     function SetFocusBehaviour(contentId: string, triggerItem: string): string;
 }
 declare namespace OutSystems.OSUI.Utils.Menu {
+    function AddMenuOnOrientationChange(callback: OSFramework.OSUI.GlobalCallbacks.Generic): void;
     function IsMenuDraggable(): boolean;
     function MenuHide(): void;
     function MenuShow(): void;
+    function RemoveMenuOnOrientationChange(): void;
     function SetActiveMenuItems(WidgetId: string, ActiveItem: number, ActiveSubItem: number): string;
     function SetBottomBarActiveElement(ActiveItem?: number): string;
     function SetMenuAttributes(): string;

--- a/dist/OutSystemsUI.js
+++ b/dist/OutSystemsUI.js
@@ -3639,12 +3639,6 @@ var OSFramework;
             var BottomSheet;
             (function (BottomSheet_1) {
                 class BottomSheet extends Patterns.AbstractPattern {
-                    get gestureEventInstance() {
-                        return this._gestureEventInstance;
-                    }
-                    get hasGestureEvents() {
-                        return this._hasGestureEvents;
-                    }
                     constructor(uniqueId, configs) {
                         super(uniqueId, new BottomSheet_1.BottomSheetConfig(configs));
                         this._isOpen = false;
@@ -3656,6 +3650,12 @@ var OSFramework;
                                 mass: 1,
                             },
                         };
+                    }
+                    get gestureEventInstance() {
+                        return this._gestureEventInstance;
+                    }
+                    get hasGestureEvents() {
+                        return this._hasGestureEvents;
                     }
                     _handleFocusTrap() {
                         const opts = {
@@ -5084,6 +5084,7 @@ var OSFramework;
                             if (isValid === false) {
                                 OSUI.Helper.Dom.Styles.AddClass(this.selfElement, ServerSide.Enum.CssClass.NotValid);
                                 this._addErrorMessage(validationMessage);
+                                this._setBalloonCoordinates();
                             }
                             else {
                                 OSUI.Helper.Dom.Styles.RemoveClass(this.selfElement, ServerSide.Enum.CssClass.NotValid);
@@ -14180,8 +14181,35 @@ var OutSystems;
         (function (Utils) {
             var Menu;
             (function (Menu) {
+                let _onOrientationChangeCallback;
+                function _onOrientationChangeCallbackHandler(callback) {
+                    if (callback !== undefined) {
+                        setTimeout(function () {
+                            _onOrientationChangeCallback();
+                        }, 300);
+                    }
+                }
+                function AddMenuOnOrientationChange(callback) {
+                    if (callback !== undefined) {
+                        _onOrientationChangeCallback = callback;
+                        OSFramework.OSUI.Event.GlobalEventManager.Instance.addHandler(OSFramework.OSUI.Event.Type.OrientationChange, _onOrientationChangeCallbackHandler);
+                    }
+                }
+                Menu.AddMenuOnOrientationChange = AddMenuOnOrientationChange;
                 function IsMenuDraggable() {
-                    return window.cordova !== undefined && Utils.DeviceDetection.IsRunningAsPWA() === false;
+                    const _layoutMenuVisible = document.querySelector('.active-screen .aside-visible');
+                    const _isLandscape = document.body.classList.contains('landscape');
+                    let _addDragGestures = false;
+                    if (window.cordova !== undefined && Utils.DeviceDetection.IsRunningAsPWA() === false) {
+                        if ((_layoutMenuVisible && OSFramework.OSUI.Helper.DeviceInfo.IsDesktop) ||
+                            (_layoutMenuVisible && OSFramework.OSUI.Helper.DeviceInfo.IsTablet && _isLandscape)) {
+                            _addDragGestures = false;
+                        }
+                        else {
+                            _addDragGestures = true;
+                        }
+                    }
+                    return _addDragGestures;
                 }
                 Menu.IsMenuDraggable = IsMenuDraggable;
                 function MenuHide() {
@@ -14218,6 +14246,13 @@ var OutSystems;
                     }
                 }
                 Menu.MenuShow = MenuShow;
+                function RemoveMenuOnOrientationChange() {
+                    if (_onOrientationChangeCallback !== undefined) {
+                        OSFramework.OSUI.Event.GlobalEventManager.Instance.removeHandler(OSFramework.OSUI.Event.Type.OrientationChange, _onOrientationChangeCallbackHandler);
+                        _onOrientationChangeCallback = undefined;
+                    }
+                }
+                Menu.RemoveMenuOnOrientationChange = RemoveMenuOnOrientationChange;
                 function SetActiveMenuItems(WidgetId, ActiveItem, ActiveSubItem) {
                     const result = OutSystems.OSUI.Utils.CreateApiResponse({
                         errorCode: OSUI.ErrorCodes.Utilities.FailSetActiveMenuItems,

--- a/dist/OutSystemsUI.js
+++ b/dist/OutSystemsUI.js
@@ -14197,8 +14197,8 @@ var OutSystems;
                 }
                 Menu.AddMenuOnOrientationChange = AddMenuOnOrientationChange;
                 function IsMenuDraggable() {
-                    const _layoutMenuVisible = document.querySelector('.active-screen .aside-visible');
-                    const _isLandscape = document.body.classList.contains('landscape');
+                    const _layoutMenuVisible = OSFramework.OSUI.Helper.Dom.TagSelector(document.body, '.active-screen .aside-visible');
+                    const _isLandscape = OSFramework.OSUI.Helper.Dom.Styles.ContainsClass(document.body, 'landscape');
                     let _addDragGestures = false;
                     if (window.cordova !== undefined && Utils.DeviceDetection.IsRunningAsPWA() === false) {
                         if ((_layoutMenuVisible && OSFramework.OSUI.Helper.DeviceInfo.IsDesktop) ||

--- a/src/scripts/OSFramework/OSUI/Event/AbstractEventsManager.ts
+++ b/src/scripts/OSFramework/OSUI/Event/AbstractEventsManager.ts
@@ -61,7 +61,7 @@ namespace OSFramework.OSUI.Event {
 		 * @param handler
 		 * @memberof OSFramework.Event.AbstractEventsManager
 		 */
-		public removeHandler(eventType: ET, handler: GlobalCallbacks.OSGeneric): void {
+		public removeHandler(eventType: ET, handler: GlobalCallbacks.Generic): void {
 			if (this._events.has(eventType)) {
 				const event = this._events.get(eventType);
 				event.removeHandler(handler);

--- a/src/scripts/OutSystems/OSUI/Utils/Menu.ts
+++ b/src/scripts/OutSystems/OSUI/Utils/Menu.ts
@@ -1,11 +1,57 @@
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 namespace OutSystems.OSUI.Utils.Menu {
+	// OrientationChange callback to be stored and removed on Destroy
+	let _onOrientationChangeCallback: OSFramework.OSUI.GlobalCallbacks.Generic;
+
+	// OrientationChange handler
+	function _onOrientationChangeCallbackHandler(callback: OSFramework.OSUI.GlobalCallbacks.Generic): void {
+		if (callback !== undefined) {
+			setTimeout(function () {
+				_onOrientationChangeCallback();
+			}, 300);
+		}
+	}
+
+	/**
+	 * Method that add the OrientationChange handler
+	 *
+	 * @export
+	 * @param {OSFramework.OSUI.GlobalCallbacks.Generic} callback
+	 */
+	export function AddMenuOnOrientationChange(callback: OSFramework.OSUI.GlobalCallbacks.Generic): void {
+		if (callback !== undefined) {
+			_onOrientationChangeCallback = callback;
+			OSFramework.OSUI.Event.GlobalEventManager.Instance.addHandler(
+				OSFramework.OSUI.Event.Type.OrientationChange,
+				_onOrientationChangeCallbackHandler
+			);
+		}
+	}
+
 	/**
 	 * Checks if the menu can be draggable
 	 * @returns
 	 */
 	export function IsMenuDraggable(): boolean {
-		return window.cordova !== undefined && DeviceDetection.IsRunningAsPWA() === false;
+		const _layoutMenuVisible = OSFramework.OSUI.Helper.Dom.TagSelector(
+			document.body,
+			'.active-screen .aside-visible'
+		);
+		const _isLandscape = OSFramework.OSUI.Helper.Dom.Styles.ContainsClass(document.body, 'landscape');
+		let _addDragGestures = false;
+
+		if (window.cordova !== undefined && DeviceDetection.IsRunningAsPWA() === false) {
+			if (
+				(_layoutMenuVisible && OSFramework.OSUI.Helper.DeviceInfo.IsDesktop) ||
+				(_layoutMenuVisible && OSFramework.OSUI.Helper.DeviceInfo.IsTablet && _isLandscape)
+			) {
+				_addDragGestures = false;
+			} else {
+				_addDragGestures = true;
+			}
+		}
+
+		return _addDragGestures;
 	}
 
 	/**
@@ -52,6 +98,19 @@ namespace OutSystems.OSUI.Utils.Menu {
 			SetMenuAttributes();
 		} else {
 			console.warn('The menu element is not present in the screen');
+		}
+	}
+
+	/**
+	 * Method that removes the OrientationChange handler
+	 */
+	export function RemoveMenuOnOrientationChange(): void {
+		if (_onOrientationChangeCallback !== undefined) {
+			OSFramework.OSUI.Event.GlobalEventManager.Instance.removeHandler(
+				OSFramework.OSUI.Event.Type.OrientationChange,
+				_onOrientationChangeCallbackHandler
+			);
+			_onOrientationChangeCallback = undefined;
 		}
 	}
 


### PR DESCRIPTION
This PR is to fix the Menu Drag when on Table landscape (that would be identified as desktop) and when using the option Menu Visible, should not add the drag gestures.

The orientationChange was also fixed, as it was not properly updating the check for gestures. Now this is done using our API.

### Checklist

-   [x] tested locally
-   [x] documented the code
-   [x] clean all warnings and errors of eslint
-   [x] requires changes in OutSystems (if so, provide a module with changes)
-   [ ] requires new sample page in OutSystems (if so, provide a module with changes)
