### PR TITLE
ROU-4210: fixed rating inside tabs

### DIFF
--- a/dist/OutSystemsUI.css
+++ b/dist/OutSystemsUI.css
@@ -12211,6 +12211,10 @@ html[data-uieditorversion^="1"] .wizard-wrapper-item{
   -webkit-box-shadow:0 0 0 3px var(--color-focus-outer);
           box-shadow:0 0 0 3px var(--color-focus-outer);
 }
+.chrome .osui-tabs .rating .wcag-hide-text,
+.edge .osui-tabs .rating .wcag-hide-text{
+  margin:unset;
+}
 /*! 6.6. Utilities */
 /*! 6.6.1. Align Center */
 .vertical-align{

--- a/src/scripts/OSFramework/OSUI/Pattern/Rating/scss/_rating.scss
+++ b/src/scripts/OSFramework/OSUI/Pattern/Rating/scss/_rating.scss
@@ -196,3 +196,15 @@
 		box-shadow: 0 0 0 3px var(--color-focus-outer);
 	}
 }
+
+// Fix issue on chromium based browsers, related with css snap and the complex combination of HTML and CSS properties used by the Rating
+.chrome,
+.edge {
+	.osui-tabs {
+		.rating {
+			.wcag-hide-text {
+				margin: unset;
+			}
+		}
+	}
+} 


### PR DESCRIPTION
This PR is for fixing an issue on chromium browsers when using the Rating inside the new tabs pattern.

### Checklist

-   [x] tested locally
-   [x] documented the code
-   [x] clean all warnings and errors of eslint
-   [x] requires changes in OutSystems (if so, provide a module with changes)
-   [ ] requires new sample page in OutSystems (if so, provide a module with changes)
