### PR TITLE
ROU-4223: Prevent Sidebar closes when a detached element is clicked

### DIFF
--- a/dist/OutSystemsUI.js
+++ b/dist/OutSystemsUI.js
@@ -7938,7 +7938,7 @@ var OSFramework;
                         OSUI.Helper.A11Y.SetElementsTabIndex(this._isOpen, this._focusTrapInstance.focusableElements);
                     }
                     _overlayClickCallback(_args, e) {
-                        if (this._isOpen && this._clickedOutsideElement) {
+                        if (this._isOpen && this._clickedOutsideElement && e.target === this.selfElement) {
                             this.close();
                         }
                         e.stopPropagation();

--- a/src/scripts/OSFramework/OSUI/Pattern/Sidebar/Sidebar.ts
+++ b/src/scripts/OSFramework/OSUI/Pattern/Sidebar/Sidebar.ts
@@ -161,7 +161,7 @@ namespace OSFramework.OSUI.Patterns.Sidebar {
 		// Overlay onClick event to close the Sidebar
 		private _overlayClickCallback(_args: string, e: MouseEvent): void {
 			// If the sidebar is opened and the mouse down event occured outside the sidebar, close it.
-			if (this._isOpen && this._clickedOutsideElement) {
+			if (this._isOpen && this._clickedOutsideElement && e.target === this.selfElement) {
 				this.close();
 			}
 


### PR DESCRIPTION
This PR is for fixing the issue of closing the sidebar when an element clicked is at body level.

### What was happening
- When a sidebar is used with elements that is detach (Dropdowns Tags and Search) from block and moved to body level, the Sidebar closes always when a selection is made on dropdowns options:
![image](https://user-images.githubusercontent.com/25321845/229154682-a21c7f87-4e8c-46ce-8c14-8236454d5d99.png)

### What was done
- Created a validation on method "_overlayMouseDownCallback" that will validate if the element clicked ids the same as the overlay:
![image](https://user-images.githubusercontent.com/25321845/229155389-7fcab123-808b-44bd-8a51-e4c5309459c2.png)

### Test Steps
1. Open Sample page
2. Click on button to open the Sidebar
3. Select each dropdown
4. Select any option / multiple options on dropdown
5. Expected: The Sidebar will keep open on each interaction

### Checklist
-   [X] tested locally
-   [X] documented the code
-   [X] clean all warnings and errors of eslint
-   [ ] requires changes in OutSystems (if so, provide a module with changes)
-   [ ] requires new sample page in OutSystems (if so, provide a module with changes)
