### PR TITLE
Remove duplicated selectors

### DIFF
--- a/gulp/Tasks/ScssTanspile.js
+++ b/gulp/Tasks/ScssTanspile.js
@@ -3,6 +3,7 @@ const gulp = require('gulp');
 const autoprefixer = require('gulp-autoprefixer');
 const postcss = require('gulp-postcss');
 const postcssdc = require('postcss-discard-comments');
+const postcssdd = require('postcss-discard-duplicates');
 const removeEmptyLines = require('gulp-remove-empty-lines');
 const rename = require("gulp-rename");
 const sass = require('gulp-sass')(require('sass'));
@@ -31,7 +32,7 @@ function scssTranspile(envMode) {
 			.src(watchScssThemes)
 			.pipe(sourcemaps.init())
 			.pipe(sass().on('error', sass.logError))
-			.pipe(postcss([postcssdc]))
+			.pipe(postcss([postcssdc, postcssdd]))
 			.pipe(
 				autoprefixer({
 					overrideBrowserslist: ['last 10 versions'],
@@ -47,7 +48,7 @@ function scssTranspile(envMode) {
     } else {
         cssResult = gulp.src(watchScssThemes)
             .pipe(sass().on('error', sass.logError))
-            .pipe(postcss([postcssdc]))
+            .pipe(postcss([postcssdc, postcssdd]))
             .pipe(autoprefixer({
                 overrideBrowserslist: ['last 10 versions']
             }))

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
 	"name": "outsystems-ui",
 	"version": "2.15.0",
 	"description": "OutSystems UI Framework",
-	"license" : "BSD-3-Clause",
+	"license": "BSD-3-Clause",
 	"scripts": {
 		"build": "gulp createProduction && npm run lint",
 		"create-osui-scss": "gulp updateScssFile",
@@ -18,9 +18,14 @@
 	"repository": {
 		"type": "git",
 		"url": "git+https://github.com/OutSystems/outsystems-ui"
-	  },
+	},
 	"author": "UI Components Team",
-	"keywords": ["OutSystems", "OutSystems UI", "Framework", "UI Components"],
+	"keywords": [
+		"OutSystems",
+		"OutSystems UI",
+		"Framework",
+		"UI Components"
+	],
 	"homepage": "https://outsystemsui.outsystems.com/OutsystemsUiWebsite/",
 	"devDependencies": {
 		"@splidejs/splide": "4.1.3",
@@ -45,6 +50,7 @@
 		"nouislider": "^15.6.1",
 		"postcss": "^8.4.5",
 		"postcss-discard-comments": "^5.0.1",
+		"postcss-discard-duplicates": "^5.1.0",
 		"prettier-eslint": "^12.0.0",
 		"prompts": "^2.4.2",
 		"sass": "^1.48.0",

--- a/src/scss/00-abstract/_setup-border-vars.scss
+++ b/src/scss/00-abstract/_setup-border-vars.scss
@@ -12,9 +12,4 @@ $osui-border-size: 'none' 0, 's' 1px, 'm' 2px, 'l' 3px;
 $osui-border-radius-types: 'none' 0, 'soft' 4px, 'rounded' 100px, 'circle' 100%;
 
 /// Border Radius BoxSides
-$osui-border-radius-box-sides: (
-	'top' 'left' 'right',
-	'top' 'right' 'left',
-	'bottom' 'left' 'right',
-	'bottom' 'right' 'left'
-);
+$osui-border-radius-box-sides: 'top' 'left' 'right', 'bottom' 'left' 'right';

--- a/src/scss/01-foundations/_html-elements-img.scss
+++ b/src/scss/01-foundations/_html-elements-img.scss
@@ -6,27 +6,6 @@
 ///
 img {
 	max-width: 100%;
-
-	&.img {
-		&-rounded {
-			border-radius: 10px;
-		}
-
-		&-circle {
-			border-radius: var(--border-radius-circle);
-		}
-
-		&-cover {
-			height: 100%;
-			object-fit: cover;
-		}
-	}
-
-	&.thumbnail {
-		background-color: var(--color-neutral-0);
-		border: var(--border-size-s) solid var(--color-neutral-4);
-		padding: var(--space-xs);
-	}
 }
 
 ///


### PR DESCRIPTION
This PR is for remove duplicated css selectors.
In order to prevent this, also added **postcss-discard-duplicates** that will manage the duplicated css selectors at the compiling moment.