### PR TITLE
ROU-4198: Input inside tabs issue

### DIFF
--- a/src/scripts/OSFramework/OSUI/Pattern/Tabs/Tabs.ts
+++ b/src/scripts/OSFramework/OSUI/Pattern/Tabs/Tabs.ts
@@ -203,9 +203,7 @@ namespace OSFramework.OSUI.Patterns.Tabs {
 		private _handleKeypressEvent(e: KeyboardEvent): void {
 			let targetHeaderItemIndex;
 			// Check if target is the header, to do not change tab on x arrow press
-			const isHeaderTarget = e.target === this._activeTabHeaderElement.selfElement;
-
-			if (!isHeaderTarget) {
+			if (e.target !== this._activeTabHeaderElement.selfElement) {
 				return;
 			}
 

--- a/src/scripts/OSFramework/OSUI/Pattern/Tabs/Tabs.ts
+++ b/src/scripts/OSFramework/OSUI/Pattern/Tabs/Tabs.ts
@@ -202,34 +202,36 @@ namespace OSFramework.OSUI.Patterns.Tabs {
 		// Method that handles the Keypress Event, for tabs navigation using arrows
 		private _handleKeypressEvent(e: KeyboardEvent): void {
 			let targetHeaderItemIndex;
-			// Check oif target is content, to preventDefault and not change tabe on x arrow press
-			const isContentTarget = e.target === this._activeTabContentElement.selfElement;
+			// Check if target is the header, to do not change tab on x arrow press
+			const isHeaderTarget = e.target === this._activeTabHeaderElement.selfElement;
+
+			if (!isHeaderTarget) {
+				return;
+			}
 
 			switch (e.key) {
 				case GlobalEnum.Keycodes.ArrowRight:
-					if (isContentTarget) {
-						e.preventDefault();
-						return;
-					}
 					// If is right arrow, navigate to current active tabs + 1 (next item)
 					targetHeaderItemIndex = this.configs.StartingTab + 1;
-					// To prevent triggerinh changeTab, if already on last item
-					if (targetHeaderItemIndex < this.getChildItems(Enum.ChildTypes.TabsHeaderItem).length) {
-						this.changeTab(targetHeaderItemIndex, undefined, true);
+
+					// If in last item, change to the first
+					if (targetHeaderItemIndex >= this.getChildItems(Enum.ChildTypes.TabsHeaderItem).length) {
+						targetHeaderItemIndex = 0;
 					}
 
+					this.changeTab(targetHeaderItemIndex, undefined, true);
 					break;
 				case GlobalEnum.Keycodes.ArrowLeft:
-					if (isContentTarget) {
-						e.preventDefault();
-						return;
-					}
 					// If is left arrow, navigate to current active tabs - 1 (previous item)
 					targetHeaderItemIndex = this.configs.StartingTab - 1;
+
 					// To prevent triggering changeTab, if already on first item
-					if (targetHeaderItemIndex >= 0) {
-						this.changeTab(targetHeaderItemIndex, undefined, true);
+					if (targetHeaderItemIndex < 0) {
+						// If in first item, change to the last
+						targetHeaderItemIndex = this.getChildItems(Enum.ChildTypes.TabsHeaderItem).length - 1;
 					}
+
+					this.changeTab(targetHeaderItemIndex, undefined, true);
 					break;
 			}
 
@@ -242,7 +244,7 @@ namespace OSFramework.OSUI.Patterns.Tabs {
 		}
 
 		// Method to adjust the tabs css active item on resize or orientation-change
-		private _handleOnResizeEvend(): void {
+		private _handleOnResizeEvent(): void {
 			this._scrollToTargetContent(this._activeTabContentElement);
 			Helper.AsyncInvocation(this._handleTabIndicator.bind(this));
 		}
@@ -708,7 +710,7 @@ namespace OSFramework.OSUI.Patterns.Tabs {
 		 */
 		protected setCallbacks(): void {
 			this._eventOnHeaderKeypress = this._handleKeypressEvent.bind(this);
-			this._eventOnResize = this._handleOnResizeEvend.bind(this);
+			this._eventOnResize = this._handleOnResizeEvent.bind(this);
 			this._addEvents();
 		}
 

--- a/src/scripts/OSFramework/OSUI/Pattern/Tabs/scss/_tabs.scss
+++ b/src/scripts/OSFramework/OSUI/Pattern/Tabs/scss/_tabs.scss
@@ -144,6 +144,7 @@
 	&--has-drag:not(.osui-tabs--is-vertical) {
 		.osui-tabs__content {
 			overflow-x: auto;
+			scroll-snap-type: x mandatory;
 		}
 	}
 
@@ -214,7 +215,6 @@
 		overflow: hidden;
 		overscroll-behavior-x: contain;
 		position: relative;
-		scroll-snap-type: x mandatory;
 		width: 100%;
 
 		&::-webkit-scrollbar {


### PR DESCRIPTION
This PR is for fix input inside tabs issue and accessibility issues:
- Fix the tabs changing when using arrow keys in tabs content
- Add behavior that moves focus to the first tab, when arrow right is pressed when the focus is on the last tab
- Add behavior that moves focus to the last tab, when arrow left is pressed when the focus is on the first tab

### What was happening
- The tabs changed when using the arrow keys to move the cursor position of an input inside the tab content. 

### What was done
- Change `_handleKeypressEvent` to validate if the key press event targetElement is the active header tab.
   - If true, then change tabs.
   - If false, then do nothing.
- Change `_handleKeypressEvent` to change to the first tab if last the active header tab and the right key was pressed.
- Change `_handleKeypressEvent` to change to the last tab if first the active header tab and the left key was pressed.
- Removed `scroll-snap-type: x mandatory;` from general `osui-tabs__content` and moved to `--has-drag.osui-tabs__content` selector
- 
### Test Steps
1. Go to a test page with inputs inside content tabs
2. Write something in the input
3. Try to move the cursor position in the input
Expected: The tabs should not change

1. Go to a test page with tabs
2. Select the active tab header
3. Press arrow left and arrow right
Expected: the tabs change as expected.

### Checklist

-   [x] tested locally
-   [x] documented the code
-   [x] clean all warnings and errors of eslint
-   [ ] requires changes in OutSystems (if so, provide a module with changes)
-   [ ] requires new sample page in OutSystems (if so, provide a module with changes)
