### PR TITLE
RDUCP-472o11: Adding Provider Configs apply event

### DIFF
--- a/src/scripts/OSFramework/OSUI/GlobalEnum.ts
+++ b/src/scripts/OSFramework/OSUI/GlobalEnum.ts
@@ -371,4 +371,15 @@ namespace OSFramework.OSUI.GlobalEnum {
 	export enum NullValues {
 		Time = '00:00:00',
 	}
+
+	/**
+	 * Events available for all provider based patterns.
+	 *
+	 * @export
+	 * @enum {number}
+	 */
+	export enum ProviderEvents {
+		Initialized = 'Initialized',
+		OnProviderConfigsApplied = 'OnProviderConfigsApplied',
+	}
 }

--- a/src/scripts/OSFramework/OSUI/Pattern/AbstractProviderPattern.ts
+++ b/src/scripts/OSFramework/OSUI/Pattern/AbstractProviderPattern.ts
@@ -13,6 +13,10 @@ namespace OSFramework.OSUI.Patterns {
 		extends AbstractPattern<C>
 		implements Interface.IProviderPattern<P>
 	{
+		// Holds the callback for the onInitialized event
+		private _platformEventInitialized: GlobalCallbacks.OSGeneric;
+		// Holds the callback for the provider config applied event
+		private _platformEventProviderConfigsAppliedCallback: GlobalCallbacks.OSGeneric;
 		// Holds the provider
 		protected _provider: P;
 		// Holds the provider info
@@ -108,10 +112,10 @@ namespace OSFramework.OSUI.Patterns {
 		 * @param {GlobalCallbacks.OSGeneric} platFormCallback
 		 * @memberof OSFramework.Patterns.AbstractProviderPattern
 		 */
-		protected triggerPlatformEventInitialized(platFormCallback: GlobalCallbacks.OSGeneric): void {
+		protected triggerPlatformEventInitialized(): void {
 			// Ensure it's only be trigger the first time!
 			if (this.isBuilt === false) {
-				this.triggerPlatformEventplatformCallback(platFormCallback);
+				this.triggerPlatformEventplatformCallback(this._platformEventInitialized);
 			}
 		}
 
@@ -125,7 +129,18 @@ namespace OSFramework.OSUI.Patterns {
 		}
 
 		/**
-		 * Build the Pattern
+		 * Unsets the callbacks.
+		 *
+		 * @protected
+		 * @memberof OSUISplide
+		 */
+		protected unsetCallbacks(): void {
+			this._platformEventInitialized = undefined;
+			this._platformEventProviderConfigsAppliedCallback = undefined;
+		}
+
+		/**
+		 * Method to build the pattern
 		 *
 		 * @memberof OSFramework.Patterns.AbstractProviderPattern
 		 */
@@ -173,8 +188,45 @@ namespace OSFramework.OSUI.Patterns {
 		 * @memberof OSFramework.Patterns.AbstractProviderPattern
 		 */
 		public dispose(): void {
-			this.providerEventsManagerInstance = undefined;
 			super.dispose();
+		}
+
+		/**
+		 * Register the default events for provider based patterns.
+		 *
+		 * @abstract
+		 * @param {string} eventName
+		 * @param {GlobalCallbacks.OSGeneric} callback
+		 * @memberof AbstractProviderPattern
+		 */
+		public registerCallback(eventName: string, callback: GlobalCallbacks.OSGeneric): void {
+			switch (eventName) {
+				case GlobalEnum.ProviderEvents.Initialized:
+					if (this._platformEventInitialized === undefined) {
+						this._platformEventInitialized = callback;
+					}
+					break;
+				case GlobalEnum.ProviderEvents.OnProviderConfigsApplied:
+					if (this._platformEventProviderConfigsAppliedCallback === undefined) {
+						this._platformEventProviderConfigsAppliedCallback = callback;
+					}
+					break;
+				default:
+					throw new Error(
+						`The pattern with id '${this.widgetId}' does not have the event '${eventName}' defined.`
+					);
+			}
+		}
+
+		/**
+		 * Method used to set all the provider configs. In the AbstractProviderPattern, it
+		 * will simply trigger the callback to warn that the configs have been applied to the provider.
+		 * @param {ProviderConfigs} providerConfigs
+		 * @memberof AbstractProviderPattern
+		 */
+		// eslint-disable-next-line @typescript-eslint/no-unused-vars
+		public setProviderConfigs(providerConfigs: unknown): void {
+			this.triggerPlatformEventplatformCallback(this._platformEventProviderConfigsAppliedCallback);
 		}
 
 		/**
@@ -305,7 +357,5 @@ namespace OSFramework.OSUI.Patterns {
 
 		// Common methods all providers must implement
 		protected abstract prepareConfigs(): void;
-		public abstract registerCallback(eventName: string, callback: GlobalCallbacks.OSGeneric): void;
-		public abstract setProviderConfigs(providerConfigs: ProviderConfigs): void;
 	}
 }

--- a/src/scripts/OSFramework/OSUI/Pattern/AbstractProviderPattern.ts
+++ b/src/scripts/OSFramework/OSUI/Pattern/AbstractProviderPattern.ts
@@ -106,6 +106,7 @@ namespace OSFramework.OSUI.Patterns {
 			}
 		}
 
+		//TODO: move this method to the AbstractPattern. Interfaces need to be updated.
 		/**
 		 * Trigger platform's InstanceIntializedHandler client Action
 		 *
@@ -119,6 +120,15 @@ namespace OSFramework.OSUI.Patterns {
 			}
 		}
 
+		//TODO: move this method to the AbstractPattern. Interfaces need to be updated.
+		/**
+		 * Triggers a generic platform event.
+		 *
+		 * @protected
+		 * @param {GlobalCallbacks.OSGeneric} platFormCallback
+		 * @param {...unknown[]} args
+		 * @memberof AbstractProviderPattern
+		 */
 		protected triggerPlatformEventplatformCallback(
 			platFormCallback: GlobalCallbacks.OSGeneric,
 			...args: unknown[]

--- a/src/scripts/OSFramework/OSUI/Pattern/AbstractProviderPattern.ts
+++ b/src/scripts/OSFramework/OSUI/Pattern/AbstractProviderPattern.ts
@@ -111,7 +111,16 @@ namespace OSFramework.OSUI.Patterns {
 		protected triggerPlatformEventInitialized(platFormCallback: GlobalCallbacks.OSGeneric): void {
 			// Ensure it's only be trigger the first time!
 			if (this.isBuilt === false) {
-				Helper.AsyncInvocation(platFormCallback, this.widgetId);
+				this.triggerPlatformEventplatformCallback(platFormCallback);
+			}
+		}
+
+		protected triggerPlatformEventplatformCallback(
+			platFormCallback: GlobalCallbacks.OSGeneric,
+			...args: unknown[]
+		): void {
+			if (platFormCallback !== undefined) {
+				Helper.AsyncInvocation(platFormCallback, this.widgetId, ...args);
 			}
 		}
 

--- a/src/scripts/Providers/OSUI/Carousel/Splide/Splide.ts
+++ b/src/scripts/Providers/OSUI/Carousel/Splide/Splide.ts
@@ -122,7 +122,7 @@ namespace Providers.OSUI.Carousel.Splide {
 		private _setOnSlideMovedEvent(): void {
 			this._provider.on(Enum.SpliderEvents.Moved, (index) => {
 				if (index !== this._currentIndex) {
-					OSFramework.OSUI.Helper.AsyncInvocation(this._platformEventOnSlideMoved, this.widgetId, index);
+					this.triggerPlatformEventplatformCallback(this._platformEventOnSlideMoved, index);
 					this._currentIndex = index;
 				}
 			});

--- a/src/scripts/Providers/OSUI/Carousel/Splide/Splide.ts
+++ b/src/scripts/Providers/OSUI/Carousel/Splide/Splide.ts
@@ -24,8 +24,6 @@ namespace Providers.OSUI.Carousel.Splide {
 		private _eventOnResize: OSFramework.OSUI.GlobalCallbacks.Generic;
 		// Store if a List widget is used inside the CarouselItems placeholder
 		private _hasList: boolean;
-		// Store the onInitialized event
-		private _platformEventInitialized: OSFramework.OSUI.GlobalCallbacks.OSGeneric;
 		// Store the onSlideMoved event
 		private _platformEventOnSlideMoved: OSFramework.OSUI.Patterns.Carousel.Callbacks.OSOnSlideMovedEvent;
 		// Store initial provider options
@@ -116,7 +114,7 @@ namespace Providers.OSUI.Carousel.Splide {
 		private _setOnInitializedEvent(): void {
 			this._provider.on(Enum.SpliderEvents.Mounted, () => {
 				// Trigger platform's InstanceIntializedHandler client Action
-				this.triggerPlatformEventInitialized(this._platformEventInitialized);
+				this.triggerPlatformEventInitialized();
 			});
 		}
 
@@ -242,8 +240,8 @@ namespace Providers.OSUI.Carousel.Splide {
 			);
 
 			this._eventOnResize = undefined;
-			this._platformEventInitialized = undefined;
 			this._platformEventOnSlideMoved = undefined;
+			super.unsetCallbacks();
 		}
 
 		/**
@@ -379,8 +377,8 @@ namespace Providers.OSUI.Carousel.Splide {
 				case OSFramework.OSUI.Patterns.Carousel.Enum.CarouselEvents.OnSlideMoved:
 					this._platformEventOnSlideMoved = callback;
 					break;
-				case OSFramework.OSUI.Patterns.Carousel.Enum.CarouselEvents.Initialized:
-					this._platformEventInitialized = callback;
+				default:
+					super.registerCallback(eventName, callback);
 					break;
 			}
 		}

--- a/src/scripts/Providers/OSUI/Carousel/Splide/Splide.ts
+++ b/src/scripts/Providers/OSUI/Carousel/Splide/Splide.ts
@@ -410,6 +410,7 @@ namespace Providers.OSUI.Carousel.Splide {
 		public setProviderConfigs(newConfigs: SplideOpts): void {
 			this.configs.setExtensibilityConfigs(newConfigs);
 			this.redraw();
+			super.setProviderConfigs(newConfigs);
 		}
 
 		/**

--- a/src/scripts/Providers/OSUI/Datepicker/Flatpickr/AbstractFlatpickr.ts
+++ b/src/scripts/Providers/OSUI/Datepicker/Flatpickr/AbstractFlatpickr.ts
@@ -8,8 +8,6 @@ namespace Providers.OSUI.Datepicker.Flatpickr {
 		private _a11yInfoContainerElem: HTMLElement;
 		// Event OnBodyScroll common behaviour
 		private _bodyScrollCommonBehaviour: SharedProviderResources.Flatpickr.UpdatePositionOnScroll;
-		// Flatpickr onInitialize event
-		private _onInitializeCallbackEvent: OSFramework.OSUI.GlobalCallbacks.OSGeneric;
 		// Validation of ZIndex position common behavior
 		private _zindexCommonBehavior: SharedProviderResources.Flatpickr.UpdateZindex;
 		// Store pattern input HTML element reference
@@ -168,7 +166,7 @@ namespace Providers.OSUI.Datepicker.Flatpickr {
 			}
 
 			// Trigger platform's InstanceIntializedHandler client Action
-			this.triggerPlatformEventInitialized(this._onInitializeCallbackEvent);
+			this.triggerPlatformEventInitialized();
 
 			// Remove inline height value style!
 			this._unsetParentMinHeight();
@@ -282,9 +280,9 @@ namespace Providers.OSUI.Datepicker.Flatpickr {
 		 */
 		protected unsetCallbacks(): void {
 			this.configs.OnChange = undefined;
-
-			this._onInitializeCallbackEvent = undefined;
 			this._onSelectedCallbackEvent = undefined;
+
+			super.unsetCallbacks();
 		}
 
 		/**
@@ -435,12 +433,9 @@ namespace Providers.OSUI.Datepicker.Flatpickr {
 					this._onSelectedCallbackEvent = callback;
 					break;
 
-				case OSFramework.OSUI.Patterns.DatePicker.Enum.DatePickerEvents.OnInitialize:
-					this._onInitializeCallbackEvent = callback;
-					break;
-
 				default:
-					throw new Error(`The given '${eventName}' event name it's not defined.`);
+					super.registerCallback(eventName, callback);
+					break;
 			}
 		}
 
@@ -479,8 +474,8 @@ namespace Providers.OSUI.Datepicker.Flatpickr {
 		 */
 		public setProviderConfigs(newConfigs: FlatpickrOptions): void {
 			this.configs.setExtensibilityConfigs(newConfigs);
-
 			this.prepareToAndRedraw();
+			super.setProviderConfigs(newConfigs);
 		}
 
 		/**

--- a/src/scripts/Providers/OSUI/Dropdown/VirtualSelect/AbstractVirtualSelect.ts
+++ b/src/scripts/Providers/OSUI/Dropdown/VirtualSelect/AbstractVirtualSelect.ts
@@ -10,6 +10,7 @@ namespace Providers.OSUI.Dropdown.VirtualSelect {
 		private _onMouseUpEvent: OSFramework.OSUI.GlobalCallbacks.Generic;
 		private _onSelectedOptionEvent: OSFramework.OSUI.GlobalCallbacks.Generic;
 		private _platformEventInitializedCallback: OSFramework.OSUI.GlobalCallbacks.OSGeneric;
+		private _platformEventProviderConfigsAppliedCallback: OSFramework.OSUI.GlobalCallbacks.OSGeneric;
 		private _platformEventSelectedOptCallback: OSFramework.OSUI.Patterns.Dropdown.Callbacks.OSOnSelectEvent;
 
 		// Store the hidden input AriaLabel value
@@ -410,6 +411,11 @@ namespace Providers.OSUI.Dropdown.VirtualSelect {
 						this._platformEventSelectedOptCallback = callback;
 					}
 					break;
+				case Enum.Events.OnProviderConfigsApplied:
+					if (this._platformEventProviderConfigsAppliedCallback === undefined) {
+						this._platformEventProviderConfigsAppliedCallback = callback;
+					}
+					break;
 
 				default:
 					throw new Error(`The given '${eventName}' event name it's not defined.`);
@@ -437,6 +443,7 @@ namespace Providers.OSUI.Dropdown.VirtualSelect {
 		public setProviderConfigs(newConfigs: VirtualSelectOpts): void {
 			this.configs.setExtensibilityConfigs(newConfigs);
 			this.redraw();
+			this.triggerPlatformEventplatformCallback(this._platformEventProviderConfigsAppliedCallback);
 		}
 
 		/**

--- a/src/scripts/Providers/OSUI/Dropdown/VirtualSelect/AbstractVirtualSelect.ts
+++ b/src/scripts/Providers/OSUI/Dropdown/VirtualSelect/AbstractVirtualSelect.ts
@@ -9,8 +9,6 @@ namespace Providers.OSUI.Dropdown.VirtualSelect {
 		// Dropdown callback events
 		private _onMouseUpEvent: OSFramework.OSUI.GlobalCallbacks.Generic;
 		private _onSelectedOptionEvent: OSFramework.OSUI.GlobalCallbacks.Generic;
-		private _platformEventInitializedCallback: OSFramework.OSUI.GlobalCallbacks.OSGeneric;
-		private _platformEventProviderConfigsAppliedCallback: OSFramework.OSUI.GlobalCallbacks.OSGeneric;
 		private _platformEventSelectedOptCallback: OSFramework.OSUI.Patterns.Dropdown.Callbacks.OSOnSelectEvent;
 
 		// Store the hidden input AriaLabel value
@@ -160,7 +158,7 @@ namespace Providers.OSUI.Dropdown.VirtualSelect {
 			this._manageAttributes();
 
 			// Trigger platform's InstanceIntializedHandler client Action
-			this.triggerPlatformEventInitialized(this._platformEventInitializedCallback);
+			this.triggerPlatformEventInitialized();
 		}
 
 		/**
@@ -209,6 +207,8 @@ namespace Providers.OSUI.Dropdown.VirtualSelect {
 			this._virtualselectConfigs = undefined;
 			this._virtualselectOpts = undefined;
 			this.provider = undefined;
+
+			super.unsetCallbacks();
 		}
 
 		/**
@@ -400,25 +400,15 @@ namespace Providers.OSUI.Dropdown.VirtualSelect {
 		 */
 		public registerCallback(eventName: string, callback: OSFramework.OSUI.GlobalCallbacks.OSGeneric): void {
 			switch (eventName) {
-				case OSFramework.OSUI.Patterns.Dropdown.Enum.Events.Initialized:
-					if (this._platformEventInitializedCallback === undefined) {
-						this._platformEventInitializedCallback = callback;
-					}
-					break;
-
 				case Enum.Events.OnSelected:
 					if (this._platformEventSelectedOptCallback === undefined) {
 						this._platformEventSelectedOptCallback = callback;
 					}
 					break;
-				case Enum.Events.OnProviderConfigsApplied:
-					if (this._platformEventProviderConfigsAppliedCallback === undefined) {
-						this._platformEventProviderConfigsAppliedCallback = callback;
-					}
-					break;
 
 				default:
-					throw new Error(`The given '${eventName}' event name it's not defined.`);
+					super.registerCallback(eventName, callback);
+					break;
 			}
 		}
 
@@ -443,7 +433,7 @@ namespace Providers.OSUI.Dropdown.VirtualSelect {
 		public setProviderConfigs(newConfigs: VirtualSelectOpts): void {
 			this.configs.setExtensibilityConfigs(newConfigs);
 			this.redraw();
-			this.triggerPlatformEventplatformCallback(this._platformEventProviderConfigsAppliedCallback);
+			super.setProviderConfigs(newConfigs);
 		}
 
 		/**

--- a/src/scripts/Providers/OSUI/Dropdown/VirtualSelect/AbstractVirtualSelect.ts
+++ b/src/scripts/Providers/OSUI/Dropdown/VirtualSelect/AbstractVirtualSelect.ts
@@ -76,11 +76,7 @@ namespace Providers.OSUI.Dropdown.VirtualSelect {
 		// Get the selected options and pass them into callBack
 		private _onSelectedOption() {
 			// Trigger platform's SelectedOptionCallbackEvent client Action
-			OSFramework.OSUI.Helper.AsyncInvocation(
-				this._platformEventSelectedOptCallback,
-				this.widgetId,
-				this.getSelectedValues()
-			);
+			this.triggerPlatformEventplatformCallback(this._platformEventSelectedOptCallback, this.getSelectedValues());
 		}
 
 		// Close the dropdown if it's open!

--- a/src/scripts/Providers/OSUI/Dropdown/VirtualSelect/AbstractVirtualSelectEnum.ts
+++ b/src/scripts/Providers/OSUI/Dropdown/VirtualSelect/AbstractVirtualSelectEnum.ts
@@ -23,6 +23,7 @@ namespace Providers.OSUI.Dropdown.VirtualSelect.Enum {
 	 */
 	export enum Events {
 		Change = 'change',
+		OnProviderConfigsApplied = 'OnProviderConfigsApplied',
 		OnSelected = 'OnSelected',
 	}
 

--- a/src/scripts/Providers/OSUI/Dropdown/VirtualSelect/AbstractVirtualSelectEnum.ts
+++ b/src/scripts/Providers/OSUI/Dropdown/VirtualSelect/AbstractVirtualSelectEnum.ts
@@ -23,7 +23,6 @@ namespace Providers.OSUI.Dropdown.VirtualSelect.Enum {
 	 */
 	export enum Events {
 		Change = 'change',
-		OnProviderConfigsApplied = 'OnProviderConfigsApplied',
 		OnSelected = 'OnSelected',
 	}
 

--- a/src/scripts/Providers/OSUI/Monthpicker/Flatpickr/FlatpickrMonth.ts
+++ b/src/scripts/Providers/OSUI/Monthpicker/Flatpickr/FlatpickrMonth.ts
@@ -9,8 +9,6 @@ namespace Providers.OSUI.MonthPicker.Flatpickr {
 		private _bodyScrollCommonBehaviour: SharedProviderResources.Flatpickr.UpdatePositionOnScroll;
 		// Store the provider options
 		private _flatpickrOpts: FlatpickrOptions;
-		// Flatpickr onInitialize event
-		private _onInitializeCallbackEvent: OSFramework.OSUI.GlobalCallbacks.OSGeneric;
 		// Validation of ZIndex position common behavior
 		private _zindexCommonBehavior: SharedProviderResources.Flatpickr.UpdateZindex;
 		// Store the flatpickr input html element that will be added by library
@@ -134,7 +132,7 @@ namespace Providers.OSUI.MonthPicker.Flatpickr {
 			});
 
 			// Trigger platform's InstanceIntializedHandler client Action
-			this.triggerPlatformEventInitialized(this._onInitializeCallbackEvent);
+			this.triggerPlatformEventInitialized();
 		}
 
 		/**
@@ -234,8 +232,8 @@ namespace Providers.OSUI.MonthPicker.Flatpickr {
 		protected unsetCallbacks(): void {
 			this.configs.OnChange = undefined;
 
-			this._onInitializeCallbackEvent = undefined;
 			this._onSelectedCallbackEvent = undefined;
+			super.unsetCallbacks();
 		}
 
 		/**
@@ -363,12 +361,9 @@ namespace Providers.OSUI.MonthPicker.Flatpickr {
 					this._onSelectedCallbackEvent = callback;
 					break;
 
-				case OSFramework.OSUI.Patterns.MonthPicker.Enum.Events.OnInitialized:
-					this._onInitializeCallbackEvent = callback;
-					break;
-
 				default:
-					throw new Error(`The given '${eventName}' event name it's not defined.`);
+					super.registerCallback(eventName, callback);
+					break;
 			}
 		}
 
@@ -409,6 +404,8 @@ namespace Providers.OSUI.MonthPicker.Flatpickr {
 			this.configs.setExtensibilityConfigs(newConfigs);
 
 			this.redraw();
+
+			super.setProviderConfigs(newConfigs);
 		}
 	}
 }

--- a/src/scripts/Providers/OSUI/Monthpicker/Flatpickr/FlatpickrMonth.ts
+++ b/src/scripts/Providers/OSUI/Monthpicker/Flatpickr/FlatpickrMonth.ts
@@ -163,9 +163,8 @@ namespace Providers.OSUI.MonthPicker.Flatpickr {
 			}
 
 			// Trigger platform's onChange callback event
-			OSFramework.OSUI.Helper.AsyncInvocation(
+			this.triggerPlatformEventplatformCallback(
 				this._onSelectedCallbackEvent,
-				this.widgetId,
 				_selectedMonthYear.month,
 				_selectedMonthYear.monthOrder,
 				_selectedMonthYear.year

--- a/src/scripts/Providers/OSUI/RangeSlider/NoUISlider/AbstractNoUiSlider.ts
+++ b/src/scripts/Providers/OSUI/RangeSlider/NoUISlider/AbstractNoUiSlider.ts
@@ -170,6 +170,7 @@ namespace Providers.OSUI.RangeSlider.NoUISlider {
 		 */
 		protected unsetCallbacks(): void {
 			this.eventProviderValueChanged = undefined;
+			super.unsetCallbacks();
 		}
 
 		/**
@@ -312,6 +313,7 @@ namespace Providers.OSUI.RangeSlider.NoUISlider {
 			this.configs.setExtensibilityConfigs(newConfigs);
 
 			this.redraw();
+			super.setProviderConfigs(newConfigs);
 		}
 
 		/**

--- a/src/scripts/Providers/OSUI/RangeSlider/NoUISlider/AbstractNoUiSlider.ts
+++ b/src/scripts/Providers/OSUI/RangeSlider/NoUISlider/AbstractNoUiSlider.ts
@@ -16,7 +16,6 @@ namespace Providers.OSUI.RangeSlider.NoUISlider {
 		protected eventProviderValueChanged: OSFramework.OSUI.GlobalCallbacks.Generic;
 		// Store the provider options
 		protected noUiSliderOpts: NoUiSliderOptions;
-		protected platformEventInitialize: OSFramework.OSUI.GlobalCallbacks.OSGeneric;
 		protected platformEventValueChange: OSFramework.OSUI.Patterns.RangeSlider.Callbacks.OSOnValueChangeEvent;
 		// throttle before invoking the platform
 		protected throttleTimeValue = 200;
@@ -98,7 +97,7 @@ namespace Providers.OSUI.RangeSlider.NoUISlider {
 			this._setOnValueChangeEvent(RangeSlider.NoUiSlider.Enum.NoUISliderEvents.Slide);
 
 			// Trigger platform's InstanceIntializedHandler client Action
-			this.triggerPlatformEventInitialized(this.platformEventInitialize);
+			this.triggerPlatformEventInitialized();
 		}
 
 		/**
@@ -292,20 +291,14 @@ namespace Providers.OSUI.RangeSlider.NoUISlider {
 		 */
 		public registerCallback(eventName: string, callback: OSFramework.OSUI.GlobalCallbacks.OSGeneric): void {
 			switch (eventName) {
-				case OSFramework.OSUI.Patterns.RangeSlider.Enum.RangeSliderEvents.OnInitialize:
-					if (this.platformEventInitialize === undefined) {
-						this.platformEventInitialize = callback;
-					}
-					break;
 				case OSFramework.OSUI.Patterns.RangeSlider.Enum.RangeSliderEvents.OnValueChange:
 					if (this.platformEventValueChange === undefined) {
 						this.platformEventValueChange = callback;
 					}
 					break;
 				default:
-					throw new Error(
-						`${OSFramework.OSUI.ErrorCodes.RangeSlider.FailRegisterCallback}:	The given '${eventName}' event name is not defined.`
-					);
+					super.registerCallback(eventName, callback);
+					break;
 			}
 		}
 

--- a/src/scripts/Providers/OSUI/Timepicker/Flatpickr/FlatpickrTime.ts
+++ b/src/scripts/Providers/OSUI/Timepicker/Flatpickr/FlatpickrTime.ts
@@ -9,8 +9,6 @@ namespace Providers.OSUI.TimePicker.Flatpickr {
 		private _bodyScrollCommonBehaviour: SharedProviderResources.Flatpickr.UpdatePositionOnScroll;
 		// Store the provider options
 		private _flatpickrOpts: FlatpickrOptions;
-		// Flatpickr onInitialize event
-		private _onInitializeCallbackEvent: OSFramework.OSUI.GlobalCallbacks.OSGeneric;
 		// Validation of ZIndex position common behavior
 		private _zindexCommonBehavior: SharedProviderResources.Flatpickr.UpdateZindex;
 		// Store the flatpickr input html element that will be added by library
@@ -134,7 +132,7 @@ namespace Providers.OSUI.TimePicker.Flatpickr {
 			});
 
 			// Trigger platform's InstanceIntializedHandler client Action
-			this.triggerPlatformEventInitialized(this._onInitializeCallbackEvent);
+			this.triggerPlatformEventInitialized();
 		}
 
 		// Method that will be triggered by library each time any time is selected
@@ -211,8 +209,8 @@ namespace Providers.OSUI.TimePicker.Flatpickr {
 		protected unsetCallbacks(): void {
 			this.configs.OnChange = undefined;
 
-			this._onInitializeCallbackEvent = undefined;
 			this._onChangeCallbackEvent = undefined;
+			super.unsetCallbacks();
 		}
 
 		/**
@@ -336,12 +334,9 @@ namespace Providers.OSUI.TimePicker.Flatpickr {
 					this._onChangeCallbackEvent = callback;
 					break;
 
-				case OSFramework.OSUI.Patterns.TimePicker.Enum.TimePickerEvents.OnInitialized:
-					this._onInitializeCallbackEvent = callback;
-					break;
-
 				default:
-					throw new Error(`The given '${eventName}' event name it's not defined.`);
+					super.registerCallback(eventName, callback);
+					break;
 			}
 		}
 		/**
@@ -381,6 +376,8 @@ namespace Providers.OSUI.TimePicker.Flatpickr {
 			this.configs.setExtensibilityConfigs(newConfigs);
 
 			this.redraw();
+
+			super.setProviderConfigs(newConfigs);
 		}
 
 		/**

--- a/src/scripts/Providers/OSUI/Timepicker/Flatpickr/FlatpickrTime.ts
+++ b/src/scripts/Providers/OSUI/Timepicker/Flatpickr/FlatpickrTime.ts
@@ -146,7 +146,7 @@ namespace Providers.OSUI.TimePicker.Flatpickr {
 			}
 
 			// Trigger platform's onChange callback event
-			OSFramework.OSUI.Helper.AsyncInvocation(this._onChangeCallbackEvent, this.widgetId, _selectedTime);
+			this.triggerPlatformEventplatformCallback(this._onChangeCallbackEvent, _selectedTime);
 		}
 
 		/**


### PR DESCRIPTION
This PR is for adding the provider configs event. This event will be triggered after the setProviderConfigs methods are invoked and the new configs applied.

### What was happening
- The lack of this event, caused somethings for a flickering to occur, since the pattern is first built, and then destroyed once the method setProviderConfigs is invoked.

### What was done
- The previously abstract method `registerCallback` in the class `AbstractProviderPattern` was not implemented.
- This method encapsulates the logic of the events `Initialized` (previously dispersed through out the code) and the newly created event `OnProviderConfigsApplied`.
- Two new methods were added in the class `AbstractProviderPattern`:
  - triggerPlatformEventInitialized: will raise the `Initialized` event of the pattern;
  - triggerPlatformEventplatformCallback: will raise any generic event to OutSystems platform. This means that as first parameter there will always be the `this.widgetId`.
- Added correct context to some of the async calls

### Checklist
-   [x] tested locally
-   [x] documented the code
-   [x] clean all warnings and errors of eslint
-   [ ] requires changes in OutSystems (if so, provide a module with changes)
-   [ ] requires new sample page in OutSystems (if so, provide a module with changes)
