### PR TITLE
ROU-4217: Allow firing the List OnScrollEnding inside Tabs

### DIFF
--- a/dist/OutSystemsUI.css
+++ b/dist/OutSystemsUI.css
@@ -11402,7 +11402,6 @@ html[data-uieditorversion^="1"] .osui-timepicker__dropdown-ss-preview.time12h, h
 }
 .osui-tabs__content-item{
   height:100%;
-  overflow-y:auto;
   padding:var(--space-m) var(--space-none);
   scroll-snap-align:start;
   scroll-snap-stop:always;

--- a/dist/OutSystemsUI.css
+++ b/dist/OutSystemsUI.css
@@ -11402,6 +11402,7 @@ html[data-uieditorversion^="1"] .osui-timepicker__dropdown-ss-preview.time12h, h
 }
 .osui-tabs__content-item{
   height:100%;
+  overflow-y:var(--tabs-content-item-overflow);
   padding:var(--space-m) var(--space-none);
   scroll-snap-align:start;
   scroll-snap-stop:always;

--- a/dist/OutSystemsUI.d.ts
+++ b/dist/OutSystemsUI.d.ts
@@ -222,9 +222,10 @@ declare namespace OSFramework.OSUI.GlobalEnum {
         TopRight = "top-right"
     }
     enum CssProperties {
+        Auto = "auto",
+        Initial = "initial",
         None = "none",
-        PaddingTop = "padding-top",
-        Auto = "auto"
+        PaddingTop = "padding-top"
     }
     enum DataBlocksTag {
         DataBlock = "[data-block]",
@@ -2901,8 +2902,9 @@ declare namespace OSFramework.OSUI.Patterns.Tabs.Enum {
         DataDirection = "data-direction"
     }
     enum CssProperty {
-        TabsHeight = "--tabs-height",
+        TabsContentItemOverflow = "--tabs-content-item-overflow",
         TabsHeaderItems = "--tabs-header-items",
+        TabsHeight = "--tabs-height",
         TabsIndicatorScale = "--tabs-indicator-scale",
         TabsIndicatorTransform = "--tabs-indicator-transform"
     }

--- a/dist/OutSystemsUI.js
+++ b/dist/OutSystemsUI.js
@@ -289,9 +289,10 @@ var OSFramework;
             })(Position = GlobalEnum.Position || (GlobalEnum.Position = {}));
             let CssProperties;
             (function (CssProperties) {
+                CssProperties["Auto"] = "auto";
+                CssProperties["Initial"] = "initial";
                 CssProperties["None"] = "none";
                 CssProperties["PaddingTop"] = "padding-top";
-                CssProperties["Auto"] = "auto";
             })(CssProperties = GlobalEnum.CssProperties || (GlobalEnum.CssProperties = {}));
             let DataBlocksTag;
             (function (DataBlocksTag) {
@@ -8684,8 +8685,9 @@ var OSFramework;
                     })(Attributes = Enum.Attributes || (Enum.Attributes = {}));
                     let CssProperty;
                     (function (CssProperty) {
-                        CssProperty["TabsHeight"] = "--tabs-height";
+                        CssProperty["TabsContentItemOverflow"] = "--tabs-content-item-overflow";
                         CssProperty["TabsHeaderItems"] = "--tabs-header-items";
+                        CssProperty["TabsHeight"] = "--tabs-height";
                         CssProperty["TabsIndicatorScale"] = "--tabs-indicator-scale";
                         CssProperty["TabsIndicatorTransform"] = "--tabs-indicator-transform";
                     })(CssProperty = Enum.CssProperty || (Enum.CssProperty = {}));
@@ -9004,7 +9006,11 @@ var OSFramework;
                         OSUI.Helper.Dom.Styles.SetStyleAttribute(this.selfElement, Tabs_1.Enum.CssProperty.TabsHeaderItems, itemsLength);
                     }
                     _setHeight(height) {
+                        const tabsOverflow = height !== OSUI.GlobalEnum.CssProperties.Auto || ''
+                            ? OSUI.GlobalEnum.CssProperties.Auto
+                            : OSUI.GlobalEnum.CssProperties.Initial;
                         OSUI.Helper.Dom.Styles.SetStyleAttribute(this.selfElement, Tabs_1.Enum.CssProperty.TabsHeight, height);
+                        OSUI.Helper.Dom.Styles.SetStyleAttribute(this.selfElement, Tabs_1.Enum.CssProperty.TabsContentItemOverflow, tabsOverflow);
                     }
                     _setInitialOptions() {
                         this._setHeaderItemsCustomProperty(this.getChildItems(Tabs_1.Enum.ChildTypes.TabsHeaderItem).length);

--- a/dist/OutSystemsUI.js
+++ b/dist/OutSystemsUI.js
@@ -9006,9 +9006,9 @@ var OSFramework;
                         OSUI.Helper.Dom.Styles.SetStyleAttribute(this.selfElement, Tabs_1.Enum.CssProperty.TabsHeaderItems, itemsLength);
                     }
                     _setHeight(height) {
-                        const tabsOverflow = height !== OSUI.GlobalEnum.CssProperties.Auto || ''
-                            ? OSUI.GlobalEnum.CssProperties.Auto
-                            : OSUI.GlobalEnum.CssProperties.Initial;
+                        const tabsOverflow = height === OSUI.GlobalEnum.CssProperties.Auto || ''
+                            ? OSUI.GlobalEnum.CssProperties.Initial
+                            : OSUI.GlobalEnum.CssProperties.Auto;
                         OSUI.Helper.Dom.Styles.SetStyleAttribute(this.selfElement, Tabs_1.Enum.CssProperty.TabsHeight, height);
                         OSUI.Helper.Dom.Styles.SetStyleAttribute(this.selfElement, Tabs_1.Enum.CssProperty.TabsContentItemOverflow, tabsOverflow);
                     }

--- a/dist/OutSystemsUI.js
+++ b/dist/OutSystemsUI.js
@@ -9006,7 +9006,7 @@ var OSFramework;
                         OSUI.Helper.Dom.Styles.SetStyleAttribute(this.selfElement, Tabs_1.Enum.CssProperty.TabsHeaderItems, itemsLength);
                     }
                     _setHeight(height) {
-                        const tabsOverflow = height === OSUI.GlobalEnum.CssProperties.Auto || ''
+                        const tabsOverflow = height === OSUI.GlobalEnum.CssProperties.Auto || height === OSUI.Constants.EmptyString
                             ? OSUI.GlobalEnum.CssProperties.Initial
                             : OSUI.GlobalEnum.CssProperties.Auto;
                         OSUI.Helper.Dom.Styles.SetStyleAttribute(this.selfElement, Tabs_1.Enum.CssProperty.TabsHeight, height);

--- a/src/scripts/OSFramework/OSUI/GlobalEnum.ts
+++ b/src/scripts/OSFramework/OSUI/GlobalEnum.ts
@@ -73,9 +73,10 @@ namespace OSFramework.OSUI.GlobalEnum {
 	 * OutSystemsUI elements CSS properties
 	 */
 	export enum CssProperties {
+		Auto = 'auto',
+		Initial = 'initial',
 		None = 'none',
 		PaddingTop = 'padding-top',
-		Auto = 'auto',
 	}
 
 	/**

--- a/src/scripts/OSFramework/OSUI/Pattern/Tabs/Enum.ts
+++ b/src/scripts/OSFramework/OSUI/Pattern/Tabs/Enum.ts
@@ -45,8 +45,9 @@ namespace OSFramework.OSUI.Patterns.Tabs.Enum {
 	 * Tabs Enum for CSS Custom Properties
 	 */
 	export enum CssProperty {
-		TabsHeight = '--tabs-height',
+		TabsContentItemOverflow = '--tabs-content-item-overflow',
 		TabsHeaderItems = '--tabs-header-items',
+		TabsHeight = '--tabs-height',
 		TabsIndicatorScale = '--tabs-indicator-scale',
 		TabsIndicatorTransform = '--tabs-indicator-transform',
 	}

--- a/src/scripts/OSFramework/OSUI/Pattern/Tabs/Tabs.ts
+++ b/src/scripts/OSFramework/OSUI/Pattern/Tabs/Tabs.ts
@@ -519,7 +519,7 @@ namespace OSFramework.OSUI.Patterns.Tabs {
 		private _setHeight(height: string): void {
 			// Set tabs overflow based on height
 			const tabsOverflow =
-				height === GlobalEnum.CssProperties.Auto || ''
+				height === GlobalEnum.CssProperties.Auto || height === Constants.EmptyString
 					? GlobalEnum.CssProperties.Initial
 					: GlobalEnum.CssProperties.Auto;
 

--- a/src/scripts/OSFramework/OSUI/Pattern/Tabs/Tabs.ts
+++ b/src/scripts/OSFramework/OSUI/Pattern/Tabs/Tabs.ts
@@ -517,8 +517,19 @@ namespace OSFramework.OSUI.Patterns.Tabs {
 
 		// Method to set the Tabs Height
 		private _setHeight(height: string): void {
-			// Create css variable
+			// Set tabs overflow based on height
+			const tabsOverflow =
+				height !== GlobalEnum.CssProperties.Auto || ''
+					? GlobalEnum.CssProperties.Auto
+					: GlobalEnum.CssProperties.Initial;
+
+			// Create css variables
 			Helper.Dom.Styles.SetStyleAttribute(this.selfElement, Enum.CssProperty.TabsHeight, height);
+			Helper.Dom.Styles.SetStyleAttribute(
+				this.selfElement,
+				Enum.CssProperty.TabsContentItemOverflow,
+				tabsOverflow
+			);
 		}
 
 		// Method to set the initial options on screen load

--- a/src/scripts/OSFramework/OSUI/Pattern/Tabs/Tabs.ts
+++ b/src/scripts/OSFramework/OSUI/Pattern/Tabs/Tabs.ts
@@ -519,9 +519,9 @@ namespace OSFramework.OSUI.Patterns.Tabs {
 		private _setHeight(height: string): void {
 			// Set tabs overflow based on height
 			const tabsOverflow =
-				height !== GlobalEnum.CssProperties.Auto || ''
-					? GlobalEnum.CssProperties.Auto
-					: GlobalEnum.CssProperties.Initial;
+				height === GlobalEnum.CssProperties.Auto || ''
+					? GlobalEnum.CssProperties.Initial
+					: GlobalEnum.CssProperties.Auto;
 
 			// Create css variables
 			Helper.Dom.Styles.SetStyleAttribute(this.selfElement, Enum.CssProperty.TabsHeight, height);

--- a/src/scripts/OSFramework/OSUI/Pattern/Tabs/scss/_tabs.scss
+++ b/src/scripts/OSFramework/OSUI/Pattern/Tabs/scss/_tabs.scss
@@ -223,6 +223,7 @@
 
 		&-item {
 			height: 100%;
+			overflow-y: var(--tabs-content-item-overflow);
 			padding: var(--space-m) var(--space-none);
 			scroll-snap-align: start;
 			scroll-snap-stop: always;

--- a/src/scripts/OSFramework/OSUI/Pattern/Tabs/scss/_tabs.scss
+++ b/src/scripts/OSFramework/OSUI/Pattern/Tabs/scss/_tabs.scss
@@ -223,7 +223,6 @@
 
 		&-item {
 			height: 100%;
-			overflow-y: auto;
 			padding: var(--space-m) var(--space-none);
 			scroll-snap-align: start;
 			scroll-snap-stop: always;


### PR DESCRIPTION
This PR is for allow firing the List OnScrollEnding inside Tabs.

### What was happening
- With the oveflow-y: auto on tabs content item, doesn't allow the OnScrollEnding event to be fired.
![2023-03-27 14 35 33](https://user-images.githubusercontent.com/25321845/227954114-dd03242b-37ae-48cb-aecf-2b7306f25416.gif)

### What was done
- Created a CSS variable to handle the tabs content overflow based on definition of height parameter;
- Updated the CSS rule of overflow on tabs content item, to have the new css variable ('--tabs-content-item-overflow');
- On the method setHeight, a validation was created to set the correct overflow based on height;
![2023-03-27 14 34 14](https://user-images.githubusercontent.com/25321845/227954061-df15f212-7859-4363-8c10-531a17f36ca1.gif)

### Checklist
-   [X] tested locally
-   [X] documented the code
-   [X] clean all warnings and errors of eslint
-   [ ] requires changes in OutSystems (if so, provide a module with changes)
-   [ ] requires new sample page in OutSystems (if so, provide a module with changes)
