### PR TITLE
ROU-4154: Fix the alignment of error messages

### DIFF
--- a/dist/OutSystemsUI.css
+++ b/dist/OutSystemsUI.css
@@ -2748,7 +2748,7 @@ span.validation-message{
 .phone .layout-native .form.OSFillParent .form-control[class*=ThemeGrid_Width].not-valid + span.validation-message{
   left:6px;
 }
-.phone .form.OSFillParent .form-control[class*=ThemeGrid_Width].not-valid + span.validation-message,
+.phone .form.OSFillParent span.input-text .form-control[class*=ThemeGrid_Width].not-valid + span.validation-message,
 .phone .form-control[class*=ThemeGrid_Width].not-valid + span.validation-message{
   left:0;
 }

--- a/dist/OutSystemsUI.css
+++ b/dist/OutSystemsUI.css
@@ -2709,10 +2709,10 @@ select.dropdown-display[disabled]{
   white-space:nowrap;
   width:100%;
 }
-.form span.input-text .form-control[class*=ThemeGrid_Width].not-valid + span.validation-message{
+.form > span.input-text .form-control[class*=ThemeGrid_Width].not-valid + span.validation-message{
   left:0;
 }
-.form span.input-text .form-control[class*=ThemeGrid_Width].not-valid.ThemeGrid_MarginGutter + span.validation-message{
+.form > span.input-text .form-control[class*=ThemeGrid_Width].not-valid.ThemeGrid_MarginGutter + span.validation-message{
   left:22px;
 }
 .form textarea[data-textarea] + span.validation-message{
@@ -2748,8 +2748,9 @@ span.validation-message{
 .phone .layout-native .form.OSFillParent .form-control[class*=ThemeGrid_Width].not-valid + span.validation-message{
   left:6px;
 }
-.phone .form.OSFillParent span.input-text[class*=ThemeGrid_Width].not-valid + span.validation-message,
-.phone .form span.input-text .ThemeGrid_MarginGutter[class*=ThemeGrid_Width].not-valid + span.validation-message, .phone .form-control[class*=ThemeGrid_Width].not-valid + span.validation-message{
+.phone .form.OSFillParent span.input-text .form-control[class*=ThemeGrid_Width].not-valid + span.validation-message,
+.phone .form span.input-text .form-control[class*=ThemeGrid_Width].not-valid.ThemeGrid_MarginGutter + span.validation-message,
+.phone .form-control[class*=ThemeGrid_Width].not-valid + span.validation-message{
   left:0;
 }
 /*! 4.12. Upload */

--- a/dist/OutSystemsUI.css
+++ b/dist/OutSystemsUI.css
@@ -2709,6 +2709,12 @@ select.dropdown-display[disabled]{
   white-space:nowrap;
   width:100%;
 }
+.form span.input-text .form-control[class*=ThemeGrid_Width].not-valid + span.validation-message{
+  left:0;
+}
+.form span.input-text .form-control[class*=ThemeGrid_Width].not-valid.ThemeGrid_MarginGutter + span.validation-message{
+  left:22px;
+}
 .form textarea[data-textarea] + span.validation-message{
   bottom:7px;
 }
@@ -2719,7 +2725,7 @@ select.dropdown-display[disabled]{
 .form .dropdown-container[class*=ThemeGrid_Width].not-valid span.validation-message{
   bottom:4px;
 }
-.form .dropdown-container.not-valid span.validation-message{
+.form .dropdown-container.not-valid span.validation-message, .form .dropdown-container.dropdown-expanded.not-valid span.validation-message{
   bottom:-19px;
 }
 .form .radio-group.not-valid{

--- a/dist/OutSystemsUI.css
+++ b/dist/OutSystemsUI.css
@@ -2748,8 +2748,8 @@ span.validation-message{
 .phone .layout-native .form.OSFillParent .form-control[class*=ThemeGrid_Width].not-valid + span.validation-message{
   left:6px;
 }
-.phone .form.OSFillParent span.input-text .form-control[class*=ThemeGrid_Width].not-valid + span.validation-message,
-.phone .form-control[class*=ThemeGrid_Width].not-valid + span.validation-message{
+.phone .form.OSFillParent span.input-text[class*=ThemeGrid_Width].not-valid + span.validation-message,
+.phone .form span.input-text .ThemeGrid_MarginGutter[class*=ThemeGrid_Width].not-valid + span.validation-message, .phone .form-control[class*=ThemeGrid_Width].not-valid + span.validation-message{
   left:0;
 }
 /*! 4.12. Upload */

--- a/src/scss/03-widgets/_form.scss
+++ b/src/scss/03-widgets/_form.scss
@@ -33,6 +33,18 @@
 			white-space: nowrap;
 			width: 100%;
 		}
+
+		&.input-text {
+			.form-control[class*='ThemeGrid_Width'].not-valid {
+				& + span.validation-message {
+					left: 0;
+				}
+
+				&.ThemeGrid_MarginGutter + span.validation-message {
+					left: 22px;
+				}
+			}
+		}
 	}
 
 	textarea[data-textarea] {
@@ -53,8 +65,11 @@
 			bottom: 4px;
 		}
 
-		&.not-valid span.validation-message {
-			bottom: -19px;
+		&,
+		&.dropdown-expanded {
+			&.not-valid span.validation-message {
+				bottom: -19px;
+			}
 		}
 	}
 

--- a/src/scss/03-widgets/_form.scss
+++ b/src/scss/03-widgets/_form.scss
@@ -111,7 +111,7 @@ span.validation-message {
 		left: 6px;
 	}
 
-	.form.OSFillParent .form-control[class*='ThemeGrid_Width'].not-valid + span.validation-message,
+	.form.OSFillParent span.input-text .form-control[class*='ThemeGrid_Width'].not-valid + span.validation-message,
 	.form-control[class*='ThemeGrid_Width'].not-valid + span.validation-message {
 		left: 0;
 	}

--- a/src/scss/03-widgets/_form.scss
+++ b/src/scss/03-widgets/_form.scss
@@ -33,16 +33,16 @@
 			white-space: nowrap;
 			width: 100%;
 		}
+	}
 
-		&.input-text {
-			.form-control[class*='ThemeGrid_Width'].not-valid {
-				& + span.validation-message {
-					left: 0;
-				}
+	& > span.input-text {
+		.form-control[class*='ThemeGrid_Width'].not-valid {
+			& + span.validation-message {
+				left: 0;
+			}
 
-				&.ThemeGrid_MarginGutter + span.validation-message {
-					left: 22px;
-				}
+			&.ThemeGrid_MarginGutter + span.validation-message {
+				left: 22px;
 			}
 		}
 	}
@@ -111,13 +111,12 @@ span.validation-message {
 		left: 6px;
 	}
 
-	.form {
-		&.OSFillParent span.input-text,
-		span.input-text .ThemeGrid_MarginGutter,
-		&-control {
-			&[class*='ThemeGrid_Width'].not-valid + span.validation-message {
-				left: 0;
-			}
-		}
+	.form.OSFillParent span.input-text .form-control[class*='ThemeGrid_Width'].not-valid + span.validation-message,
+	.form
+		span.input-text
+		.form-control[class*='ThemeGrid_Width'].not-valid.ThemeGrid_MarginGutter
+		+ span.validation-message,
+	.form-control[class*='ThemeGrid_Width'].not-valid + span.validation-message {
+		left: 0;
 	}
 }

--- a/src/scss/03-widgets/_form.scss
+++ b/src/scss/03-widgets/_form.scss
@@ -111,8 +111,13 @@ span.validation-message {
 		left: 6px;
 	}
 
-	.form.OSFillParent span.input-text .form-control[class*='ThemeGrid_Width'].not-valid + span.validation-message,
-	.form-control[class*='ThemeGrid_Width'].not-valid + span.validation-message {
-		left: 0;
+	.form {
+		&.OSFillParent span.input-text,
+		span.input-text .ThemeGrid_MarginGutter,
+		&-control {
+			&[class*='ThemeGrid_Width'].not-valid + span.validation-message {
+				left: 0;
+			}
+		}
 	}
 }


### PR DESCRIPTION
This PR is for fixing the alignment of error messages in some use cases. Please check the JIRA issue for more information.

### What was happening
- Error labels are wrongly positioned on some inputs:
<img width="707" alt="image" src="https://user-images.githubusercontent.com/25321845/228312652-a7f2ec63-0ec7-411d-89f9-2d6ba9b39180.png">

### What was done
- Review the CSS rules of all use cases of validation messages and fix the issue, by default:
<img width="1234" alt="image" src="https://user-images.githubusercontent.com/25321845/228312964-4072d92c-f2f3-4cf9-b215-8b73fcce1031.png">

### Test Steps
1. Open the test page
2. Click on Save button
3. Expected: all the inputs on page will received the error messages and will be placed in the right positions.

### Checklist
-   [X] tested locally
-   [X] documented the code
-   [X] clean all warnings and errors of eslint
-   [ ] requires changes in OutSystems (if so, provide a module with changes)
-   [ ] requires new sample page in OutSystems (if so, provide a module with changes)
