### PR TITLE
ROU-4123: Submenu fixes and improvements

### DIFF
--- a/dist/OutSystemsUI.css
+++ b/dist/OutSystemsUI.css
@@ -10990,33 +10990,33 @@ html[data-uieditorversion^="1"] .osui-timepicker__dropdown-ss-preview.time12h, h
 .layout-side .app-menu-links .osui-submenu a{
   border-left:none;
 }
-.layout-side .osui-submenu{
+.layout-side .app-menu-links .osui-submenu{
   -webkit-box-orient:vertical;
   -webkit-box-direction:normal;
       -ms-flex-direction:column;
           flex-direction:column;
   width:100%;
 }
-.layout-side .osui-submenu.active .osui-submenu__header{
+.layout-side .app-menu-links .osui-submenu.active .osui-submenu__header{
   border-left:var(--border-size-m) solid var(--color-primary);
 }
-.layout-side .osui-submenu--is-open .osui-submenu__items{
+.layout-side .app-menu-links .osui-submenu--is-open > .osui-submenu__items{
   display:-webkit-box;
   display:-ms-flexbox;
   display:flex;
 }
-.layout-side .osui-submenu .osui-submenu__header{
+.layout-side .app-menu-links .osui-submenu .osui-submenu__header{
   border-bottom:0;
   border-left:var(--border-size-m) solid transparent;
   border-top:0;
   padding:var(--space-s) var(--space-m);
 }
-.layout-side .osui-submenu .osui-submenu__header__item{
+.layout-side .app-menu-links .osui-submenu .osui-submenu__header__item{
   -webkit-box-flex:1;
       -ms-flex:1;
           flex:1;
 }
-.layout-side .osui-submenu__items{
+.layout-side .app-menu-links .osui-submenu__items{
   border:none;
   -webkit-box-shadow:none;
           box-shadow:none;
@@ -11030,7 +11030,7 @@ html[data-uieditorversion^="1"] .osui-timepicker__dropdown-ss-preview.time12h, h
       -ms-transform:translateY(0);
           transform:translateY(0);
 }
-.layout-side .osui-submenu__items a{
+.layout-side .app-menu-links .osui-submenu__items a{
   padding:var(--space-s) var(--space-base);
 }
 .layout-side .app-menu-links .osui-submenu__header a,

--- a/dist/OutSystemsUI.d.ts
+++ b/dist/OutSystemsUI.d.ts
@@ -2761,7 +2761,6 @@ declare namespace OSFramework.OSUI.Patterns.Submenu {
 }
 declare namespace OSFramework.OSUI.Patterns.Submenu {
     class Submenu extends AbstractPattern<SubmenuConfig> implements ISubmenu {
-        private _dynamicallyOpening;
         private _eventClick;
         private _eventKeypress;
         private _eventOnMouseEnter;

--- a/dist/OutSystemsUI.d.ts
+++ b/dist/OutSystemsUI.d.ts
@@ -122,6 +122,9 @@ declare namespace OSFramework.OSUI.ErrorCodes {
     const SectionIndexItem: {
         FailToSetTargetElement: string;
     };
+    const Submenu: {
+        FailRegisterCallback: string;
+    };
     const Tooltip: {
         FailRegisterCallback: string;
         FailOnSetIntersectionObserver: string;
@@ -903,7 +906,7 @@ declare namespace OSFramework.OSUI.Interface {
 }
 declare namespace OSFramework.OSUI.Interface {
     interface ICallback {
-        registerCallback(callback: GlobalCallbacks.OSGeneric): void;
+        registerCallback(callback: GlobalCallbacks.OSGeneric, eventName?: string): void;
     }
 }
 declare namespace OSFramework.OSUI.Interface {
@@ -2716,9 +2719,6 @@ declare namespace OSFramework.OSUI.Patterns.Sidebar {
     }
 }
 declare namespace OSFramework.OSUI.Patterns.Submenu.Enum {
-    enum Properties {
-        OpenOnHover = "OpenOnHover"
-    }
     enum CssClass {
         Pattern = "osui-submenu",
         PatternActive = "active",
@@ -2731,9 +2731,17 @@ declare namespace OSFramework.OSUI.Patterns.Submenu.Enum {
         PatternItem = "osui-submenu__header__item",
         PatternLinks = "osui-submenu__items"
     }
+    enum Events {
+        Initialized = "Initialized",
+        OnToggle = "OnToggle"
+    }
+    enum Properties {
+        OpenOnHover = "OpenOnHover"
+    }
 }
 declare namespace OSFramework.OSUI.Patterns.Submenu {
-    interface ISubmenu extends Interface.IPattern, Interface.IOpenable, Interface.IRenderUpdate {
+    interface ISubmenu extends Interface.IPattern, Interface.IOpenable, Interface.IRenderUpdate, Interface.ICallback {
+        setOpenOnHover(): void;
     }
 }
 declare namespace OSFramework.OSUI.Patterns.Submenu {
@@ -2748,6 +2756,8 @@ declare namespace OSFramework.OSUI.Patterns.Submenu {
         private _hasElements;
         private _isActive;
         private _isOpen;
+        private _platformEventInitializedCallback;
+        private _platformEventOnToggleCallback;
         private _submenuActiveLinksElement;
         private _submenuAllLinksElement;
         private _submenuHeaderElement;
@@ -2762,7 +2772,6 @@ declare namespace OSFramework.OSUI.Patterns.Submenu {
         private _removeActive;
         private _removeEvents;
         private _setActive;
-        private _setOpenOnHover;
         private _show;
         private _toggleSubmenu;
         private _updateA11yProperties;
@@ -2777,6 +2786,8 @@ declare namespace OSFramework.OSUI.Patterns.Submenu {
         close(): void;
         dispose(): void;
         open(): void;
+        registerCallback(callback: GlobalCallbacks.OSGeneric, eventName: string): void;
+        setOpenOnHover(): void;
         updateOnRender(): void;
     }
 }
@@ -3424,6 +3435,7 @@ declare namespace OutSystems.OSUI.ErrorCodes {
         FailDispose: string;
         FailOpen: string;
         FailOpenOnHover: string;
+        FailRegisterCallback: string;
         FailUpdate: string;
     };
     const Tooltip: {
@@ -3807,12 +3819,13 @@ declare namespace OutSystems.OSUI.Patterns.SubmenuAPI {
     function ChangeProperty(submenuId: string, propertyName: string, propertyValue: any): string;
     function Close(submenuId: string): string;
     function Open(submenuId: string): string;
-    function SubmenuOpenOnHover(submenuId: string): string;
     function Create(submenuId: string, configs: string): OSFramework.OSUI.Patterns.Submenu.ISubmenu;
     function Dispose(submenuId: string): string;
     function GetAllSubmenus(): Array<string>;
     function GetSubmenuById(submenuId: string): OSFramework.OSUI.Patterns.Submenu.ISubmenu;
     function Initialize(submenuId: string): OSFramework.OSUI.Patterns.Submenu.ISubmenu;
+    function RegisterCallback(submenuId: string, eventName: string, callback: OSFramework.OSUI.GlobalCallbacks.OSGeneric): string;
+    function SubmenuOpenOnHover(submenuId: string): string;
     function UpdateOnRender(submenuId: string): string;
 }
 declare namespace OutSystems.OSUI.Patterns.SwipeEventsAPI {

--- a/dist/OutSystemsUI.js
+++ b/dist/OutSystemsUI.js
@@ -8228,7 +8228,7 @@ var OSFramework;
                         e.stopPropagation();
                     }
                     _onMouseEnterCallback(e) {
-                        this._show();
+                        this.open();
                         e.stopPropagation();
                     }
                     _onMouseLeaveCallback(e) {
@@ -8277,7 +8277,7 @@ var OSFramework;
                         }
                         else {
                             OSUI.Event.GlobalEventManager.Instance.addHandler(OSUI.Event.Type.BodyOnClick, this._globalEventBody);
-                            OSUI.Helper.AsyncInvocation(this._show.bind(this));
+                            OSUI.Helper.AsyncInvocation(this.open.bind(this));
                         }
                     }
                     _updateA11yProperties() {

--- a/dist/OutSystemsUI.js
+++ b/dist/OutSystemsUI.js
@@ -8039,7 +8039,6 @@ var OSFramework;
                         }
                     }
                     clickOutsideToClose(closeOnOutSideClick) {
-                        console.log(closeOnOutSideClick);
                         this._clickOutsideToClose = closeOnOutSideClick;
                     }
                     close() {
@@ -8197,22 +8196,18 @@ var OSFramework;
                 class Submenu extends Patterns.AbstractPattern {
                     constructor(uniqueId, configs) {
                         super(uniqueId, new Submenu_1.SubmenuConfig(configs));
-                        this._dynamicallyOpening = false;
                         this._hasActiveLinks = false;
                         this._hasElements = false;
                         this._isActive = false;
                         this._isOpen = false;
                     }
                     _bodyClickCallback(_args, e) {
-                        if (this.isBuilt && this._isOpen && this._dynamicallyOpening === false) {
+                        if (this.isBuilt && this._isOpen) {
                             if (!this.selfElement.contains(e.target)) {
                                 this.close();
                             }
                             e.preventDefault();
                             e.stopPropagation();
-                        }
-                        if (this._dynamicallyOpening) {
-                            this._dynamicallyOpening = false;
                         }
                     }
                     _checkForActiveLinks() {
@@ -8384,7 +8379,6 @@ var OSFramework;
                             OSUI.Event.GlobalEventManager.Instance.removeHandler(OSUI.Event.Type.BodyOnClick, this._globalEventBody);
                             OSUI.Helper.Dom.Styles.RemoveClass(this.selfElement, Submenu_1.Enum.CssClass.PatternIsOpen);
                             this._isOpen = false;
-                            this._dynamicallyOpening = false;
                             this._updateA11yProperties();
                             OSUI.Helper.AsyncInvocation(this._platformEventOnToggleCallback, this.widgetId, false);
                         }
@@ -8395,7 +8389,6 @@ var OSFramework;
                         super.dispose();
                     }
                     open() {
-                        this._dynamicallyOpening = true;
                         OSUI.Event.GlobalEventManager.Instance.addHandler(OSUI.Event.Type.BodyOnClick, this._globalEventBody);
                         OSUI.Helper.AsyncInvocation(this._show.bind(this));
                         setTimeout(function () {

--- a/src/scripts/OSFramework/OSUI/ErrorCodes.ts
+++ b/src/scripts/OSFramework/OSUI/ErrorCodes.ts
@@ -52,6 +52,10 @@ namespace OSFramework.OSUI.ErrorCodes {
 		FailToSetTargetElement: 'OSUI-GEN-06001',
 	};
 
+	export const Submenu = {
+		FailRegisterCallback: 'OSUI-GEN-14001',
+	};
+
 	export const Tooltip = {
 		FailRegisterCallback: 'OSUI-GEN-08001',
 		FailOnSetIntersectionObserver: 'OSUI-GEN-08002',

--- a/src/scripts/OSFramework/OSUI/Interface/ICallback.ts
+++ b/src/scripts/OSFramework/OSUI/Interface/ICallback.ts
@@ -7,6 +7,6 @@ namespace OSFramework.OSUI.Interface {
 	 * @interface ICallback
 	 */
 	export interface ICallback {
-		registerCallback(callback: GlobalCallbacks.OSGeneric): void;
+		registerCallback(callback: GlobalCallbacks.OSGeneric, eventName?: string): void;
 	}
 }

--- a/src/scripts/OSFramework/OSUI/Pattern/Submenu/Enum.ts
+++ b/src/scripts/OSFramework/OSUI/Pattern/Submenu/Enum.ts
@@ -1,13 +1,8 @@
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 namespace OSFramework.OSUI.Patterns.Submenu.Enum {
 	/**
-	 * Submenu Enum properties
+	 *  Css Classes
 	 */
-	export enum Properties {
-		OpenOnHover = 'OpenOnHover',
-	}
-
-	// Css Classes
 	export enum CssClass {
 		Pattern = 'osui-submenu',
 		PatternActive = 'active' /* This active class is injected by platform and we need to keep it */,
@@ -19,5 +14,20 @@ namespace OSFramework.OSUI.Patterns.Submenu.Enum {
 		PatternIcon = 'osui-submenu__header__icon',
 		PatternItem = 'osui-submenu__header__item',
 		PatternLinks = 'osui-submenu__items',
+	}
+
+	/**
+	 * Events
+	 */
+	export enum Events {
+		Initialized = 'Initialized',
+		OnToggle = 'OnToggle',
+	}
+
+	/**
+	 * Submenu Enum properties
+	 */
+	export enum Properties {
+		OpenOnHover = 'OpenOnHover',
 	}
 }

--- a/src/scripts/OSFramework/OSUI/Pattern/Submenu/ISubmenu.ts
+++ b/src/scripts/OSFramework/OSUI/Pattern/Submenu/ISubmenu.ts
@@ -3,5 +3,11 @@ namespace OSFramework.OSUI.Patterns.Submenu {
 	/**
 	 * Defines the interface for OutSystemsUI Submenu Pattern
 	 */
-	export interface ISubmenu extends Interface.IPattern, Interface.IOpenable, Interface.IRenderUpdate {}
+	export interface ISubmenu
+		extends Interface.IPattern,
+			Interface.IOpenable,
+			Interface.IRenderUpdate,
+			Interface.ICallback {
+		setOpenOnHover(): void;
+	}
 }

--- a/src/scripts/OSFramework/OSUI/Pattern/Submenu/Submenu.ts
+++ b/src/scripts/OSFramework/OSUI/Pattern/Submenu/Submenu.ts
@@ -4,8 +4,6 @@ namespace OSFramework.OSUI.Patterns.Submenu {
 	 * Defines the interface for OutSystemsUI Patterns
 	 */
 	export class Submenu extends AbstractPattern<SubmenuConfig> implements ISubmenu {
-		// Store the pattern locals
-		private _dynamicallyOpening = false;
 		private _eventClick: GlobalCallbacks.Generic;
 		private _eventKeypress: GlobalCallbacks.Generic;
 		private _eventOnMouseEnter: GlobalCallbacks.Generic;
@@ -29,18 +27,13 @@ namespace OSFramework.OSUI.Patterns.Submenu {
 
 		// Close submenu, when BodyOnCLick event is triggered
 		private _bodyClickCallback(_args: string, e: MouseEvent): void {
-			if (this.isBuilt && this._isOpen && this._dynamicallyOpening === false) {
+			if (this.isBuilt && this._isOpen) {
 				if (!this.selfElement.contains(e.target as HTMLElement)) {
 					this.close();
 				}
 
 				e.preventDefault();
 				e.stopPropagation();
-			}
-
-			//this flag _dynamiclyOpening is just needed one time per interaction
-			if (this._dynamicallyOpening) {
-				this._dynamicallyOpening = false;
 			}
 		}
 
@@ -348,7 +341,6 @@ namespace OSFramework.OSUI.Patterns.Submenu {
 				Helper.Dom.Styles.RemoveClass(this.selfElement, Enum.CssClass.PatternIsOpen);
 
 				this._isOpen = false;
-				this._dynamicallyOpening = false;
 
 				this._updateA11yProperties();
 
@@ -379,9 +371,6 @@ namespace OSFramework.OSUI.Patterns.Submenu {
 		 * @memberof OSFramework.Patterns.Submenu.Submenu
 		 */
 		public open(): void {
-			// Keep the submenu open when using the Open api. After the first bodyclick, this will close
-			this._dynamicallyOpening = true;
-
 			// Add the body click handler to event manager
 			Event.GlobalEventManager.Instance.addHandler(Event.Type.BodyOnClick, this._globalEventBody);
 

--- a/src/scripts/OSFramework/OSUI/Pattern/Submenu/Submenu.ts
+++ b/src/scripts/OSFramework/OSUI/Pattern/Submenu/Submenu.ts
@@ -90,7 +90,7 @@ namespace OSFramework.OSUI.Patterns.Submenu {
 
 		// Trigger the submenu after an hover behaviour
 		private _onMouseEnterCallback(e: MouseEvent) {
-			this._show();
+			this.open();
 			e.stopPropagation();
 		}
 
@@ -163,7 +163,7 @@ namespace OSFramework.OSUI.Patterns.Submenu {
 				Event.GlobalEventManager.Instance.addHandler(Event.Type.BodyOnClick, this._globalEventBody);
 
 				// Make async the method call
-				Helper.AsyncInvocation(this._show.bind(this));
+				Helper.AsyncInvocation(this.open.bind(this));
 			}
 		}
 

--- a/src/scripts/OSFramework/OSUI/Pattern/Submenu/scss/_submenu.scss
+++ b/src/scripts/OSFramework/OSUI/Pattern/Submenu/scss/_submenu.scss
@@ -224,44 +224,44 @@
 		.osui-submenu a {
 			border-left: none;
 		}
-	}
 
-	.osui-submenu {
-		flex-direction: column;
-		width: 100%;
-
-		&.active .osui-submenu__header {
-			border-left: var(--border-size-m) solid var(--color-primary);
-		}
-
-		&--is-open .osui-submenu__items {
-			display: flex;
-		}
-
-		.osui-submenu__header {
-			border-bottom: 0;
-			border-left: var(--border-size-m) solid transparent;
-			border-top: 0;
-			padding: var(--space-s) var(--space-m);
-
-			&__item {
-				flex: 1;
+		.osui-submenu {
+			flex-direction: column;
+			width: 100%;
+	
+			&.active .osui-submenu__header {
+				border-left: var(--border-size-m) solid var(--color-primary);
 			}
-		}
-
-		&__items {
-			border: none;
-			box-shadow: none;
-			display: none;
-			opacity: 1;
-			padding: var(--space-xs) var(--space-m);
-			pointer-events: auto;
-			position: relative;
-			top: 0;
-			transform: translateY(0);
-
-			a {
-				padding: var(--space-s) var(--space-base);
+	
+			&--is-open > .osui-submenu__items {
+				display: flex;
+			}
+	
+			.osui-submenu__header {
+				border-bottom: 0;
+				border-left: var(--border-size-m) solid transparent;
+				border-top: 0;
+				padding: var(--space-s) var(--space-m);
+	
+				&__item {
+					flex: 1;
+				}
+			}
+	
+			&__items {
+				border: none;
+				box-shadow: none;
+				display: none;
+				opacity: 1;
+				padding: var(--space-xs) var(--space-m);
+				pointer-events: auto;
+				position: relative;
+				top: 0;
+				transform: translateY(0);
+	
+				a {
+					padding: var(--space-s) var(--space-base);
+				}
 			}
 		}
 	}

--- a/src/scripts/OSFramework/OSUI/Pattern/Tooltip/ITooltip.ts
+++ b/src/scripts/OSFramework/OSUI/Pattern/Tooltip/ITooltip.ts
@@ -9,7 +9,7 @@ namespace OSFramework.OSUI.Patterns.Tooltip {
 		 *
 		 * @readonly
 		 * @type {boolean}
-		 * @memberof IDropdownServerSideItem
+		 * @memberof ITooltip
 		 */
 		get IsOpen(): boolean;
 	}

--- a/src/scripts/OutSystems/OSUI/ErrorCodes.ts
+++ b/src/scripts/OutSystems/OSUI/ErrorCodes.ts
@@ -141,7 +141,8 @@ namespace OutSystems.OSUI.ErrorCodes {
 		FailDispose: 'OSUI-API-12003',
 		FailOpen: 'OSUI-API-12004',
 		FailOpenOnHover: 'OSUI-API-12005',
-		FailUpdate: 'OSUI-API-12006',
+		FailRegisterCallback: 'OSUI-API-12006',
+		FailUpdate: 'OSUI-API-12007',
 	};
 
 	export const Tooltip = {

--- a/src/scripts/OutSystems/OSUI/Patterns/SubmenuAPI.ts
+++ b/src/scripts/OutSystems/OSUI/Patterns/SubmenuAPI.ts
@@ -63,25 +63,6 @@ namespace OutSystems.OSUI.Patterns.SubmenuAPI {
 	}
 
 	/**
-	 * Function that will set the hover trigger to a given submenu.
-	 *
-	 * @export
-	 * @param {string} submenuId
-	 */
-	export function SubmenuOpenOnHover(submenuId: string): string {
-		const result = OutSystems.OSUI.Utils.CreateApiResponse({
-			errorCode: ErrorCodes.Submenu.FailOpenOnHover,
-			callback: () => {
-				const submenu = GetSubmenuById(submenuId);
-
-				submenu.changeProperty(OSFramework.OSUI.Patterns.Submenu.Enum.Properties.OpenOnHover, true);
-			},
-		});
-
-		return result;
-	}
-
-	/**
 	 * Create the new submenu instance and add it to the submenusMap
 	 *
 	 * @export
@@ -162,6 +143,51 @@ namespace OutSystems.OSUI.Patterns.SubmenuAPI {
 		submenu.build();
 
 		return submenu;
+	}
+
+	/**
+	 * Function to register a provider callback
+	 *
+	 * @export
+	 * @param {string} submenuId
+	 * @param {string} eventName
+	 * @param {OSFramework.OSUI.GlobalCallbacks.OSGeneric} callback
+	 * @return {*}  {string}
+	 */
+	export function RegisterCallback(
+		submenuId: string,
+		eventName: string,
+		callback: OSFramework.OSUI.GlobalCallbacks.OSGeneric
+	): string {
+		const result = OutSystems.OSUI.Utils.CreateApiResponse({
+			errorCode: ErrorCodes.Submenu.FailRegisterCallback,
+			callback: () => {
+				const submenu = GetSubmenuById(submenuId);
+
+				submenu.registerCallback(callback, eventName);
+			},
+		});
+
+		return result;
+	}
+
+	/**
+	 * Function that will set the hover trigger to a given submenu.
+	 *
+	 * @export
+	 * @param {string} submenuId
+	 */
+	export function SubmenuOpenOnHover(submenuId: string): string {
+		const result = OutSystems.OSUI.Utils.CreateApiResponse({
+			errorCode: ErrorCodes.Submenu.FailOpenOnHover,
+			callback: () => {
+				const submenu = GetSubmenuById(submenuId);
+
+				submenu.setOpenOnHover();
+			},
+		});
+
+		return result;
 	}
 
 	/**


### PR DESCRIPTION
This PR is for fixing a bug on the OpenOnHover, that was not working when using it on the OnReady of a parent block/screen. 

Initialize and OnToggle events were added.

Fixed CSS issue that was causing the submenu to have different when used outside of the Menu, depending if the Layout was SideMneu or TopMenu.

### Checklist

-   [x] tested locally
-   [x] documented the code
-   [x] clean all warnings and errors of eslint
-   [ ] requires changes in OutSystems (if so, provide a module with changes)
-   [ ] requires new sample page in OutSystems (if so, provide a module with changes)
