### PR TITLE
ROU-4140: Flatpickr Patterns issue when input is disabled

### DIFF
--- a/dist/OutSystemsUI.js
+++ b/dist/OutSystemsUI.js
@@ -15450,7 +15450,10 @@ var Providers;
                         }
                     }
                     clear() {
-                        this.provider.clear();
+                        const isInputDisable = this._datePickerPlatformInputElem.disabled;
+                        if (isInputDisable === false) {
+                            this.provider.clear();
+                        }
                     }
                     close() {
                         if (this.provider.isOpen) {
@@ -17305,7 +17308,10 @@ var Providers;
                         }
                     }
                     clear() {
-                        this.provider.clear();
+                        const isInputDisable = this._monthPickerProviderInputElem.disabled;
+                        if (isInputDisable === false) {
+                            this.provider.clear();
+                        }
                     }
                     close() {
                         if (this.provider.isOpen) {
@@ -18289,7 +18295,10 @@ var Providers;
                         }
                     }
                     clear() {
-                        this.provider.clear();
+                        const isInputDisable = this._timePickerProviderInputElem.disabled;
+                        if (isInputDisable === false) {
+                            this.provider.clear();
+                        }
                     }
                     close() {
                         if (this.provider.isOpen) {

--- a/dist/OutSystemsUI.js
+++ b/dist/OutSystemsUI.js
@@ -15478,7 +15478,8 @@ var Providers;
                         super.dispose();
                     }
                     open() {
-                        if (this.provider.isOpen === false) {
+                        const isInputDisable = this._datePickerPlatformInputElem.disabled;
+                        if (this.provider.isOpen === false && isInputDisable === false) {
                             this.provider.open();
                         }
                     }
@@ -17324,7 +17325,8 @@ var Providers;
                         super.dispose();
                     }
                     open() {
-                        if (this.provider.isOpen === false) {
+                        const isInputDisable = this._monthPickerProviderInputElem.disabled;
+                        if (this.provider.isOpen === false && isInputDisable === false) {
                             this.provider.open();
                         }
                     }
@@ -18307,7 +18309,8 @@ var Providers;
                         super.dispose();
                     }
                     open() {
-                        if (this.provider.isOpen === false) {
+                        const isInputDisable = this._timePickerProviderInputElem.disabled;
+                        if (this.provider.isOpen === false && isInputDisable === false) {
                             this.provider.open();
                         }
                     }

--- a/dist/OutSystemsUI.js
+++ b/dist/OutSystemsUI.js
@@ -15831,7 +15831,8 @@ var Providers;
                         }
                         updateInitialDate(startDate, endDate) {
                             if (OSFramework.OSUI.Helper.Dates.IsNull(startDate) === false &&
-                                OSFramework.OSUI.Helper.Dates.IsNull(endDate) === false) {
+                                OSFramework.OSUI.Helper.Dates.IsNull(endDate) === false &&
+                                this._datePickerPlatformInputElem.disabled === false) {
                                 this.configs.InitialStartDate = startDate;
                                 this.configs.InitialEndDate = endDate;
                                 if (OSFramework.OSUI.Helper.Dates.IsBeforeThan(startDate, endDate)) {
@@ -15991,9 +15992,11 @@ var Providers;
                             }
                         }
                         updateInitialDate(value) {
-                            this._isUpdatedInitialDateByClientAction = true;
-                            this.configs.InitialDate = value;
-                            this.prepareToAndRedraw();
+                            if (this._datePickerPlatformInputElem.disabled === false) {
+                                this._isUpdatedInitialDateByClientAction = true;
+                                this.configs.InitialDate = value;
+                                this.prepareToAndRedraw();
+                            }
                         }
                     }
                     SingleDate.OSUIFlatpickrSingleDate = OSUIFlatpickrSingleDate;
@@ -18358,8 +18361,10 @@ var Providers;
                         }
                     }
                     updateInitialTime(value) {
-                        this.configs.InitialTime = value;
-                        this.redraw();
+                        if (this._timePickerProviderInputElem.disabled === false) {
+                            this.configs.InitialTime = value;
+                            this.redraw();
+                        }
                     }
                 }
                 Flatpickr.OSUIFlatpickrTime = OSUIFlatpickrTime;

--- a/src/scripts/Providers/OSUI/Datepicker/Flatpickr/AbstractFlatpickr.ts
+++ b/src/scripts/Providers/OSUI/Datepicker/Flatpickr/AbstractFlatpickr.ts
@@ -415,7 +415,8 @@ namespace Providers.OSUI.Datepicker.Flatpickr {
 		 * @memberof Providers.OSUI.DatePicker.Flatpickr.AbstractFlatpickr
 		 */
 		public open(): void {
-			if (this.provider.isOpen === false) {
+			const isInputDisable = this._datePickerPlatformInputElem.disabled;
+			if (this.provider.isOpen === false && isInputDisable === false) {
 				this.provider.open();
 			}
 		}

--- a/src/scripts/Providers/OSUI/Datepicker/Flatpickr/AbstractFlatpickr.ts
+++ b/src/scripts/Providers/OSUI/Datepicker/Flatpickr/AbstractFlatpickr.ts
@@ -350,7 +350,10 @@ namespace Providers.OSUI.Datepicker.Flatpickr {
 		 * @memberof Providers.OSUI.DatePicker.Flatpickr.AbstractFlatpickr
 		 */
 		public clear(): void {
-			this.provider.clear();
+			const isInputDisable = this._datePickerPlatformInputElem.disabled;
+			if (isInputDisable === false) {
+				this.provider.clear();
+			}
 		}
 
 		/**

--- a/src/scripts/Providers/OSUI/Datepicker/Flatpickr/RangeDate/FlatpickrRangeDate.ts
+++ b/src/scripts/Providers/OSUI/Datepicker/Flatpickr/RangeDate/FlatpickrRangeDate.ts
@@ -171,7 +171,8 @@ namespace Providers.OSUI.Datepicker.Flatpickr.RangeDate {
 			// Ensure assigns only occurs if both dates are set!
 			if (
 				OSFramework.OSUI.Helper.Dates.IsNull(startDate) === false &&
-				OSFramework.OSUI.Helper.Dates.IsNull(endDate) === false
+				OSFramework.OSUI.Helper.Dates.IsNull(endDate) === false &&
+				this._datePickerPlatformInputElem.disabled === false
 			) {
 				// Redefine the Initial dates
 				this.configs.InitialStartDate = startDate;

--- a/src/scripts/Providers/OSUI/Datepicker/Flatpickr/SingleDate/FlatpickrSingleDate.ts
+++ b/src/scripts/Providers/OSUI/Datepicker/Flatpickr/SingleDate/FlatpickrSingleDate.ts
@@ -153,12 +153,14 @@ namespace Providers.OSUI.Datepicker.Flatpickr.SingleDate {
 		 * @memberof Providers.OSUI.DatePicker.Flatpickr.SingleDate.OSUIFlatpickrSingleDate
 		 */
 		public updateInitialDate(value: string): void {
-			// Enable Flag in order to prevent trigger OnDateSelected platform callback event
-			this._isUpdatedInitialDateByClientAction = true;
-			// Redefine the Initial date
-			this.configs.InitialDate = value;
-			// Redraw calendar!
-			this.prepareToAndRedraw();
+			if (this._datePickerPlatformInputElem.disabled === false) {
+				// Enable Flag in order to prevent trigger OnDateSelected platform callback event
+				this._isUpdatedInitialDateByClientAction = true;
+				// Redefine the Initial date
+				this.configs.InitialDate = value;
+				// Redraw calendar!
+				this.prepareToAndRedraw();
+			}
 		}
 	}
 }

--- a/src/scripts/Providers/OSUI/Monthpicker/Flatpickr/FlatpickrMonth.ts
+++ b/src/scripts/Providers/OSUI/Monthpicker/Flatpickr/FlatpickrMonth.ts
@@ -335,7 +335,8 @@ namespace Providers.OSUI.MonthPicker.Flatpickr {
 		 * @memberof Providers.OSUI.MonthPicker.Flatpickr.OSUIFlatpickrMonth
 		 */
 		public open(): void {
-			if (this.provider.isOpen === false) {
+			const isInputDisable = this._monthPickerProviderInputElem.disabled;
+			if (this.provider.isOpen === false && isInputDisable === false) {
 				this.provider.open();
 			}
 		}

--- a/src/scripts/Providers/OSUI/Monthpicker/Flatpickr/FlatpickrMonth.ts
+++ b/src/scripts/Providers/OSUI/Monthpicker/Flatpickr/FlatpickrMonth.ts
@@ -293,7 +293,10 @@ namespace Providers.OSUI.MonthPicker.Flatpickr {
 		 * @memberof Providers.OSUI.MonthPicker.Flatpickr.OSUIFlatpickrMonth
 		 */
 		public clear(): void {
-			this.provider.clear();
+			const isInputDisable = this._monthPickerProviderInputElem.disabled;
+			if (isInputDisable === false) {
+				this.provider.clear();
+			}
 		}
 
 		/**

--- a/src/scripts/Providers/OSUI/Timepicker/Flatpickr/FlatpickrTime.ts
+++ b/src/scripts/Providers/OSUI/Timepicker/Flatpickr/FlatpickrTime.ts
@@ -308,7 +308,8 @@ namespace Providers.OSUI.TimePicker.Flatpickr {
 		 * @memberof Providers.OSUI.TimePicker.Flatpickr.OSUIFlatpickrTime
 		 */
 		public open(): void {
-			if (this.provider.isOpen === false) {
+			const isInputDisable = this._timePickerProviderInputElem.disabled;
+			if (this.provider.isOpen === false && isInputDisable === false) {
 				this.provider.open();
 			}
 		}

--- a/src/scripts/Providers/OSUI/Timepicker/Flatpickr/FlatpickrTime.ts
+++ b/src/scripts/Providers/OSUI/Timepicker/Flatpickr/FlatpickrTime.ts
@@ -395,10 +395,12 @@ namespace Providers.OSUI.TimePicker.Flatpickr {
 		 * @memberof OSUIFlatpickrTime
 		 */
 		public updateInitialTime(value: string): void {
-			// Redefine the Initial time
-			this.configs.InitialTime = value;
-			// Trigger the Redraw method in order to update calendar with this new value
-			this.redraw();
+			if (this._timePickerProviderInputElem.disabled === false) {
+				// Redefine the Initial time
+				this.configs.InitialTime = value;
+				// Trigger the Redraw method in order to update calendar with this new value
+				this.redraw();
+			}
 		}
 	}
 }

--- a/src/scripts/Providers/OSUI/Timepicker/Flatpickr/FlatpickrTime.ts
+++ b/src/scripts/Providers/OSUI/Timepicker/Flatpickr/FlatpickrTime.ts
@@ -266,7 +266,10 @@ namespace Providers.OSUI.TimePicker.Flatpickr {
 		 * @memberof Providers.OSUI.TimePicker.Flatpickr.OSUIFlatpickrTime
 		 */
 		public clear(): void {
-			this.provider.clear();
+			const isInputDisable = this._timePickerProviderInputElem.disabled;
+			if (isInputDisable === false) {
+				this.provider.clear();
+			}
 		}
 
 		/**


### PR DESCRIPTION
This PR is for fix pickers opening via Open Client Action when disabled.

### What was happening
- When the input is disabled, the Pickers can still be opened by using the Open API Client Actions, and the patterns works and changes dates after that.

### What was done
- Add validation to check if the input is disabled before run the provider's open, clear and update methods.

### Test Steps
1. Go to a test page with a DatePicker
2. Disable the DatePicker input
3. Run the pattern's Open, Clear and Update Client Actions.

### Checklist
-   [x] tested locally
-   [x] documented the code
-   [x] clean all warnings and errors of eslint
-   [ ] requires changes in OutSystems (if so, provide a module with changes)
-   [ ] requires new sample page in OutSystems (if so, provide a module with changes)
