### PR TITLE
Minimal supported node version set to 12 to support globalThis variab…

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ We highly recommend the usage of the following tools:
     -   Document This
     -   ESLint
     -   Prettier - Code formatter
+-   [Node v12.0+](https://nodejs.org/en)
 
 ### How to change this code?
 

--- a/package.json
+++ b/package.json
@@ -19,6 +19,9 @@
 		"type": "git",
 		"url": "git+https://github.com/OutSystems/outsystems-ui"
 	},
+	"engines": {
+		"node": ">=12"
+	},
 	"author": "UI Components Team",
 	"keywords": [
 		"OutSystems",


### PR DESCRIPTION
### What was happening

Unable to build with node version 10, because of the error "ReferenceError: globalThis is not defined", This is added in node 12 see this post [ReferenceError: globalThis is not defined](https://stackoverflow.com/questions/66586352/referenceerror-globalthis-is-not-defined)

By requiring a minimal node version it will be easier for new developers to startup the project, If there is a minimal node version please let me know so I can update my pull request.

### What was done

- Added minimal node version 12 in packages.json
- Added node to recommended tools list

### Test Steps

1. 

### Screenshots

(prefer animated gif)

### Checklist

-   [] tested locally
-   [] documented the code
-   [] clean all warnings and errors of eslint
-   [] requires changes in OutSystems (if so, provide a module with changes)
-   [] requires new sample page in OutSystems (if so, provide a module with changes)
