### PR TITLE
Rducp 429   status bar

### DIFF
--- a/src/scripts/OSFramework/Pattern/SectionIndex/scss/_sectionindex.scss
+++ b/src/scripts/OSFramework/Pattern/SectionIndex/scss/_sectionindex.scss
@@ -101,7 +101,7 @@
 			left: calc(var(--os-safe-area-right) + var(--space-base));
 			padding: 0 var(--space-base) 0 0;
 			position: fixed;
-			top: var(--header-size);
+			top: calc(var(--header-size) + var(--header-size-content) + var(--status-bar-height));
 			z-index: 1;
 		}
 	}
@@ -118,18 +118,6 @@
 }
 
 // Browser -----------------------------------------------------------------------
-///
-.android[data-status-bar-height] {
-	.layout-native {
-		.osui-section-index {
-			&--is-sticky {
-				top: calc(
-					var(--header-size) + var(--header-size-content) + var(--top-position) + var(--status-bar-height)
-				);
-			}
-		}
-	}
-}
 
 // Fixes the sticky problem on Safari 14.1
 ///

--- a/src/scripts/OSFramework/Pattern/Tabs/scss/_tabs.scss
+++ b/src/scripts/OSFramework/Pattern/Tabs/scss/_tabs.scss
@@ -243,6 +243,9 @@
 			-servicestudio-border: 1px dashed var(--color-neutral-5);
 			-servicestudio-width: 100%;
 		}
+		.osui-tabs__content-item .display-contents {
+			-servicestudio-display: block;
+		}
 	}
 }
 

--- a/src/scripts/OutSystems/OSUI/Utils/LayoutPrivateBodyCssVars.ts
+++ b/src/scripts/OutSystems/OSUI/Utils/LayoutPrivateBodyCssVars.ts
@@ -3,6 +3,7 @@ namespace OutSystems.OSUI.Utils.LayoutPrivate {
 	export abstract class CssBodyVariables {
 		// Function that will set the css variables to body element
 		private static _setCssVars(): void {
+			const body = document.body;
 			const headerContent = OSFramework.Helper.Dom.ClassSelector(
 				document,
 				OSFramework.GlobalEnum.CssClassElements.HeaderTopContent
@@ -11,25 +12,22 @@ namespace OutSystems.OSUI.Utils.LayoutPrivate {
 				document,
 				OSFramework.GlobalEnum.CssClassElements.Footer
 			);
-			const body = document.body;
-
-			let stylesToBeAdded = '';
 
 			if (OSUI.Utils.DeviceDetection.IsWebApp() === false) {
 				if (headerContent) {
-					stylesToBeAdded += `${OSFramework.GlobalEnum.CSSVariables.HeaderContentHeight}: ${
-						headerContent.getBoundingClientRect().height
-					}${OSFramework.GlobalEnum.Units.Pixel}`;
+					OSFramework.Helper.Dom.Styles.SetStyleAttribute(
+						body,
+						OSFramework.GlobalEnum.CSSVariables.HeaderContentHeight,
+						headerContent.getBoundingClientRect().height + OSFramework.GlobalEnum.Units.Pixel
+					);
 				}
 
 				if (footer) {
-					stylesToBeAdded +=
-						stylesToBeAdded === ''
-							? ''
-							: '; ' +
-							  `${OSFramework.GlobalEnum.CSSVariables.FooterHeight}: ${
-									footer.getBoundingClientRect().height
-							  }${OSFramework.GlobalEnum.Units.Pixel}`;
+					OSFramework.Helper.Dom.Styles.SetStyleAttribute(
+						body,
+						OSFramework.GlobalEnum.CSSVariables.FooterHeight,
+						footer.getBoundingClientRect().height + OSFramework.GlobalEnum.Units.Pixel
+					);
 				}
 			}
 
@@ -37,14 +35,12 @@ namespace OutSystems.OSUI.Utils.LayoutPrivate {
 				OSFramework.Helper.Dom.Styles.ContainsClass(body, OSFramework.GlobalEnum.DeviceType.phone) ||
 				OSFramework.Helper.Dom.Styles.ContainsClass(body, OSFramework.GlobalEnum.DeviceType.tablet)
 			) {
-				stylesToBeAdded +=
-					stylesToBeAdded === ''
-						? ''
-						: '; ' +
-						  `${OSFramework.GlobalEnum.CSSVariables.ViewportHeight}: ${window.innerHeight}${OSFramework.GlobalEnum.Units.Pixel}`;
+				OSFramework.Helper.Dom.Styles.SetStyleAttribute(
+					body,
+					OSFramework.GlobalEnum.CSSVariables.ViewportHeight,
+					window.innerHeight + OSFramework.GlobalEnum.Units.Pixel
+				);
 			}
-
-			OSFramework.Helper.Dom.Attribute.Set(body, OSFramework.GlobalEnum.HTMLAttributes.Style, stylesToBeAdded);
 		}
 
 		/**

--- a/src/scss/02-layout/_menu.scss
+++ b/src/scss/02-layout/_menu.scss
@@ -184,8 +184,18 @@
 
 ///
 .android {
-	[data-status-bar-height] .app-menu-content {
-		padding-top: var(--status-bar-height);
+	&[data-status-bar-height] {
+		&.portrait {
+			.app-menu-content {
+				padding-top: var(--status-bar-height);
+			}
+		}
+
+		&.landscape {
+			.app-menu-content {
+				padding-left: var(--status-bar-height);
+			}
+		}
 	}
 }
 


### PR DESCRIPTION
This PR is to bring the code from O11 that consider the status bar in the application UI.

### What was happening

Status bar was not being considered, making the UI overlap the status bar

### What was done

Bring the commit from O11 that fix the issue

### Test Steps

1. Create a new mobile application
2. Add the extensibility configuration to enable the StatusBarOverlaysWebView
3. Generate a mobile app
4. Download the application
5. Open the application on the phone and check if the status bar is being considered (you can also use an emulator for that)

### Screenshots

N/A

### Checklist

-   [x] tested locally
-   [ ] documented the code
-   [ ] clean all warnings and errors of eslint
-   [ ] requires changes in OutSystems (if so, provide a module with changes)
-   [ ] requires new sample page in OutSystems (if so, provide a module with changes)
