### PR TITLE
ROU-4223: Add feature to detached patterns to prevent trigger the body click global event

### DIFF
--- a/dist/OutSystemsUI.d.ts
+++ b/dist/OutSystemsUI.d.ts
@@ -544,13 +544,17 @@ declare namespace OSFramework.OSUI.Event {
 }
 declare namespace OSFramework.OSUI.Event {
     abstract class AbstractEventsManager<ET, D> {
+        private _enableBodyClick;
         private _events;
         constructor();
         addHandler(eventType: ET, handler: GlobalCallbacks.Generic): void;
+        disableBodyClickEvent(): void;
+        enableBodyClickEvent(): void;
         hasHandlers(eventType: ET): boolean;
         removeHandler(eventType: ET, handler: GlobalCallbacks.Generic): void;
         trigger(eventType: ET, data?: D, ...args: unknown[]): void;
         get events(): Map<ET, IEvent<D>>;
+        get getBodyClickStatus(): boolean;
         protected abstract getInstanceOfEventType(eventType: ET): IEvent<D>;
     }
 }
@@ -4861,6 +4865,8 @@ declare namespace Providers.OSUI.Dropdown.VirtualSelect.Enum {
         OptionItemImage = "osui-dropdown-option-image"
     }
     enum Events {
+        BeforeClose = "beforeClose",
+        BeforeOpen = "beforeOpen",
         Change = "change",
         OnSelected = "OnSelected"
     }

--- a/dist/OutSystemsUI.js
+++ b/dist/OutSystemsUI.js
@@ -17388,9 +17388,6 @@ var Providers;
                         this.provider.config.onOpen.push(function () {
                             OSFramework.OSUI.Event.GlobalEventManager.Instance.disableBodyClickEvent();
                         });
-                        this.provider.config.onOpen.push(() => {
-                            OSFramework.OSUI.Event.GlobalEventManager.Instance.disableBodyClickEvent();
-                        });
                         this.provider.config.onClose.push(() => {
                             OSFramework.OSUI.Event.GlobalEventManager.Instance.enableBodyClickEvent();
                         });

--- a/dist/OutSystemsUI.js
+++ b/dist/OutSystemsUI.js
@@ -16778,7 +16778,6 @@ var Providers;
                     }
                     close() {
                         this._virtualselectConfigs.close();
-                        OSFramework.OSUI.Event.GlobalEventManager.Instance.enableBodyClickEvent();
                     }
                     disable() {
                         if (this.configs.IsDisabled === false) {
@@ -16819,7 +16818,6 @@ var Providers;
                     }
                     open() {
                         this._virtualselectConfigs.open();
-                        OSFramework.OSUI.Event.GlobalEventManager.Instance.disableBodyClickEvent();
                     }
                     registerCallback(eventName, callback) {
                         switch (eventName) {

--- a/dist/OutSystemsUI.js
+++ b/dist/OutSystemsUI.js
@@ -952,6 +952,7 @@ var OSFramework;
         (function (Event) {
             class AbstractEventsManager {
                 constructor() {
+                    this._enableBodyClick = true;
                     this._events = new Map();
                 }
                 addHandler(eventType, handler) {
@@ -965,6 +966,12 @@ var OSFramework;
                             this._events.set(eventType, ev);
                         }
                     }
+                }
+                disableBodyClickEvent() {
+                    this._enableBodyClick = false;
+                }
+                enableBodyClickEvent() {
+                    this._enableBodyClick = true;
                 }
                 hasHandlers(eventType) {
                     let returnValue = false;
@@ -988,6 +995,9 @@ var OSFramework;
                 get events() {
                     return this._events;
                 }
+                get getBodyClickStatus() {
+                    return this._enableBodyClick;
+                }
             }
             Event.AbstractEventsManager = AbstractEventsManager;
         })(Event = OSUI.Event || (OSUI.Event = {}));
@@ -1005,7 +1015,9 @@ var OSFramework;
                     document.body.addEventListener(OSUI.GlobalEnum.HTMLEvent.Click, this._bodyTrigger.bind(this));
                 }
                 _bodyTrigger(evt) {
-                    this.trigger(OSUI.GlobalEnum.HTMLEvent.Click, evt);
+                    if (Event.GlobalEventManager.Instance.getBodyClickStatus) {
+                        this.trigger(OSUI.GlobalEnum.HTMLEvent.Click, evt);
+                    }
                 }
             }
             Event.BodyOnClick = BodyOnClick;
@@ -7938,7 +7950,7 @@ var OSFramework;
                         OSUI.Helper.A11Y.SetElementsTabIndex(this._isOpen, this._focusTrapInstance.focusableElements);
                     }
                     _overlayClickCallback(_args, e) {
-                        if (this._isOpen && this._clickedOutsideElement && e.target === this.selfElement) {
+                        if (this._isOpen && this._clickedOutsideElement) {
                             this.close();
                         }
                         e.stopPropagation();
@@ -16691,6 +16703,12 @@ var Providers;
                         });
                         this._manageAttributes();
                         this.triggerPlatformEventInitialized();
+                        this.selfElement.addEventListener(VirtualSelect.Enum.Events.BeforeOpen, () => {
+                            OSFramework.OSUI.Event.GlobalEventManager.Instance.disableBodyClickEvent();
+                        });
+                        this.selfElement.addEventListener(VirtualSelect.Enum.Events.BeforeClose, () => {
+                            OSFramework.OSUI.Event.GlobalEventManager.Instance.enableBodyClickEvent();
+                        });
                     }
                     setA11YProperties() {
                         this.setHiddenInputWrapperAriaLabelVal();
@@ -16760,6 +16778,7 @@ var Providers;
                     }
                     close() {
                         this._virtualselectConfigs.close();
+                        OSFramework.OSUI.Event.GlobalEventManager.Instance.enableBodyClickEvent();
                     }
                     disable() {
                         if (this.configs.IsDisabled === false) {
@@ -16800,6 +16819,7 @@ var Providers;
                     }
                     open() {
                         this._virtualselectConfigs.open();
+                        OSFramework.OSUI.Event.GlobalEventManager.Instance.disableBodyClickEvent();
                     }
                     registerCallback(eventName, callback) {
                         switch (eventName) {
@@ -17038,6 +17058,8 @@ var Providers;
                     })(CssClass = Enum.CssClass || (Enum.CssClass = {}));
                     let Events;
                     (function (Events) {
+                        Events["BeforeClose"] = "beforeClose";
+                        Events["BeforeOpen"] = "beforeOpen";
                         Events["Change"] = "change";
                         Events["OnSelected"] = "OnSelected";
                     })(Events = Enum.Events || (Enum.Events = {}));
@@ -17365,6 +17387,12 @@ var Providers;
                             this._zindexCommonBehavior = new OSUI.SharedProviderResources.Flatpickr.UpdateZindex(this);
                         }
                         this.createdInstance();
+                        this.provider.config.onOpen.push(function () {
+                            OSFramework.OSUI.Event.GlobalEventManager.Instance.disableBodyClickEvent();
+                        });
+                        this.provider.config.onClose.push(function () {
+                            OSFramework.OSUI.Event.GlobalEventManager.Instance.enableBodyClickEvent();
+                        });
                     }
                     createdInstance() {
                         this.updateProviderEvents({
@@ -18380,6 +18408,12 @@ var Providers;
                             this._zindexCommonBehavior = new OSUI.SharedProviderResources.Flatpickr.UpdateZindex(this);
                         }
                         this.createdInstance();
+                        this.provider.config.onOpen.push(function () {
+                            OSFramework.OSUI.Event.GlobalEventManager.Instance.disableBodyClickEvent();
+                        });
+                        this.provider.config.onClose.push(function () {
+                            OSFramework.OSUI.Event.GlobalEventManager.Instance.enableBodyClickEvent();
+                        });
                     }
                     createdInstance() {
                         this.updateProviderEvents({

--- a/dist/OutSystemsUI.js
+++ b/dist/OutSystemsUI.js
@@ -17390,7 +17390,10 @@ var Providers;
                         this.provider.config.onOpen.push(function () {
                             OSFramework.OSUI.Event.GlobalEventManager.Instance.disableBodyClickEvent();
                         });
-                        this.provider.config.onClose.push(function () {
+                        this.provider.config.onOpen.push(() => {
+                            OSFramework.OSUI.Event.GlobalEventManager.Instance.disableBodyClickEvent();
+                        });
+                        this.provider.config.onClose.push(() => {
                             OSFramework.OSUI.Event.GlobalEventManager.Instance.enableBodyClickEvent();
                         });
                     }
@@ -18408,10 +18411,10 @@ var Providers;
                             this._zindexCommonBehavior = new OSUI.SharedProviderResources.Flatpickr.UpdateZindex(this);
                         }
                         this.createdInstance();
-                        this.provider.config.onOpen.push(function () {
+                        this.provider.config.onOpen.push(() => {
                             OSFramework.OSUI.Event.GlobalEventManager.Instance.disableBodyClickEvent();
                         });
-                        this.provider.config.onClose.push(function () {
+                        this.provider.config.onClose.push(() => {
                             OSFramework.OSUI.Event.GlobalEventManager.Instance.enableBodyClickEvent();
                         });
                     }

--- a/src/scripts/OSFramework/OSUI/Event/AbstractEventsManager.ts
+++ b/src/scripts/OSFramework/OSUI/Event/AbstractEventsManager.ts
@@ -13,6 +13,7 @@ namespace OSFramework.OSUI.Event {
 	 * @template D  this will be the type of Data to be passed, by default to the handlers.
 	 */
 	export abstract class AbstractEventsManager<ET, D> {
+		private _enableBodyClick = true;
 		private _events: Map<ET, IEvent<D>>;
 
 		constructor() {
@@ -36,6 +37,26 @@ namespace OSFramework.OSUI.Event {
 					this._events.set(eventType, ev);
 				}
 			}
+		}
+
+		/**
+		 * This method is to disable the body click on detached patterns
+		 *
+		 * @param {boolean} disableBodyClick
+		 * @memberof AbstractEventsManager
+		 */
+		public disableBodyClickEvent(): void {
+			this._enableBodyClick = false;
+		}
+
+		/**
+		 * This method is to enable the body click on detached patterns
+		 *
+		 * @param {boolean} disableBodyClick
+		 * @memberof AbstractEventsManager
+		 */
+		public enableBodyClickEvent(): void {
+			this._enableBodyClick = true;
 		}
 
 		/**
@@ -91,6 +112,17 @@ namespace OSFramework.OSUI.Event {
 		 */
 		public get events(): Map<ET, IEvent<D>> {
 			return this._events;
+		}
+
+		/**
+		 * Getter that returns the body click status
+		 *
+		 * @readonly
+		 * @type {boolean}
+		 * @memberof AbstractEventsManager
+		 */
+		public get getBodyClickStatus(): boolean {
+			return this._enableBodyClick;
 		}
 
 		/**

--- a/src/scripts/OSFramework/OSUI/Event/BodyOnClick.ts
+++ b/src/scripts/OSFramework/OSUI/Event/BodyOnClick.ts
@@ -26,7 +26,10 @@ namespace OSFramework.OSUI.Event {
 		}
 
 		private _bodyTrigger(evt: PointerEvent): void {
-			this.trigger(GlobalEnum.HTMLEvent.Click, evt);
+			// Trigger the body click event only if the getBodyClickStatus is True
+			if (GlobalEventManager.Instance.getBodyClickStatus) {
+				this.trigger(GlobalEnum.HTMLEvent.Click, evt);
+			}
 		}
 	}
 }

--- a/src/scripts/OSFramework/OSUI/Pattern/Sidebar/Sidebar.ts
+++ b/src/scripts/OSFramework/OSUI/Pattern/Sidebar/Sidebar.ts
@@ -161,7 +161,7 @@ namespace OSFramework.OSUI.Patterns.Sidebar {
 		// Overlay onClick event to close the Sidebar
 		private _overlayClickCallback(_args: string, e: MouseEvent): void {
 			// If the sidebar is opened and the mouse down event occured outside the sidebar, close it.
-			if (this._isOpen && this._clickedOutsideElement && e.target === this.selfElement) {
+			if (this._isOpen && this._clickedOutsideElement) {
 				this.close();
 			}
 

--- a/src/scripts/Providers/OSUI/Dropdown/VirtualSelect/AbstractVirtualSelect.ts
+++ b/src/scripts/Providers/OSUI/Dropdown/VirtualSelect/AbstractVirtualSelect.ts
@@ -308,9 +308,6 @@ namespace Providers.OSUI.Dropdown.VirtualSelect {
 		 */
 		public close(): void {
 			this._virtualselectConfigs.close();
-
-			// Enable the global event to close on body click
-			OSFramework.OSUI.Event.GlobalEventManager.Instance.enableBodyClickEvent();
 		}
 
 		/**
@@ -396,9 +393,6 @@ namespace Providers.OSUI.Dropdown.VirtualSelect {
 		 */
 		public open(): void {
 			this._virtualselectConfigs.open();
-
-			// Disable the global event to close on body click
-			OSFramework.OSUI.Event.GlobalEventManager.Instance.disableBodyClickEvent();
 		}
 
 		/**

--- a/src/scripts/Providers/OSUI/Dropdown/VirtualSelect/AbstractVirtualSelect.ts
+++ b/src/scripts/Providers/OSUI/Dropdown/VirtualSelect/AbstractVirtualSelect.ts
@@ -155,6 +155,14 @@ namespace Providers.OSUI.Dropdown.VirtualSelect {
 
 			// Trigger platform's InstanceIntializedHandler client Action
 			this.triggerPlatformEventInitialized();
+
+			// Add events to change the global event triggering of body click on Open / Close
+			this.selfElement.addEventListener(Enum.Events.BeforeOpen, () => {
+				OSFramework.OSUI.Event.GlobalEventManager.Instance.disableBodyClickEvent();
+			});
+			this.selfElement.addEventListener(Enum.Events.BeforeClose, () => {
+				OSFramework.OSUI.Event.GlobalEventManager.Instance.enableBodyClickEvent();
+			});
 		}
 
 		/**
@@ -300,6 +308,9 @@ namespace Providers.OSUI.Dropdown.VirtualSelect {
 		 */
 		public close(): void {
 			this._virtualselectConfigs.close();
+
+			// Enable the global event to close on body click
+			OSFramework.OSUI.Event.GlobalEventManager.Instance.enableBodyClickEvent();
 		}
 
 		/**
@@ -385,6 +396,9 @@ namespace Providers.OSUI.Dropdown.VirtualSelect {
 		 */
 		public open(): void {
 			this._virtualselectConfigs.open();
+
+			// Disable the global event to close on body click
+			OSFramework.OSUI.Event.GlobalEventManager.Instance.disableBodyClickEvent();
 		}
 
 		/**

--- a/src/scripts/Providers/OSUI/Dropdown/VirtualSelect/AbstractVirtualSelectEnum.ts
+++ b/src/scripts/Providers/OSUI/Dropdown/VirtualSelect/AbstractVirtualSelectEnum.ts
@@ -22,6 +22,8 @@ namespace Providers.OSUI.Dropdown.VirtualSelect.Enum {
 	 * Events
 	 */
 	export enum Events {
+		BeforeClose = 'beforeClose',
+		BeforeOpen = 'beforeOpen',
 		Change = 'change',
 		OnSelected = 'OnSelected',
 	}

--- a/src/scripts/Providers/OSUI/Monthpicker/Flatpickr/FlatpickrMonth.ts
+++ b/src/scripts/Providers/OSUI/Monthpicker/Flatpickr/FlatpickrMonth.ts
@@ -115,6 +115,14 @@ namespace Providers.OSUI.MonthPicker.Flatpickr {
 			}
 
 			this.createdInstance();
+
+			// Add triggers to change the global event triggering of body click on Open / Close
+			this.provider.config.onOpen.push(function () {
+				OSFramework.OSUI.Event.GlobalEventManager.Instance.disableBodyClickEvent();
+			});
+			this.provider.config.onClose.push(function () {
+				OSFramework.OSUI.Event.GlobalEventManager.Instance.enableBodyClickEvent();
+			});
 		}
 
 		/**

--- a/src/scripts/Providers/OSUI/Monthpicker/Flatpickr/FlatpickrMonth.ts
+++ b/src/scripts/Providers/OSUI/Monthpicker/Flatpickr/FlatpickrMonth.ts
@@ -120,7 +120,10 @@ namespace Providers.OSUI.MonthPicker.Flatpickr {
 			this.provider.config.onOpen.push(function () {
 				OSFramework.OSUI.Event.GlobalEventManager.Instance.disableBodyClickEvent();
 			});
-			this.provider.config.onClose.push(function () {
+			this.provider.config.onOpen.push(() => {
+				OSFramework.OSUI.Event.GlobalEventManager.Instance.disableBodyClickEvent();
+			});
+			this.provider.config.onClose.push(() => {
 				OSFramework.OSUI.Event.GlobalEventManager.Instance.enableBodyClickEvent();
 			});
 		}

--- a/src/scripts/Providers/OSUI/Monthpicker/Flatpickr/FlatpickrMonth.ts
+++ b/src/scripts/Providers/OSUI/Monthpicker/Flatpickr/FlatpickrMonth.ts
@@ -120,9 +120,6 @@ namespace Providers.OSUI.MonthPicker.Flatpickr {
 			this.provider.config.onOpen.push(function () {
 				OSFramework.OSUI.Event.GlobalEventManager.Instance.disableBodyClickEvent();
 			});
-			this.provider.config.onOpen.push(() => {
-				OSFramework.OSUI.Event.GlobalEventManager.Instance.disableBodyClickEvent();
-			});
 			this.provider.config.onClose.push(() => {
 				OSFramework.OSUI.Event.GlobalEventManager.Instance.enableBodyClickEvent();
 			});

--- a/src/scripts/Providers/OSUI/Timepicker/Flatpickr/FlatpickrTime.ts
+++ b/src/scripts/Providers/OSUI/Timepicker/Flatpickr/FlatpickrTime.ts
@@ -117,10 +117,10 @@ namespace Providers.OSUI.TimePicker.Flatpickr {
 			this.createdInstance();
 
 			// Add triggers to change the global event triggering of body click on Open / Close
-			this.provider.config.onOpen.push(function () {
+			this.provider.config.onOpen.push(() => {
 				OSFramework.OSUI.Event.GlobalEventManager.Instance.disableBodyClickEvent();
 			});
-			this.provider.config.onClose.push(function () {
+			this.provider.config.onClose.push(() => {
 				OSFramework.OSUI.Event.GlobalEventManager.Instance.enableBodyClickEvent();
 			});
 		}

--- a/src/scripts/Providers/OSUI/Timepicker/Flatpickr/FlatpickrTime.ts
+++ b/src/scripts/Providers/OSUI/Timepicker/Flatpickr/FlatpickrTime.ts
@@ -115,6 +115,14 @@ namespace Providers.OSUI.TimePicker.Flatpickr {
 			}
 
 			this.createdInstance();
+
+			// Add triggers to change the global event triggering of body click on Open / Close
+			this.provider.config.onOpen.push(function () {
+				OSFramework.OSUI.Event.GlobalEventManager.Instance.disableBodyClickEvent();
+			});
+			this.provider.config.onClose.push(function () {
+				OSFramework.OSUI.Event.GlobalEventManager.Instance.enableBodyClickEvent();
+			});
 		}
 
 		/**


### PR DESCRIPTION
This PR is for adding feature to detached patterns to prevent trigger the body click global event:
- Rollback the previous fix to prevent sidebar close when has detached patterns inside
- Add methods **enableBodyClickEvent** & **disableBodyClickEvent** to prevent body click triggering on patterns that are detached from the block and uses the global body click event
- Add a getter **getBodyClickStatus** to check the global body click event status
- Review the global event **BodyOnClick** to add the status validation of body click and trigger it only if is enabled

### Checklist
-   [X] tested locally
-   [X] documented the code
-   [X] clean all warnings and errors of eslint
-   [ ] requires changes in OutSystems (if so, provide a module with changes)
-   [ ] requires new sample page in OutSystems (if so, provide a module with changes)
