### PR TITLE
RDUCP-472: Adding Provider Configs apply event

### DIFF
--- a/gulp/templates/PatternFramework_HasProvider/Provider/Provider.ts
+++ b/gulp/templates/PatternFramework_HasProvider/Provider/Provider.ts
@@ -51,6 +51,7 @@ namespace Providers.<%= patternNamePC %>.<%= providerNamePC %> {
 		 */
 		protected unsetCallbacks(): void {
 			// TODO (by CreateNewPattern): Update or Remove
+			super.unsetCallbacks();
 		}
 
 		public build(): void {

--- a/gulp/templates/PatternFramework_HasProvider/Provider_HasMode/Provider.ts
+++ b/gulp/templates/PatternFramework_HasProvider/Provider_HasMode/Provider.ts
@@ -54,6 +54,7 @@ namespace Providers.<%= patternNamePC %>.<%= providerNamePC %> {
 		 */
 		protected unsetCallbacks(): void {
 			// TODO (by CreateNewPattern): Update or Remove
+			super.unsetCallbacks();
 		}
 
 		public build(): void {

--- a/src/scripts/OSFramework/GlobalEnum.ts
+++ b/src/scripts/OSFramework/GlobalEnum.ts
@@ -352,4 +352,15 @@ namespace OSFramework.GlobalEnum {
 	export enum NullValues {
 		Time = '00:00:00',
 	}
+
+	/**
+	 * Events available for all provider based patterns.
+	 *
+	 * @export
+	 * @enum {number}
+	 */
+	export enum ProviderEvents {
+		Initialized = 'Initialized',
+		OnProviderConfigsApplied = 'OnProviderConfigsApplied',
+	}
 }

--- a/src/scripts/OSFramework/Pattern/AbstractProviderPattern.ts
+++ b/src/scripts/OSFramework/Pattern/AbstractProviderPattern.ts
@@ -125,7 +125,16 @@ namespace OSFramework.Patterns {
 		protected triggerPlatformEventInitialized(platFormCallback: GlobalCallbacks.OSGeneric): void {
 			// Ensure it's only be trigger the first time!
 			if (this.isBuilt === false) {
-				Helper.AsyncInvocation(platFormCallback, this.widgetId);
+				this.triggerPlatformEventplatformCallback(platFormCallback);
+			}
+		}
+
+		protected triggerPlatformEventplatformCallback(
+			platFormCallback: GlobalCallbacks.OSGeneric,
+			...args: unknown[]
+		): void {
+			if (platFormCallback !== undefined) {
+				Helper.AsyncInvocation(platFormCallback, this.widgetId, ...args);
 			}
 		}
 

--- a/src/scripts/OSFramework/Pattern/AbstractProviderPattern.ts
+++ b/src/scripts/OSFramework/Pattern/AbstractProviderPattern.ts
@@ -13,6 +13,10 @@ namespace OSFramework.Patterns {
 		extends AbstractPattern<C>
 		implements Interface.IProviderPattern<P>
 	{
+		// Holds the callback for the onInitialized event
+		private _platformEventInitialized: GlobalCallbacks.OSGeneric;
+		// Holds the callback for the provider config applied event
+		private _platformEventProviderConfigsAppliedCallback: GlobalCallbacks.OSGeneric;
 		// Holds the provider
 		protected _provider: P;
 		// Holds the provider info
@@ -122,10 +126,10 @@ namespace OSFramework.Patterns {
 		}
 
 		// Trigger platform's InstanceIntializedHandler client Action
-		protected triggerPlatformEventInitialized(platFormCallback: GlobalCallbacks.OSGeneric): void {
+		protected triggerPlatformEventInitialized(): void {
 			// Ensure it's only be trigger the first time!
 			if (this.isBuilt === false) {
-				this.triggerPlatformEventplatformCallback(platFormCallback);
+				this.triggerPlatformEventplatformCallback(this._platformEventInitialized);
 			}
 		}
 
@@ -136,6 +140,17 @@ namespace OSFramework.Patterns {
 			if (platFormCallback !== undefined) {
 				Helper.AsyncInvocation(platFormCallback, this.widgetId, ...args);
 			}
+		}
+
+		/**
+		 * Unsets the callbacks.
+		 *
+		 * @protected
+		 * @memberof OSUISplide
+		 */
+		protected unsetCallbacks(): void {
+			this._platformEventInitialized = undefined;
+			this._platformEventProviderConfigsAppliedCallback = undefined;
 		}
 
 		/**
@@ -187,8 +202,45 @@ namespace OSFramework.Patterns {
 		 * @memberof AbstractProviderPattern
 		 */
 		public dispose(): void {
-			this.providerEventsManagerInstance = undefined;
 			super.dispose();
+		}
+
+		/**
+		 * Register the default events for provider based patterns.
+		 *
+		 * @abstract
+		 * @param {string} eventName
+		 * @param {GlobalCallbacks.OSGeneric} callback
+		 * @memberof AbstractProviderPattern
+		 */
+		public registerCallback(eventName: string, callback: GlobalCallbacks.OSGeneric): void {
+			switch (eventName) {
+				case GlobalEnum.ProviderEvents.Initialized:
+					if (this._platformEventInitialized === undefined) {
+						this._platformEventInitialized = callback;
+					}
+					break;
+				case GlobalEnum.ProviderEvents.OnProviderConfigsApplied:
+					if (this._platformEventProviderConfigsAppliedCallback === undefined) {
+						this._platformEventProviderConfigsAppliedCallback = callback;
+					}
+					break;
+				default:
+					throw new Error(
+						`The pattern with id '${this.widgetId}' does not have the event '${eventName}' defined.`
+					);
+			}
+		}
+
+		/**
+		 * Method used to set all the provider configs. In the AbstractProviderPattern, it
+		 * will simply trigger the callback to warn that the configs have been applied to the provider.
+		 * @param {ProviderConfigs} providerConfigs
+		 * @memberof AbstractProviderPattern
+		 */
+		// eslint-disable-next-line @typescript-eslint/no-unused-vars
+		public setProviderConfigs(providerConfigs: unknown): void {
+			this.triggerPlatformEventplatformCallback(this._platformEventProviderConfigsAppliedCallback);
 		}
 
 		/**
@@ -276,8 +328,5 @@ namespace OSFramework.Patterns {
 				this.providerInfo.version = providerInfo.version;
 			}
 		}
-
-		public abstract registerCallback(eventName: string, callback: GlobalCallbacks.OSGeneric): void;
-		public abstract setProviderConfigs(providerConfigs: ProviderConfigs): void;
 	}
 }

--- a/src/scripts/Providers/Carousel/Splide/Splide.ts
+++ b/src/scripts/Providers/Carousel/Splide/Splide.ts
@@ -24,8 +24,6 @@ namespace Providers.Splide {
 		private _eventOnResize: OSFramework.GlobalCallbacks.Generic;
 		// Store if a List widget is used inside the CarouselItems placeholder
 		private _hasList: boolean;
-		// Store the onInitialized event
-		private _platformEventInitialized: OSFramework.GlobalCallbacks.OSGeneric;
 		// Store the onSlideMoved event
 		private _platformEventOnSlideMoved: OSFramework.Patterns.Carousel.Callbacks.OSOnSlideMovedEvent;
 		// Store initial provider options
@@ -116,7 +114,7 @@ namespace Providers.Splide {
 		private _setOnInitializedEvent(): void {
 			this._provider.on(Enum.SpliderEvents.Mounted, () => {
 				// Trigger platform's InstanceIntializedHandler client Action
-				this.triggerPlatformEventInitialized(this._platformEventInitialized);
+				this.triggerPlatformEventInitialized();
 			});
 		}
 
@@ -218,8 +216,8 @@ namespace Providers.Splide {
 			);
 
 			this._eventOnResize = undefined;
-			this._platformEventInitialized = undefined;
 			this._platformEventOnSlideMoved = undefined;
+			super.unsetCallbacks();
 		}
 
 		/**
@@ -355,8 +353,8 @@ namespace Providers.Splide {
 				case OSFramework.Patterns.Carousel.Enum.CarouselEvents.OnSlideMoved:
 					this._platformEventOnSlideMoved = callback;
 					break;
-				case OSFramework.Patterns.Carousel.Enum.CarouselEvents.Initialized:
-					this._platformEventInitialized = callback;
+				default:
+					super.registerCallback(eventName, callback);
 					break;
 			}
 		}

--- a/src/scripts/Providers/Carousel/Splide/Splide.ts
+++ b/src/scripts/Providers/Carousel/Splide/Splide.ts
@@ -122,7 +122,7 @@ namespace Providers.Splide {
 		private _setOnSlideMovedEvent(): void {
 			this._provider.on(Enum.SpliderEvents.Moved, (index) => {
 				if (index !== this._currentIndex) {
-					OSFramework.Helper.AsyncInvocation(this._platformEventOnSlideMoved, this.widgetId, index);
+					this.triggerPlatformEventplatformCallback(this._platformEventOnSlideMoved, index);
 					this._currentIndex = index;
 				}
 			});

--- a/src/scripts/Providers/Carousel/Splide/Splide.ts
+++ b/src/scripts/Providers/Carousel/Splide/Splide.ts
@@ -383,6 +383,8 @@ namespace Providers.Splide {
 		public setProviderConfigs(newConfigs: SplideOpts): void {
 			this.configs.setExtensibilityConfigs(newConfigs);
 			this.updateCarousel();
+
+			super.setProviderConfigs(newConfigs);
 		}
 
 		/**

--- a/src/scripts/Providers/Datepicker/Flatpickr/AbstractFlatpickr.ts
+++ b/src/scripts/Providers/Datepicker/Flatpickr/AbstractFlatpickr.ts
@@ -288,7 +288,7 @@ namespace Providers.Datepicker.Flatpickr {
 				}
 
 				// Wait for _datePickerProviderInputElem be removed from DOM, before destroy the provider instance!
-				OSFramework.Helper.AsyncInvocation(this.provider.destroy);
+				OSFramework.Helper.AsyncInvocation(this.provider.destroy.bind(this.provider));
 			}
 
 			super.dispose();

--- a/src/scripts/Providers/Datepicker/Flatpickr/AbstractFlatpickr.ts
+++ b/src/scripts/Providers/Datepicker/Flatpickr/AbstractFlatpickr.ts
@@ -357,6 +357,8 @@ namespace Providers.Datepicker.Flatpickr {
 			this.configs.setExtensibilityConfigs(newConfigs);
 
 			this.redraw();
+
+			super.setProviderConfigs(newConfigs);
 		}
 
 		/**

--- a/src/scripts/Providers/Datepicker/Flatpickr/AbstractFlatpickr.ts
+++ b/src/scripts/Providers/Datepicker/Flatpickr/AbstractFlatpickr.ts
@@ -6,8 +6,6 @@ namespace Providers.Datepicker.Flatpickr {
 	{
 		// Event OnBodyScroll common behaviour
 		private _bodyScrollCommonBehaviour: SharedProviderResources.Flatpickr.UpdatePositionOnScroll;
-		// Flatpickr onInitialize event
-		private _onInitializeCallbackEvent: OSFramework.GlobalCallbacks.OSGeneric;
 		// Store pattern input HTML element reference
 		protected _datePickerProviderInputElem: HTMLInputElement;
 		// Store the flatpickr input html element that will be added by library
@@ -138,7 +136,7 @@ namespace Providers.Datepicker.Flatpickr {
 			}
 
 			// Trigger platform's InstanceIntializedHandler client Action
-			this.triggerPlatformEventInitialized(this._onInitializeCallbackEvent);
+			this.triggerPlatformEventInitialized();
 		}
 
 		/**
@@ -174,8 +172,8 @@ namespace Providers.Datepicker.Flatpickr {
 		protected unsetCallbacks(): void {
 			this.configs.OnChange = undefined;
 
-			this._onInitializeCallbackEvent = undefined;
 			this._onSelectedCallbackEvent = undefined;
+			super.unsetCallbacks();
 		}
 
 		/**
@@ -316,12 +314,9 @@ namespace Providers.Datepicker.Flatpickr {
 					this._onSelectedCallbackEvent = callback;
 					break;
 
-				case OSFramework.Patterns.DatePicker.Enum.DatePickerEvents.OnInitialize:
-					this._onInitializeCallbackEvent = callback;
-					break;
-
 				default:
-					throw new Error(`The given '${eventName}' event name it's not defined.`);
+					super.registerCallback(eventName, callback);
+					break;
 			}
 		}
 

--- a/src/scripts/Providers/Datepicker/Flatpickr/RangeDate/FlatpickrRangeDate.ts
+++ b/src/scripts/Providers/Datepicker/Flatpickr/RangeDate/FlatpickrRangeDate.ts
@@ -51,7 +51,6 @@ namespace Providers.Datepicker.Flatpickr.RangeDate {
 			// Trigger platform's onChange callback event
 			this.triggerPlatformEventplatformCallback(
 				this._onSelectedCallbackEvent,
-				this.widgetId,
 				_selectedDate[0],
 				_selectedDate[1]
 			);

--- a/src/scripts/Providers/Datepicker/Flatpickr/RangeDate/FlatpickrRangeDate.ts
+++ b/src/scripts/Providers/Datepicker/Flatpickr/RangeDate/FlatpickrRangeDate.ts
@@ -49,7 +49,7 @@ namespace Providers.Datepicker.Flatpickr.RangeDate {
 			}
 
 			// Trigger platform's onChange callback event
-			OSFramework.Helper.AsyncInvocation(
+			this.triggerPlatformEventplatformCallback(
 				this._onSelectedCallbackEvent,
 				this.widgetId,
 				_selectedDate[0],

--- a/src/scripts/Providers/Dropdown/VirtualSelect/AbstractVirtualSelect.ts
+++ b/src/scripts/Providers/Dropdown/VirtualSelect/AbstractVirtualSelect.ts
@@ -9,6 +9,7 @@ namespace Providers.Dropdown.VirtualSelect {
 		// Dropdown callback events
 		private _onSelectedOptionEvent: OSFramework.GlobalCallbacks.Generic;
 		private _platformEventInitializedCallback: OSFramework.GlobalCallbacks.OSGeneric;
+		private _platformEventProviderConfigsAppliedCallback: OSFramework.GlobalCallbacks.OSGeneric;
 		private _platformEventSelectedOptCallback: OSFramework.Patterns.Dropdown.Callbacks.OSOnSelectEvent;
 
 		// Store a reference of available provider methods
@@ -342,6 +343,11 @@ namespace Providers.Dropdown.VirtualSelect {
 						this._platformEventSelectedOptCallback = callback;
 					}
 					break;
+				case Enum.Events.OnProviderConfigsApplied:
+					if (this._platformEventProviderConfigsAppliedCallback === undefined) {
+						this._platformEventProviderConfigsAppliedCallback = callback;
+					}
+					break;
 
 				default:
 					throw new Error(`The given '${eventName}' event name it's not defined.`);
@@ -357,6 +363,7 @@ namespace Providers.Dropdown.VirtualSelect {
 		public setProviderConfigs(newConfigs: VirtualSelectOpts): void {
 			this.configs.setExtensibilityConfigs(newConfigs);
 			this.redraw();
+			this.triggerPlatformEventplatformCallback(this._platformEventProviderConfigsAppliedCallback);
 		}
 
 		/**

--- a/src/scripts/Providers/Dropdown/VirtualSelect/AbstractVirtualSelect.ts
+++ b/src/scripts/Providers/Dropdown/VirtualSelect/AbstractVirtualSelect.ts
@@ -62,11 +62,7 @@ namespace Providers.Dropdown.VirtualSelect {
 		// Get the selected options and pass them into callBack
 		private _onSelectedOption() {
 			// Trigger platform's SelectedOptionCallbackEvent client Action
-			OSFramework.Helper.AsyncInvocation(
-				this._platformEventSelectedOptCallback,
-				this.widgetId,
-				this.getSelectedValues()
-			);
+			this.triggerPlatformEventplatformCallback(this._platformEventSelectedOptCallback, this.getSelectedValues());
 		}
 
 		// Close the dropdown if it's open!

--- a/src/scripts/Providers/Dropdown/VirtualSelect/AbstractVirtualSelect.ts
+++ b/src/scripts/Providers/Dropdown/VirtualSelect/AbstractVirtualSelect.ts
@@ -8,8 +8,6 @@ namespace Providers.Dropdown.VirtualSelect {
 		private _eventOnWindowResize: OSFramework.GlobalCallbacks.Generic;
 		// Dropdown callback events
 		private _onSelectedOptionEvent: OSFramework.GlobalCallbacks.Generic;
-		private _platformEventInitializedCallback: OSFramework.GlobalCallbacks.OSGeneric;
-		private _platformEventProviderConfigsAppliedCallback: OSFramework.GlobalCallbacks.OSGeneric;
 		private _platformEventSelectedOptCallback: OSFramework.Patterns.Dropdown.Callbacks.OSOnSelectEvent;
 
 		// Store a reference of available provider methods
@@ -137,7 +135,7 @@ namespace Providers.Dropdown.VirtualSelect {
 			this._manageAttributes();
 
 			// Trigger platform's InstanceIntializedHandler client Action
-			this.triggerPlatformEventInitialized(this._platformEventInitializedCallback);
+			this.triggerPlatformEventInitialized();
 		}
 
 		/**
@@ -178,6 +176,8 @@ namespace Providers.Dropdown.VirtualSelect {
 			this._virtualselectConfigs = undefined;
 			this._virtualselectOpts = undefined;
 			this.provider = undefined;
+
+			super.unsetCallbacks();
 		}
 
 		public build(): void {
@@ -332,25 +332,15 @@ namespace Providers.Dropdown.VirtualSelect {
 		 */
 		public registerCallback(eventName: string, callback: OSFramework.GlobalCallbacks.OSGeneric): void {
 			switch (eventName) {
-				case OSFramework.Patterns.Dropdown.Enum.Events.Initialized:
-					if (this._platformEventInitializedCallback === undefined) {
-						this._platformEventInitializedCallback = callback;
-					}
-					break;
-
 				case Enum.Events.OnSelected:
 					if (this._platformEventSelectedOptCallback === undefined) {
 						this._platformEventSelectedOptCallback = callback;
 					}
 					break;
-				case Enum.Events.OnProviderConfigsApplied:
-					if (this._platformEventProviderConfigsAppliedCallback === undefined) {
-						this._platformEventProviderConfigsAppliedCallback = callback;
-					}
-					break;
 
 				default:
-					throw new Error(`The given '${eventName}' event name it's not defined.`);
+					super.registerCallback(eventName, callback);
+					break;
 			}
 		}
 

--- a/src/scripts/Providers/Dropdown/VirtualSelect/AbstractVirtualSelect.ts
+++ b/src/scripts/Providers/Dropdown/VirtualSelect/AbstractVirtualSelect.ts
@@ -353,7 +353,7 @@ namespace Providers.Dropdown.VirtualSelect {
 		public setProviderConfigs(newConfigs: VirtualSelectOpts): void {
 			this.configs.setExtensibilityConfigs(newConfigs);
 			this.redraw();
-			this.triggerPlatformEventplatformCallback(this._platformEventProviderConfigsAppliedCallback);
+			super.setProviderConfigs(newConfigs);
 		}
 
 		/**

--- a/src/scripts/Providers/Dropdown/VirtualSelect/AbstractVirtualSelectEnum.ts
+++ b/src/scripts/Providers/Dropdown/VirtualSelect/AbstractVirtualSelectEnum.ts
@@ -23,7 +23,6 @@ namespace Providers.Dropdown.VirtualSelect.Enum {
 	 */
 	export enum Events {
 		Change = 'change',
-		OnProviderConfigsApplied = 'OnProviderConfigsApplied',
 		OnSelected = 'OnSelected',
 	}
 

--- a/src/scripts/Providers/Dropdown/VirtualSelect/AbstractVirtualSelectEnum.ts
+++ b/src/scripts/Providers/Dropdown/VirtualSelect/AbstractVirtualSelectEnum.ts
@@ -23,6 +23,7 @@ namespace Providers.Dropdown.VirtualSelect.Enum {
 	 */
 	export enum Events {
 		Change = 'change',
+		OnProviderConfigsApplied = 'OnProviderConfigsApplied',
 		OnSelected = 'OnSelected',
 	}
 

--- a/src/scripts/Providers/Monthpicker/Flatpickr/FlatpickrMonth.ts
+++ b/src/scripts/Providers/Monthpicker/Flatpickr/FlatpickrMonth.ts
@@ -7,8 +7,6 @@ namespace Providers.MonthPicker.Flatpickr {
 	{
 		// Event OnBodyScroll common behaviour
 		private _bodyScrollCommonBehaviour: SharedProviderResources.Flatpickr.UpdatePositionOnScroll;
-		// Flatpickr onInitialize event
-		private _onInitializeCallbackEvent: OSFramework.GlobalCallbacks.OSGeneric;
 		// Store the flatpickr input html element that will be added by library
 		protected _flatpickrInputElem: HTMLInputElement;
 		// Store the provider options
@@ -134,7 +132,7 @@ namespace Providers.MonthPicker.Flatpickr {
 			});
 
 			// Trigger platform's InstanceIntializedHandler client Action
-			this.triggerPlatformEventInitialized(this._onInitializeCallbackEvent);
+			this.triggerPlatformEventInitialized();
 		}
 
 		/**
@@ -205,8 +203,8 @@ namespace Providers.MonthPicker.Flatpickr {
 		protected unsetCallbacks(): void {
 			this.configs.OnChange = undefined;
 
-			this._onInitializeCallbackEvent = undefined;
 			this._onSelectedCallbackEvent = undefined;
+			super.unsetCallbacks();
 		}
 
 		/**
@@ -321,12 +319,9 @@ namespace Providers.MonthPicker.Flatpickr {
 					this._onSelectedCallbackEvent = callback;
 					break;
 
-				case OSFramework.Patterns.MonthPicker.Enum.Events.OnInitialized:
-					this._onInitializeCallbackEvent = callback;
-					break;
-
 				default:
-					throw new Error(`The given '${eventName}' event name it's not defined.`);
+					super.registerCallback(eventName, callback);
+					break;
 			}
 		}
 

--- a/src/scripts/Providers/Monthpicker/Flatpickr/FlatpickrMonth.ts
+++ b/src/scripts/Providers/Monthpicker/Flatpickr/FlatpickrMonth.ts
@@ -292,7 +292,7 @@ namespace Providers.MonthPicker.Flatpickr {
 				}
 
 				// Wait for _monthPickerProviderInputElem be removed from DOM, before detroy the provider instance!
-				OSFramework.Helper.AsyncInvocation(this.provider.destroy);
+				OSFramework.Helper.AsyncInvocation(this.provider.destroy.bind(this.provider));
 			}
 
 			super.dispose();

--- a/src/scripts/Providers/Monthpicker/Flatpickr/FlatpickrMonth.ts
+++ b/src/scripts/Providers/Monthpicker/Flatpickr/FlatpickrMonth.ts
@@ -350,6 +350,8 @@ namespace Providers.MonthPicker.Flatpickr {
 			this.configs.setExtensibilityConfigs(newConfigs);
 
 			this.redraw();
+
+			super.setProviderConfigs(newConfigs);
 		}
 	}
 }

--- a/src/scripts/Providers/Monthpicker/Flatpickr/FlatpickrMonth.ts
+++ b/src/scripts/Providers/Monthpicker/Flatpickr/FlatpickrMonth.ts
@@ -160,7 +160,6 @@ namespace Providers.MonthPicker.Flatpickr {
 			// Trigger platform's onChange callback event
 			this.triggerPlatformEventplatformCallback(
 				this._onSelectedCallbackEvent,
-				this.widgetId,
 				_selectedMonthYear.month,
 				_selectedMonthYear.year
 			);

--- a/src/scripts/Providers/Monthpicker/Flatpickr/FlatpickrMonth.ts
+++ b/src/scripts/Providers/Monthpicker/Flatpickr/FlatpickrMonth.ts
@@ -158,7 +158,7 @@ namespace Providers.MonthPicker.Flatpickr {
 			}
 
 			// Trigger platform's onChange callback event
-			OSFramework.Helper.AsyncInvocation(
+			this.triggerPlatformEventplatformCallback(
 				this._onSelectedCallbackEvent,
 				this.widgetId,
 				_selectedMonthYear.month,

--- a/src/scripts/Providers/RangeSlider/NoUISlider/AbstractNoUiSlider.ts
+++ b/src/scripts/Providers/RangeSlider/NoUISlider/AbstractNoUiSlider.ts
@@ -169,6 +169,7 @@ namespace Providers.RangeSlider.NoUISlider {
 		 */
 		protected unsetCallbacks(): void {
 			this.eventProviderValueChanged = undefined;
+			super.unsetCallbacks();
 		}
 
 		/**
@@ -304,6 +305,8 @@ namespace Providers.RangeSlider.NoUISlider {
 			this.configs.setExtensibilityConfigs(newConfigs);
 
 			this.updateRangeSlider();
+
+			super.setProviderConfigs(newConfigs);
 		}
 
 		/**

--- a/src/scripts/Providers/RangeSlider/NoUISlider/AbstractNoUiSlider.ts
+++ b/src/scripts/Providers/RangeSlider/NoUISlider/AbstractNoUiSlider.ts
@@ -14,7 +14,6 @@ namespace Providers.RangeSlider.NoUISlider {
 		private _rangeSliderProviderElem: HTMLElement;
 		// RangeSlider events
 		protected eventProviderValueChanged: OSFramework.GlobalCallbacks.Generic;
-		protected platformEventInitialize: OSFramework.GlobalCallbacks.OSGeneric;
 		protected platformEventValueChange: OSFramework.Patterns.RangeSlider.Callbacks.OSOnValueChangeEvent;
 		// Store the provider options
 		protected providerOptions: NoUiSliderOptions;
@@ -97,7 +96,7 @@ namespace Providers.RangeSlider.NoUISlider {
 			this._setOnValueChangeEvent(RangeSlider.NoUiSlider.Enum.NoUISliderEvents.Slide);
 
 			// Trigger platform's InstanceIntializedHandler client Action
-			this.triggerPlatformEventInitialized(this.platformEventInitialize);
+			this.triggerPlatformEventInitialized();
 		}
 
 		/**
@@ -284,20 +283,14 @@ namespace Providers.RangeSlider.NoUISlider {
 		 */
 		public registerCallback(eventName: string, callback: OSFramework.GlobalCallbacks.OSGeneric): void {
 			switch (eventName) {
-				case OSFramework.Patterns.RangeSlider.Enum.RangeSliderEvents.OnInitialize:
-					if (this.platformEventInitialize === undefined) {
-						this.platformEventInitialize = callback;
-					}
-					break;
 				case OSFramework.Patterns.RangeSlider.Enum.RangeSliderEvents.OnValueChange:
 					if (this.platformEventValueChange === undefined) {
 						this.platformEventValueChange = callback;
 					}
 					break;
 				default:
-					throw new Error(
-						`${OSFramework.ErrorCodes.RangeSlider.FailRegisterCallback}:	The given '${eventName}' event name is not defined.`
-					);
+					super.registerCallback(eventName, callback);
+					break;
 			}
 		}
 

--- a/src/scripts/Providers/Timepicker/Flatpickr/FlatpickrTime.ts
+++ b/src/scripts/Providers/Timepicker/Flatpickr/FlatpickrTime.ts
@@ -275,8 +275,8 @@ namespace Providers.Timepicker.Flatpickr {
 					this._bodyScrollCommonBehaviour = undefined;
 				}
 
-				// Wait for _datePickerProviderInputElem be removed from DOM, before detroy the provider instance!
-				OSFramework.Helper.AsyncInvocation(this.provider.destroy);
+				// Wait for _datePickerProviderInputElem be removed from DOM, before destroy the provider instance!
+				OSFramework.Helper.AsyncInvocation(this.provider.destroy.bind(this.provider));
 			}
 
 			super.dispose();

--- a/src/scripts/Providers/Timepicker/Flatpickr/FlatpickrTime.ts
+++ b/src/scripts/Providers/Timepicker/Flatpickr/FlatpickrTime.ts
@@ -146,7 +146,7 @@ namespace Providers.Timepicker.Flatpickr {
 			}
 
 			// Trigger platform's onChange callback event
-			OSFramework.Helper.AsyncInvocation(this._onChangeCallbackEvent, this.widgetId, _selectedTime);
+			this.triggerPlatformEventplatformCallback(this._onChangeCallbackEvent, _selectedTime);
 		}
 
 		/**

--- a/src/scripts/Providers/Timepicker/Flatpickr/FlatpickrTime.ts
+++ b/src/scripts/Providers/Timepicker/Flatpickr/FlatpickrTime.ts
@@ -302,12 +302,9 @@ namespace Providers.Timepicker.Flatpickr {
 					this._onChangeCallbackEvent = callback;
 					break;
 
-				case OSFramework.Patterns.TimePicker.Enum.TimePickerEvents.OnInitialized:
-					this._onInitializeCallbackEvent = callback;
-					break;
-
 				default:
-					throw new Error(`The given '${eventName}' event name it's not defined.`);
+					super.registerCallback(eventName, callback);
+					break;
 			}
 		}
 		/**
@@ -347,6 +344,8 @@ namespace Providers.Timepicker.Flatpickr {
 			this.configs.setExtensibilityConfigs(newConfigs);
 
 			this.redraw();
+
+			super.setProviderConfigs(newConfigs);
 		}
 
 		/**

--- a/src/scripts/Providers/Timepicker/Flatpickr/FlatpickrTime.ts
+++ b/src/scripts/Providers/Timepicker/Flatpickr/FlatpickrTime.ts
@@ -7,8 +7,6 @@ namespace Providers.Timepicker.Flatpickr {
 	{
 		// Event OnBodyScroll common behaviour
 		private _bodyScrollCommonBehaviour: SharedProviderResources.Flatpickr.UpdatePositionOnScroll;
-		// Flatpickr onInitialize event
-		private _onInitializeCallbackEvent: OSFramework.GlobalCallbacks.OSGeneric;
 		// Store the flatpickr input html element that will be added by library
 		protected _flatpickrInputElem: HTMLInputElement;
 		// Store the provider options
@@ -134,7 +132,7 @@ namespace Providers.Timepicker.Flatpickr {
 			});
 
 			// Trigger platform's InstanceIntializedHandler client Action
-			this.triggerPlatformEventInitialized(this._onInitializeCallbackEvent);
+			this.triggerPlatformEventInitialized();
 		}
 
 		// Method that will be triggered by library each time any time is selected
@@ -188,8 +186,8 @@ namespace Providers.Timepicker.Flatpickr {
 		protected unsetCallbacks(): void {
 			this.configs.OnChange = undefined;
 
-			this._onInitializeCallbackEvent = undefined;
 			this._onChangeCallbackEvent = undefined;
+			super.unsetCallbacks();
 		}
 
 		/**


### PR DESCRIPTION
This PR is for adding the provider configs event. This event will be triggered after the setProviderConfigs methods are invoked and the new configs applied.

### What was happening
- The lack of this event, caused somethings for a flickering to occur, since the pattern is first built, and then destroyed once the method setProviderConfigs is invoked.

### What was done
- The previously abstract method `registerCallback` in the class `AbstractProviderPattern` was not implemented.
- This method encapsulates the logic of the events `Initialized` (previously dispersed through out the code) and the newly created event `OnProviderConfigsApplied`.
- Two new methods were added in the class `AbstractProviderPattern`:
  - triggerPlatformEventInitialized: will raise the `Initialized` event of the pattern;
  - triggerPlatformEventplatformCallback: will raise any generic event to OutSystems platform. This means that as first parameter there will always be the `this.widgetId`.
- Added correct context to some of the async calls

### Checklist
-   [x] tested locally
-   [x] documented the code
-   [x] clean all warnings and errors of eslint
-   [ ] requires changes in OutSystems (if so, provide a module with changes)
-   [ ] requires new sample page in OutSystems (if so, provide a module with changes)
