### PR TITLE
[ROU-4228]: - Open/Close API methods update.

### DIFF
--- a/src/scripts/OSFramework/OSUI/Helper/AsyncInvocation.ts
+++ b/src/scripts/OSFramework/OSUI/Helper/AsyncInvocation.ts
@@ -1,6 +1,25 @@
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 namespace OSFramework.OSUI.Helper {
+	/**
+	 * Method that should be used in order to grant given callbacks will be async
+	 *
+	 * @export
+	 * @param {GlobalCallbacks.Generic} callback
+	 * @param {...unknown[]} args
+	 */
 	export function AsyncInvocation(callback: GlobalCallbacks.Generic, ...args: unknown[]): void {
 		if (callback) setTimeout(() => callback(...args), 0);
+	}
+
+	/**
+	 * Method to be used when a setTimeout is needed
+	 *
+	 * @export
+	 * @param {GlobalCallbacks.Generic} callback
+	 * @param {number} time
+	 * @param {...unknown[]} args
+	 */
+	export function ApplySetTimeOut(callback: GlobalCallbacks.Generic, time: number, ...args: unknown[]): void {
+		if (callback) setTimeout(() => callback(...args), time);
 	}
 }

--- a/src/scripts/OSFramework/OSUI/Pattern/Dropdown/AbstractDropdown.ts
+++ b/src/scripts/OSFramework/OSUI/Pattern/Dropdown/AbstractDropdown.ts
@@ -4,6 +4,16 @@ namespace OSFramework.OSUI.Patterns.Dropdown {
 		extends AbstractProviderPattern<P, C>
 		implements IDropdown
 	{
+		// Close and Open setTimeout value time
+		protected _setTimeOutOpenCloseVal = 100;
+
+		/**
+		 * Creates an instance of AbstractDropdown.
+		 *
+		 * @param {string} uniqueId
+		 * @param {C} configs
+		 * @memberof AbstractDropdown
+		 */
 		constructor(uniqueId: string, configs: C) {
 			super(uniqueId, configs);
 		}

--- a/src/scripts/OSFramework/OSUI/Pattern/Dropdown/ServerSide/DropdownServerSide.ts
+++ b/src/scripts/OSFramework/OSUI/Pattern/Dropdown/ServerSide/DropdownServerSide.ts
@@ -77,6 +77,8 @@ namespace OSFramework.OSUI.Patterns.Dropdown.ServerSide {
 		private _selectValuesWrapperAriaLabel: string;
 		// Store the selfElementBounds in order to check if they changed!
 		private _selfElementBoundingClientRect: DOMRect = new DOMRect(0, 0);
+		// Close and Open setTimeout value time
+		private _setTimeOutOpenCloseVal = 100;
 		// Store the window width value in order to check if has changed at windowResize
 		private _windowWidth: number;
 
@@ -1050,7 +1052,11 @@ namespace OSFramework.OSUI.Patterns.Dropdown.ServerSide {
 		 * @memberof OSFramework.Patterns.Dropdown.ServerSide.OSUIDropdownServerSide
 		 */
 		public close(): void {
-			this._close();
+			// SetTimeout is needed in order to ensure there is no conflit between OnClickBody and a button click that trigger this method.
+			OSFramework.OSUI.Helper.ApplySetTimeOut(
+				this._close.bind(this) as OSFramework.OSUI.GlobalCallbacks.Generic,
+				this._setTimeOutOpenCloseVal
+			);
 		}
 
 		/**
@@ -1108,7 +1114,11 @@ namespace OSFramework.OSUI.Patterns.Dropdown.ServerSide {
 		 * @memberof OSFramework.Patterns.Dropdown.ServerSide.OSUIDropdownServerSide
 		 */
 		public open(): void {
-			this._open();
+			// SetTimeout is needed in order to ensure there is no conflit between OnClickBody and a button click that trigger this method.
+			OSFramework.OSUI.Helper.ApplySetTimeOut(
+				this._open.bind(this) as OSFramework.OSUI.GlobalCallbacks.Generic,
+				this._setTimeOutOpenCloseVal
+			);
 		}
 
 		/**

--- a/src/scripts/Providers/OSUI/Dropdown/VirtualSelect/AbstractVirtualSelect.ts
+++ b/src/scripts/Providers/OSUI/Dropdown/VirtualSelect/AbstractVirtualSelect.ts
@@ -307,7 +307,13 @@ namespace Providers.OSUI.Dropdown.VirtualSelect {
 		 * @memberof Providers.OSUI.Dropdown.VirtualSelect.AbstractVirtualSelect
 		 */
 		public close(): void {
-			this._virtualselectConfigs.close();
+			// SetTimeout is needed in order to ensure there is no conflit between OnClickBody and a button click that trigger this method.
+			OSFramework.OSUI.Helper.ApplySetTimeOut(
+				this._virtualselectConfigs.close.bind(
+					this._virtualselectConfigs
+				) as OSFramework.OSUI.GlobalCallbacks.Generic,
+				this._setTimeOutOpenCloseVal
+			);
 		}
 
 		/**
@@ -392,7 +398,13 @@ namespace Providers.OSUI.Dropdown.VirtualSelect {
 		 * @memberof Providers.OSUI.Dropdown.VirtualSelect.AbstractVirtualSelect
 		 */
 		public open(): void {
-			this._virtualselectConfigs.open();
+			// SetTimeout is needed in order to ensure there is no conflit between OnClickBody and a button click that trigger this method.
+			OSFramework.OSUI.Helper.ApplySetTimeOut(
+				this._virtualselectConfigs.open.bind(
+					this._virtualselectConfigs
+				) as OSFramework.OSUI.GlobalCallbacks.Generic,
+				this._setTimeOutOpenCloseVal
+			);
 		}
 
 		/**


### PR DESCRIPTION
This PR is for implement a way to avoid events conflicts when an Open/Close api methods was being triggered through a button click, since we had Body click event that was being triggered at the same time.
This was implemented on the context of DropdownSearch, DropdownTags and DropdownServerSide.