### PR TITLE
Fix DropdownServerSide initialized as disabled

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ We highly recommend the usage of the following tools:
 
 <ol>
   <li>Do a Repository <strong>Fork</strong></li>
-  <li>Create a branch based in the branch <strong>master</strong> (lastest & greatest release)</li>
+  <li>Create a branch based in the branch <strong>master</strong> (latest & greatest release) - branch master is <strong>dev</strong></li>
   <li>Open your banch Code in Visual Studio Code</li>
   <li>Run the following command in Visual Studio Code terminal: <code>npm run setup</code> (this will install all the dependencies that you need to compile the code)</li>
   <li>Do your magic! 😎</li>

--- a/dist/OutSystemsUI.d.ts
+++ b/dist/OutSystemsUI.d.ts
@@ -1724,6 +1724,7 @@ declare namespace OSFramework.OSUI.Patterns.Dropdown.ServerSide {
         private _setBalloonWrapperExtendedClass;
         private _setCssClasses;
         private _setFocusSpanElements;
+        private _setInitialOptions;
         private _setNewOptionItem;
         private _setObserver;
         private _setUpEvents;

--- a/dist/OutSystemsUI.js
+++ b/dist/OutSystemsUI.js
@@ -4810,6 +4810,11 @@ var OSFramework;
                             };
                             this._focusTrapObject = new OSUI.Behaviors.FocusTrap(opts);
                         }
+                        _setInitialOptions() {
+                            if (this.configs.IsDisabled) {
+                                this.disable();
+                            }
+                        }
                         _setNewOptionItem(optionItem) {
                             if (this.getChild(optionItem.uniqueId)) {
                                 throw new Error(`${OSUI.ErrorCodes.Dropdown.FailSetNewOptionItem}: There is already a ${OSUI.GlobalEnum.PatternName.DropdownServerSideItem} under Id: '${optionItem.widgetId}' added to ${OSUI.GlobalEnum.PatternName.Dropdown} with uniqueId: ${this.uniqueId}.`);
@@ -5036,6 +5041,7 @@ var OSFramework;
                             super.build();
                             this.setCallbacks();
                             this.setHtmlElements();
+                            this._setInitialOptions();
                             super.finishBuild();
                         }
                         changeProperty(propertyName, propertyValue) {

--- a/src/scripts/OSFramework/OSUI/Pattern/Dropdown/ServerSide/DropdownServerSide.ts
+++ b/src/scripts/OSFramework/OSUI/Pattern/Dropdown/ServerSide/DropdownServerSide.ts
@@ -552,7 +552,6 @@ namespace OSFramework.OSUI.Patterns.Dropdown.ServerSide {
 				this._setBalloonWrapperExtendedClass(this.configs.ExtendedClass);
 			}
 		}
-
 		// Add Custom HTML elements to the DropdownBallon in order to help on deal with keyboard navigation (Accessibility)
 		private _setFocusSpanElements(): void {
 			const opts = {
@@ -564,6 +563,12 @@ namespace OSFramework.OSUI.Patterns.Dropdown.ServerSide {
 			this._focusTrapObject = new Behaviors.FocusTrap(opts);
 		}
 
+		// Method to set the initial options on screen load
+		private _setInitialOptions(): void {
+			if (this.configs.IsDisabled) {
+				this.disable();
+			}
+		}
 		// Method used to store a given DropdownOption into optionItems list, it's triggered by DropdownServerSideItem
 		private _setNewOptionItem(optionItem: Patterns.DropdownServerSideItem.DropdownServerSideItem): void {
 			// Check if the given OptionId has been already added
@@ -994,6 +999,7 @@ namespace OSFramework.OSUI.Patterns.Dropdown.ServerSide {
 			super.build();
 			this.setCallbacks();
 			this.setHtmlElements();
+			this._setInitialOptions();
 			super.finishBuild();
 		}
 


### PR DESCRIPTION
This PR is for fixing an issue that caused the DropdownServerSide component not to properly be initialized in the disabled state.

### What was happening

- This occurred when the IsDisabled configuration was initialized with True (when changing the value in runtime it worked as expected).

### What was done

- A validation was added to the build to look at the IsDisabled attribute and, if True, we'll disable the input accordingly.

### Screenshots

![ROU-4224_TestsOK](https://user-images.githubusercontent.com/29493222/229578520-4a013feb-94f0-4d4e-aa1a-0afaf9d07a87.gif)


### Test Steps

1. Created a screen with two DropdownServerSide instances - one with IsDisabled = True and the other with IsDisabled = False
2. Checked that the input is disabled for the first and enabled for the second as expected
3. Clicked on the Toggle button to toggle the IsDisabled value in runtime
4. Checked that they changed accordingly to the value 


### Checklist

-   [X] tested locally
-   [X] documented the code
-   [X] clean all warnings and errors of eslint
-   [ ] requires changes in OutSystems (if so, provide a module with changes)
-   [ ] requires new sample page in OutSystems (if so, provide a module with changes)
