### PR TITLE
Fixed Zoom issue on Tabs when using Edge

### DIFF
--- a/dist/OutSystemsUI.d.ts
+++ b/dist/OutSystemsUI.d.ts
@@ -2959,6 +2959,7 @@ declare namespace OSFramework.OSUI.Patterns.Tabs {
         private _hasSingleContent;
         private _headerItemsLength;
         private _isChrome;
+        private _isEdge;
         private _platformEventTabsOnChange;
         private _requestAnimationFrameOnIndicatorResize;
         private _tabsContentElement;

--- a/dist/OutSystemsUI.js
+++ b/dist/OutSystemsUI.js
@@ -8786,6 +8786,7 @@ var OSFramework;
                         this._hasDragGestures =
                             OSUI.Helper.DeviceInfo.IsNative && this.configs.TabsOrientation === OSUI.GlobalEnum.Orientation.Horizontal;
                         this._isChrome = OSUI.Helper.DeviceInfo.GetBrowser() === 'chrome';
+                        this._isEdge = OSUI.Helper.DeviceInfo.GetBrowser() === 'edge';
                     }
                     _addContentItem(tabsContentChildItem) {
                         if (this.getChild(tabsContentChildItem.uniqueId)) {
@@ -8918,7 +8919,7 @@ var OSFramework;
                                     : activeElement.offsetLeft;
                             const newSize = isVertical ? activeElement.offsetHeight : activeElement.offsetWidth;
                             let pixelRatio = 1;
-                            if (this._isChrome) {
+                            if (this._isChrome || this._isEdge) {
                                 pixelRatio = window.devicePixelRatio;
                             }
                             const newScaleValue = (pixelRatio * newSize) / Math.round(pixelRatio);

--- a/src/scripts/OSFramework/OSUI/Pattern/Tabs/Tabs.ts
+++ b/src/scripts/OSFramework/OSUI/Pattern/Tabs/Tabs.ts
@@ -32,8 +32,10 @@ namespace OSFramework.OSUI.Patterns.Tabs {
 		private _hasSingleContent: boolean;
 		// Store the number of headerItems to be used to set the css variable
 		private _headerItemsLength: number;
-		// Store if the current browser is chrome
+		// Store if the current browser is Edge
 		private _isChrome: boolean;
+		// Store if the current browser is Chrome
+		private _isEdge: boolean;
 		// Store the onTabsChange platform callback
 		private _platformEventTabsOnChange: Callbacks.OSOnChangeEvent;
 		// Store the id of the requestAnimationFrame called to animate the indicator
@@ -52,6 +54,7 @@ namespace OSFramework.OSUI.Patterns.Tabs {
 			this._hasDragGestures =
 				Helper.DeviceInfo.IsNative && this.configs.TabsOrientation === GlobalEnum.Orientation.Horizontal;
 			this._isChrome = Helper.DeviceInfo.GetBrowser() === 'chrome';
+			this._isEdge = Helper.DeviceInfo.GetBrowser() === 'edge';
 		}
 
 		// Method that it's called whenever a new TabsContentItem is rendered
@@ -275,7 +278,7 @@ namespace OSFramework.OSUI.Patterns.Tabs {
 
 				let pixelRatio = 1;
 
-				if (this._isChrome) {
+				if (this._isChrome || this._isEdge) {
 					// devicePixelRatio used here to account for browser or system zoom
 					pixelRatio = window.devicePixelRatio;
 				}


### PR DESCRIPTION
This PR is to fix a Zoom issue on Tabs when using Edge.


### What was happening

- Tabs indicator was not updating properly in Edge when using the browser's Zoom.

![TabsZoomEdge](https://user-images.githubusercontent.com/29493222/229822169-668a33ca-e939-4edd-99ff-51490516a579.gif)


### What was done

- Added support to Edge when doing the Math needed for Zoom, taking advantage of _window.devicePixelRatio_ is used here to account for browser or system Zoom, which has [support for Edge as well after version 97](https://www.lambdatest.com/web-technologies/devicepixelratio-support-on-edge-97).

### Test Steps

1. Open a screen containing Tabs in Edge
2. Resize the window, use the responsiveness points for Tablet and Phone and use the browser's Zoom
3. Checked that the Tab's active indicator adapts its size accordingly.
4. Repeat for Chrome / Firefox and Safari

### Screenshots

![TabsZoomEdgeOK](https://user-images.githubusercontent.com/29493222/229824582-2fd76666-0b6d-41d3-885f-5f0b26352d25.gif)


### Checklist

-   [X] tested locally
-   [X] documented the code
-   [X] clean all warnings and errors of eslint
-   [ ] requires changes in OutSystems (if so, provide a module with changes)
-   [ ] requires new sample page in OutSystems (if so, provide a module with changes)
