### PR TITLE
ROU-4139: MonthPicker/Timepicker input enable issue in runtime

### DIFF
--- a/src/scripts/OSFramework/OSUI/Pattern/MonthPicker/scss/_monthpicker.scss
+++ b/src/scripts/OSFramework/OSUI/Pattern/MonthPicker/scss/_monthpicker.scss
@@ -44,6 +44,16 @@
 	.not-valid + .flatpickr-mobile {
 		border-color: var(--color-error);
 	}
+
+	input {
+		// Disable states for Datepicker
+		&.flatpickr-input[disabled] + input {
+			background-color: var(--color-neutral-2);
+			border: var(--border-size-s) solid var(--color-neutral-4);
+			color: var(--color-neutral-6);
+			pointer-events: none;
+		}
+	}
 }
 
 ///

--- a/src/scripts/Providers/OSUI/Monthpicker/Flatpickr/FlatpickrMonth.ts
+++ b/src/scripts/Providers/OSUI/Monthpicker/Flatpickr/FlatpickrMonth.ts
@@ -38,6 +38,14 @@ namespace Providers.OSUI.MonthPicker.Flatpickr {
 				OSFramework.OSUI.GlobalEnum.HTMLAttributes.DataInput,
 				OSFramework.OSUI.Constants.EmptyString
 			);
+
+			// If the provider cloned a disabled platform input, remove the disable attribute form the provider input
+			if (this._flatpickrInputElem.disabled) {
+				OSFramework.OSUI.Helper.Dom.Attribute.Remove(
+					this._flatpickrInputElem,
+					OSFramework.OSUI.GlobalEnum.HTMLAttributes.Disabled
+				);
+			}
 		}
 
 		// Method used to set the CSS classes to the pattern HTML elements

--- a/src/scripts/Providers/OSUI/Timepicker/Flatpickr/FlatpickrTime.ts
+++ b/src/scripts/Providers/OSUI/Timepicker/Flatpickr/FlatpickrTime.ts
@@ -36,8 +36,16 @@ namespace Providers.OSUI.TimePicker.Flatpickr {
 			OSFramework.OSUI.Helper.Dom.Attribute.Set(
 				this._flatpickrInputElem,
 				OSFramework.OSUI.GlobalEnum.HTMLAttributes.DataInput,
-				''
+				OSFramework.OSUI.Constants.EmptyString
 			);
+
+			// If the provider cloned a disabled platform input, remove the disable attribute form the provider input
+			if (this._flatpickrInputElem.disabled) {
+				OSFramework.OSUI.Helper.Dom.Attribute.Remove(
+					this._flatpickrInputElem,
+					OSFramework.OSUI.GlobalEnum.HTMLAttributes.Disabled
+				);
+			}
 		}
 
 		// Method used to set the CSS classes to the pattern HTML elements


### PR DESCRIPTION
This PR is for when toggling the input to enable/disable in runtime, the pattern doesn’t react to the change.

### What was done
- Remove the disabled attribute from the cloned provider input.

### Test Steps
1. Go to the test page
2. Toggle the Enable of the Time/MonthPicker's platfrm input
3. Check if the Time/MonthPicker reacts as expected.

### Checklist

-   [x] tested locally
-   [x] documented the code
-   [x] clean all warnings and errors of eslint
-   [ ] requires changes in OutSystems (if so, provide a module with changes)
-   [ ] requires new sample page in OutSystems (if so, provide a module with changes)
