### PR TITLE
ROU-4212: Increase area of dropping elements on tabs

### DIFF
--- a/dist/OutSystemsUI.css
+++ b/dist/OutSystemsUI.css
@@ -11411,6 +11411,9 @@ html[data-uieditorversion^="1"] .osui-timepicker__dropdown-ss-preview.time12h, h
   -servicestudio-display:block !important;
   -servicestudio-margin-bottom:var(--space-m);
 }
+.osui-tabs__content-item div:empty{
+  -servicestudio-padding:var(--space-m);
+}
 .osui-tabs__content-item .columns{
   max-width:99.99%;
 }

--- a/src/scripts/OSFramework/OSUI/Pattern/Tabs/scss/_tabs.scss
+++ b/src/scripts/OSFramework/OSUI/Pattern/Tabs/scss/_tabs.scss
@@ -234,6 +234,10 @@
 				-servicestudio-margin-bottom: var(--space-m);
 			}
 
+			& div:empty {
+				-servicestudio-padding: var(--space-m);
+			}
+
 			// This selector is used to prevent render issues on chrome, in some screen-sizes, due to overflow hidden and css snap
 			.columns {
 				max-width: 99.99%;

--- a/src/scripts/OSFramework/OSUI/Pattern/Tabs/scss/_tabs.scss
+++ b/src/scripts/OSFramework/OSUI/Pattern/Tabs/scss/_tabs.scss
@@ -232,10 +232,10 @@
 			& {
 				-servicestudio-display: block !important;
 				-servicestudio-margin-bottom: var(--space-m);
-			}
 
-			& div:empty {
-				-servicestudio-padding: var(--space-m);
+				div:empty {
+					-servicestudio-padding: var(--space-m);
+				}
 			}
 
 			// This selector is used to prevent render issues on chrome, in some screen-sizes, due to overflow hidden and css snap


### PR DESCRIPTION
This PR is for increase the area of dropping elements on tabs content. Please check the JIRA issue for more information

### What was happening
- Now the area to drag and drop elements is to short;

### What was done
- The area of dropping elements on content tabs was increase only when is empty;

### Screenshots
Previous:
![image](https://user-images.githubusercontent.com/25321845/227188449-5f9e2c1d-541a-46d2-bc1d-4f59af37781c.png)

After:
![image](https://user-images.githubusercontent.com/25321845/227188525-26582963-9258-42cd-aa47-8a24e5f81d22.png)

### Checklist
-   [X] tested locally
-   [X] documented the code
-   [X] clean all warnings and errors of eslint
-   [ ] requires changes in OutSystems (if so, provide a module with changes)
-   [ ] requires new sample page in OutSystems (if so, provide a module with changes)
