### PR TITLE
[ROU-4158] - Fix an issue related with the UpdateInitialDate API method.

### DIFF
--- a/src/scripts/Providers/OSUI/Datepicker/Flatpickr/AbstractFlatpickr.ts
+++ b/src/scripts/Providers/OSUI/Datepicker/Flatpickr/AbstractFlatpickr.ts
@@ -185,7 +185,7 @@ namespace Providers.OSUI.Datepicker.Flatpickr {
 		}
 
 		/**
-		 * Method that will set the provider configurations in order to properly create its instance
+		 * The method used to prepare the pattern before being redrawn in order to prevent possible flickering.
 		 *
 		 * @protected
 		 * @memberof Providers.OSUI.DatePicker.Flatpickr.AbstractFlatpickr

--- a/src/scripts/Providers/OSUI/Datepicker/Flatpickr/SingleDate/FlatpickrSingleDate.ts
+++ b/src/scripts/Providers/OSUI/Datepicker/Flatpickr/SingleDate/FlatpickrSingleDate.ts
@@ -41,7 +41,7 @@ namespace Providers.OSUI.Datepicker.Flatpickr.SingleDate {
 		}
 
 		/**
-		 * Method used to prepare pattern before being redrawed in order to prevent possible flickerings!
+		 * The method used to prepare the pattern before being redrawn in order to prevent possible flickering.
 		 *
 		 * @protected
 		 * @memberof Providers.OSUI.DatePicker.Flatpickr.SingleDate.OSUIFlatpickrSingleDate

--- a/src/scripts/Providers/OSUI/Datepicker/Flatpickr/SingleDate/FlatpickrSingleDate.ts
+++ b/src/scripts/Providers/OSUI/Datepicker/Flatpickr/SingleDate/FlatpickrSingleDate.ts
@@ -41,6 +41,19 @@ namespace Providers.OSUI.Datepicker.Flatpickr.SingleDate {
 		}
 
 		/**
+		 * Method used to prepare pattern before being redrawed in order to prevent possible flickerings!
+		 *
+		 * @protected
+		 * @memberof Providers.OSUI.DatePicker.Flatpickr.SingleDate.OSUIFlatpickrSingleDate
+		 */
+		protected prepareToAndRedraw(): void {
+			// Ensure the Flag value is reset at the redraw!
+			this._isUpdatedInitialDateByClientAction = false;
+
+			super.prepareToAndRedraw();
+		}
+
+		/**
 		 * Trigger the jumToDate to now and trigger the Now as a selected Date!
 		 *
 		 * @protected
@@ -75,7 +88,6 @@ namespace Providers.OSUI.Datepicker.Flatpickr.SingleDate {
 				dateType
 			);
 		}
-
 		/**
 		 * Builds the Pattern
 		 *

--- a/src/scripts/Providers/OSUI/Datepicker/Flatpickr/SingleDate/FlatpickrSingleDate.ts
+++ b/src/scripts/Providers/OSUI/Datepicker/Flatpickr/SingleDate/FlatpickrSingleDate.ts
@@ -170,6 +170,11 @@ namespace Providers.OSUI.Datepicker.Flatpickr.SingleDate {
 				this._isUpdatedInitialDateByClientAction = true;
 				// Redefine the Initial date
 				this.configs.InitialDate = value;
+				// Redefine the value that is assigned to the input, since pattern will be redrawed it will be based on that value as well
+				OSFramework.OSUI.Helper.Dom.SetInputValue(
+					this._datePickerPlatformInputElem,
+					this.provider.formatDate(value, this._flatpickrOpts.dateFormat)
+				);
 				// Redraw calendar!
 				this.prepareToAndRedraw();
 			}


### PR DESCRIPTION
This PR is for fixing an issue related with the redraw that happen when he **UpdateInitialDate** API method is triggered, since the **onDateSelectedEvent** method will not be fired at the redraw, the **_isUpdatedInitialDateByClientAction** property will not be updated.