### PR TITLE
ROU-4126: Fix RTL issue in TD in mobile when is RTL

### DIFF
--- a/dist/OutSystemsUI.css
+++ b/dist/OutSystemsUI.css
@@ -2602,6 +2602,9 @@ select.dropdown-display[disabled]{
   position:relative;
   z-index:var(--layer-global-screen);
 }
+.is-rtl.phone .table:not(.table-no-responsive) td, .is-rtl.tablet .table:not(.table-no-responsive) td{
+  text-align:right !important;
+}
 .is-rtl.phone .table:not(.table-no-responsive) td:before, .is-rtl.tablet .table:not(.table-no-responsive) td:before{
   margin-left:10px;
   margin-right:0px;

--- a/src/scss/03-widgets/_table.scss
+++ b/src/scss/03-widgets/_table.scss
@@ -280,6 +280,10 @@
 	&.phone,
 	&.tablet {
 		.table:not(.table-no-responsive) {
+			td {
+				text-align: right !important;
+			}
+
 			td:before {
 				margin-left: 10px;
 				margin-right: 0px;


### PR DESCRIPTION
This PR is for the alignment of elements inside table on mobile when the RTL is enabled.
### What was happening
![image](https://user-images.githubusercontent.com/25321845/229161376-5b458de0-0a8b-446c-9a03-42726257de70.png)

### What was done
![image](https://user-images.githubusercontent.com/25321845/229161469-e13a61af-7a5d-4ce5-90e3-7a25bf55ef6e.png)

### Test Steps
1. Open Sample Page
2. Enable RTL
3. Emulate a mobile device
4. Expected: the table elements will align to right

### Checklist
-   [X] tested locally
-   [X] documented the code
-   [X] clean all warnings and errors of eslint
-   [ ] requires changes in OutSystems (if so, provide a module with changes)
-   [ ] requires new sample page in OutSystems (if so, provide a module with changes)
