### PR TITLE
Fixed AbstractNormalizeProviderConfigs

### DIFF
--- a/dist/OutSystemsUI.js
+++ b/dist/OutSystemsUI.js
@@ -14719,9 +14719,11 @@ var OutSystems;
                     if ((htmlElementsProps === null || htmlElementsProps === void 0 ? void 0 : htmlElementsProps.indexOf(keyName)) > -1) {
                         providerConfigs[keyName] = OSFramework.OSUI.Helper.Dom.GetElementById(keyValue);
                     }
-                    keyValue = keyValue.toLowerCase().trim();
-                    if (keyValue === 'true' || keyValue === 'false') {
-                        providerConfigs[keyName] = keyValue === 'true';
+                    else {
+                        keyValue = keyValue.toLowerCase().trim();
+                        if (keyValue === 'true' || keyValue === 'false') {
+                            providerConfigs[keyName] = keyValue === 'true';
+                        }
                     }
                 }
                 return providerConfigs;

--- a/dist/OutSystemsUI.js
+++ b/dist/OutSystemsUI.js
@@ -14716,12 +14716,12 @@ var OutSystems;
                     if (typeof keyValue !== 'string') {
                         continue;
                     }
+                    if ((htmlElementsProps === null || htmlElementsProps === void 0 ? void 0 : htmlElementsProps.indexOf(keyName)) > -1) {
+                        providerConfigs[keyName] = OSFramework.OSUI.Helper.Dom.GetElementById(keyValue);
+                    }
                     keyValue = keyValue.toLowerCase().trim();
                     if (keyValue === 'true' || keyValue === 'false') {
                         providerConfigs[keyName] = keyValue === 'true';
-                    }
-                    if ((htmlElementsProps === null || htmlElementsProps === void 0 ? void 0 : htmlElementsProps.indexOf(keyName)) > -1) {
-                        providerConfigs[keyName] = OSFramework.OSUI.Helper.Dom.GetElementById(keyValue);
                     }
                 }
                 return providerConfigs;

--- a/src/scripts/OutSystems/OSUI/Utils/NormalizeProviderConfigs.ts
+++ b/src/scripts/OutSystems/OSUI/Utils/NormalizeProviderConfigs.ts
@@ -24,13 +24,13 @@ namespace OutSystems.OSUI.Utils {
 			// Check if type is HTMLElement, if so then get the Element from the DOM, using the elementId passed
 			if (htmlElementsProps?.indexOf(keyName) > -1) {
 				providerConfigs[keyName] = OSFramework.OSUI.Helper.Dom.GetElementById(keyValue);
-			}
+			} else {
+				// Trim and apply lower case to match the boolean data type
+				keyValue = keyValue.toLowerCase().trim();
 
-			// Trim and apply lower case to match the boolean data type
-			keyValue = keyValue.toLowerCase().trim();
-
-			if (keyValue === 'true' || keyValue === 'false') {
-				providerConfigs[keyName] = keyValue === 'true';
+				if (keyValue === 'true' || keyValue === 'false') {
+					providerConfigs[keyName] = keyValue === 'true';
+				}
 			}
 		}
 

--- a/src/scripts/OutSystems/OSUI/Utils/NormalizeProviderConfigs.ts
+++ b/src/scripts/OutSystems/OSUI/Utils/NormalizeProviderConfigs.ts
@@ -21,15 +21,16 @@ namespace OutSystems.OSUI.Utils {
 				continue;
 			}
 
+			// Check if type is HTMLElement, if so then get the Element from the DOM, using the elementId passed
+			if (htmlElementsProps?.indexOf(keyName) > -1) {
+				providerConfigs[keyName] = OSFramework.OSUI.Helper.Dom.GetElementById(keyValue);
+			}
+
+			// Trim and apply lower case to match the boolean data type
 			keyValue = keyValue.toLowerCase().trim();
 
 			if (keyValue === 'true' || keyValue === 'false') {
 				providerConfigs[keyName] = keyValue === 'true';
-			}
-
-			// Check if type is HTMLElement, if so then get the Element from the DOM, using the elementId passed
-			if (htmlElementsProps?.indexOf(keyName) > -1) {
-				providerConfigs[keyName] = OSFramework.OSUI.Helper.Dom.GetElementById(keyValue);
 			}
 		}
 


### PR DESCRIPTION
This PR is to fix the method AbstractNormalizeProviderConfigs for the scenario where we are dealing with the type HTMLElement. If so then get the element from the DOM, using the elementId passed and by having keyValue.toLowerCase().trim() first was causing errors while trying to run this operation.

### What was happening

-  By having keyValue.toLowerCase().trim() first was causing errors while trying to get the Element from the DOM, using the elementId passed.

### What was done

- Changed the order of the validations to check first for the HTML Element.

### Test Steps

1. Go to the Date Picker and Date Range functional test screens.
2. In the extensibility configurations set the attribute positionElement = "b3-b59-b14-Content".
3. Click apply (where we're calling SetFlatpickrConfigs client action).
4. Opened the Date Picker.
5. Checked that it was opened on the element with the id = "b3-b59-b14-Content" in the DOM.



### Checklist

-   [X] tested locally
-   [X] documented the code
-   [X] clean all warnings and errors of eslint
-   [ ] requires changes in OutSystems (if so, provide a module with changes)
-   [ ] requires new sample page in OutSystems (if so, provide a module with changes)
