### PR TITLE
ROU-3789: Fix desktop issue on LayoutNative expandable

### DIFF
--- a/dist/OutSystemsUI.css
+++ b/dist/OutSystemsUI.css
@@ -1049,9 +1049,6 @@ body,
 .desktop .layout-side.layout-native.aside-expandable .header{
   margin-left:0;
 }
-.desktop .layout-side.layout-native.aside-expandable.menu-visible .header{
-  margin-left:calc(-1 * var(--side-menu-size));
-}
 .desktop .aside-expandable .header{
   z-index:var(--layer-global-navigation);
 }
@@ -1068,10 +1065,6 @@ body,
 }
 .phone .layout-side.layout-native.aside-expandable .main .header{
   z-index:var(--layer-global-navigation);
-}
-.is-rtl.desktop .layout-side.layout-native.aside-expandable.menu-visible .header{
-  margin-left:0;
-  margin-right:calc(-1 * var(--side-menu-size));
 }
 .is-rtl.tablet, .is-rtl.phone{
   left:0;

--- a/src/scss/02-layout/_header-layout-side.scss
+++ b/src/scss/02-layout/_header-layout-side.scss
@@ -58,10 +58,6 @@
 		.header {
 			margin-left: 0;
 		}
-
-		&.menu-visible .header {
-			margin-left: calc(-1 * var(--side-menu-size));
-		}
 	}
 
 	.aside-expandable {
@@ -106,13 +102,6 @@
 // IsRTL -------------------------------------------------------------------------
 ///
 .is-rtl {
-	&.desktop {
-		.layout-side.layout-native.aside-expandable.menu-visible .header {
-			margin-left: 0;
-			margin-right: calc(-1 * var(--side-menu-size));
-		}
-	}
-
 	&.tablet,
 	&.phone {
 		left: 0;


### PR DESCRIPTION
This PR is for fixing an issue on layout native when the menu behavior is expandable.

### What was happening
- The CSS rules are incorrectly applied:
![image](https://user-images.githubusercontent.com/25321845/232471523-e38d5bac-8cb4-4613-9554-5c94e7047f0d.png)
![image](https://user-images.githubusercontent.com/25321845/232471591-c103d52c-6853-42e2-a5fc-feb13dbb9b40.png)

### What was done
- Removed the CSS that are causing the issue:
![image](https://user-images.githubusercontent.com/25321845/232450965-6e125a89-627e-4596-a55d-5d2097cc8841.png)
![image](https://user-images.githubusercontent.com/25321845/232451056-e0de135e-ba08-4ae8-8c7f-9e7f2fcde4b1.png)

### Test Steps
1. Open Sample Page
2. Check if the layout are correct
3. Enable the RTL
4. Expected: The layout will change the view based on RTL and the menu icon are visible

### Checklist
-   [X] tested locally
-   [X] documented the code
-   [X] clean all warnings and errors of eslint
-   [ ] requires changes in OutSystems (if so, provide a module with changes)
-   [ ] requires new sample page in OutSystems (if so, provide a module with changes)
