### PR TITLE
ROU-4142: Fix tabs display on servicestudio only

### DIFF
--- a/src/scripts/OSFramework/OSUI/Pattern/Tabs/scss/_tabs.scss
+++ b/src/scripts/OSFramework/OSUI/Pattern/Tabs/scss/_tabs.scss
@@ -257,6 +257,9 @@
 			-servicestudio-border: 1px dashed var(--color-neutral-5);
 			-servicestudio-width: 100%;
 		}
+		.osui-tabs__content-item .display-contents {
+			-servicestudio-display: block;
+		}
 	}
 }
 


### PR DESCRIPTION
This PR is for fix tabs display on servicestudio only.

### What was happening
- It was not possible to drag and drop content to the tabs placeholder in service studio preview.

### What was done
- Cherry picking from ODC branch:
   - Adds the -servicestudio-display tag to change the display only inside the servicestudio.

### Test Steps
1. Go to Service Studio
2. Drag a button to the Tabs' content placeholder
Expected: The button appears in Tabs' content

### Checklist

-   [x] tested locally
-   [ ] documented the code
-   [ ] clean all warnings and errors of eslint
-   [ ] requires changes in OutSystems (if so, provide a module with changes)
-   [ ] requires new sample page in OutSystems (if so, provide a module with changes)
