### PR TITLE
ROU-4203: Change the moved elements to active screen

### DIFF
--- a/dist/OutSystemsUI.d.ts
+++ b/dist/OutSystemsUI.d.ts
@@ -3208,6 +3208,7 @@ declare namespace OSFramework.OSUI.Patterns.Tooltip {
 }
 declare namespace OSFramework.OSUI.Patterns.Tooltip {
     class Tooltip extends AbstractPattern<TooltipConfig> implements ITooltip {
+        private _activeScreenElement;
         private _eventBalloonWrapperOnMouseEnter;
         private _eventBalloonWrapperOnMouseLeave;
         private _eventIconOnMouseEnter;

--- a/dist/OutSystemsUI.d.ts
+++ b/dist/OutSystemsUI.d.ts
@@ -1696,7 +1696,6 @@ declare namespace OSFramework.OSUI.Patterns.Dropdown.ServerSide {
         private _intersectionObserver;
         private _isBlocked;
         private _isOpen;
-        private _layoutElement;
         private _platformEventInitializedCallback;
         private _platformEventOnToggleCallback;
         private _requestAnimationOnBodyScroll;

--- a/dist/OutSystemsUI.js
+++ b/dist/OutSystemsUI.js
@@ -9786,8 +9786,7 @@ var OSFramework;
                         this._tooltipBalloonPositionClass = this.configs.Position;
                     }
                     _moveBalloonElement() {
-                        const activeScreenElement = OSUI.Helper.Dom.ClassSelector(document.body, OSUI.GlobalEnum.CssClassElements.ActiveScreen);
-                        OSUI.Helper.Dom.Move(this._tooltipBalloonWrapperElem, activeScreenElement);
+                        OSUI.Helper.Dom.Move(this._tooltipBalloonWrapperElem, this._activeScreenElement);
                     }
                     _onBalloonClick(e) {
                         const clickableItems = Array.from(this._tooltipBalloonContentElem.querySelectorAll(OSUI.Constants.FocusableElems + ', ' + OSUI.GlobalEnum.HTMLAttributes.AllowEventPropagation));
@@ -10088,6 +10087,7 @@ var OSFramework;
                         this._eventIconOnMouseLeave = this._onIconMouseLeave.bind(this);
                     }
                     setHtmlElements() {
+                        this._activeScreenElement = OSUI.Helper.Dom.ClassSelector(document.body, OSUI.GlobalEnum.CssClassElements.ActiveScreen);
                         this._tooltipIconElem = OSUI.Helper.Dom.ClassSelector(this.selfElement, Tooltip_1.Enum.CssClass.Content);
                         this._tooltipBalloonContentElem = OSUI.Helper.Dom.ClassSelector(this.selfElement, Tooltip_1.Enum.CssClass.BalloonContent);
                         this._tooltipBalloonWrapperElem = OSUI.Helper.Dom.ClassSelector(this.selfElement, Tooltip_1.Enum.CssClass.BalloonWrapper);
@@ -10119,6 +10119,7 @@ var OSFramework;
                     }
                     unsetHtmlElements() {
                         this._tooltipBalloonWrapperElem.remove();
+                        this._activeScreenElement = undefined;
                         this._tooltipIconElem = undefined;
                         this._tooltipBalloonContentElem = undefined;
                         this._tooltipBalloonWrapperElem = undefined;

--- a/dist/OutSystemsUI.js
+++ b/dist/OutSystemsUI.js
@@ -4569,7 +4569,7 @@ var OSFramework;
                             if (this._closeDynamically === false) {
                                 this._selectValuesWrapper.focus();
                             }
-                            OSUI.Helper.Dom.Styles.RemoveClass(this._activeScreenElement, ServerSide.Enum.CssClass.IsVisible);
+                            OSUI.Helper.Dom.Styles.RemoveClass(document.body, ServerSide.Enum.CssClass.IsVisible);
                             this._touchMove();
                             cancelAnimationFrame(this._requestAnimationOnBodyScroll);
                             this._isOpen = false;
@@ -4610,7 +4610,7 @@ var OSFramework;
                             throw new Error(`${OSUI.ErrorCodes.Dropdown.HasNoImplementation.code}: ${OSUI.ErrorCodes.Dropdown.HasNoImplementation.message}`);
                         }
                         _moveBallonElement() {
-                            OSUI.Helper.Dom.Move(this._balloonWrapperElement, this._layoutElement);
+                            OSUI.Helper.Dom.Move(this._balloonWrapperElement, this._activeScreenElement);
                         }
                         _onBodyClick(_eventType, event) {
                             const targetElement = event.target;
@@ -4720,7 +4720,7 @@ var OSFramework;
                             this._windowWidth = window.innerWidth;
                             this._setBalloonCoordinates();
                             this._touchMove();
-                            OSUI.Helper.Dom.Styles.AddClass(this._activeScreenElement, ServerSide.Enum.CssClass.IsVisible);
+                            OSUI.Helper.Dom.Styles.AddClass(document.body, ServerSide.Enum.CssClass.IsVisible);
                             this._updatePatternState();
                             this._setObserver();
                         }
@@ -4988,7 +4988,6 @@ var OSFramework;
                             this._eventOnWindowResize = this._onWindowResize.bind(this);
                         }
                         setHtmlElements() {
-                            this._layoutElement = OSUI.Helper.Dom.ClassSelector(document.body, OSUI.GlobalEnum.CssClassElements.Layout);
                             this._activeScreenElement = OSUI.Helper.Dom.ClassSelector(document.body, OSUI.GlobalEnum.CssClassElements.ActiveScreen);
                             this._balloonFooterElement = OSUI.Helper.Dom.ClassSelector(this.selfElement, ServerSide.Enum.CssClass.BalloonFooter);
                             this._balloonFocusableElemsInFooter = OSUI.Helper.Dom.TagSelectorAll(this._balloonFooterElement, OSUI.Constants.FocusableElems);
@@ -5025,7 +5024,6 @@ var OSFramework;
                         }
                         unsetHtmlElements() {
                             this._balloonWrapperElement.remove();
-                            this._layoutElement = undefined;
                             this._activeScreenElement = undefined;
                             this._balloonContainerElement = undefined;
                             this._balloonFocusableElemsInFooter = [];
@@ -9788,8 +9786,8 @@ var OSFramework;
                         this._tooltipBalloonPositionClass = this.configs.Position;
                     }
                     _moveBalloonElement() {
-                        const layoutElement = OSUI.Helper.Dom.ClassSelector(document.body, OSUI.GlobalEnum.CssClassElements.Layout);
-                        OSUI.Helper.Dom.Move(this._tooltipBalloonWrapperElem, layoutElement);
+                        const activeScreenElement = OSUI.Helper.Dom.ClassSelector(document.body, OSUI.GlobalEnum.CssClassElements.ActiveScreen);
+                        OSUI.Helper.Dom.Move(this._tooltipBalloonWrapperElem, activeScreenElement);
                     }
                     _onBalloonClick(e) {
                         const clickableItems = Array.from(this._tooltipBalloonContentElem.querySelectorAll(OSUI.Constants.FocusableElems + ', ' + OSUI.GlobalEnum.HTMLAttributes.AllowEventPropagation));

--- a/src/scripts/OSFramework/OSUI/Pattern/Dropdown/ServerSide/DropdownServerSide.ts
+++ b/src/scripts/OSFramework/OSUI/Pattern/Dropdown/ServerSide/DropdownServerSide.ts
@@ -63,8 +63,6 @@ namespace OSFramework.OSUI.Patterns.Dropdown.ServerSide {
 		private _isBlocked = false;
 		// Store the Element State, by default is closed!
 		private _isOpen = false;
-		// Store the HTML element for the layout where the Balloon will be moved into.
-		private _layoutElement: HTMLElement;
 		// Platform OnInitialize Callback
 		private _platformEventInitializedCallback: GlobalCallbacks.OSGeneric;
 		// Platform OnClose Callback
@@ -111,7 +109,7 @@ namespace OSFramework.OSUI.Patterns.Dropdown.ServerSide {
 			}
 
 			// Remove isVisible class to the layout
-			Helper.Dom.Styles.RemoveClass(this._activeScreenElement, Enum.CssClass.IsVisible);
+			Helper.Dom.Styles.RemoveClass(document.body, Enum.CssClass.IsVisible);
 
 			// Update the touchMove when pattern is open!
 			this._touchMove();
@@ -190,9 +188,9 @@ namespace OSFramework.OSUI.Patterns.Dropdown.ServerSide {
 			);
 		}
 
-		// Move ballon element to outside of the pattern context
+		// Move ballon element to active screen element, outside of the pattern context
 		private _moveBallonElement(): void {
-			Helper.Dom.Move(this._balloonWrapperElement, this._layoutElement);
+			Helper.Dom.Move(this._balloonWrapperElement, this._activeScreenElement);
 		}
 
 		// Close when click outside of pattern
@@ -370,7 +368,7 @@ namespace OSFramework.OSUI.Patterns.Dropdown.ServerSide {
 			this._touchMove();
 
 			// Add the isVisible class to the layout
-			Helper.Dom.Styles.AddClass(this._activeScreenElement, Enum.CssClass.IsVisible);
+			Helper.Dom.Styles.AddClass(document.body, Enum.CssClass.IsVisible);
 			this._updatePatternState();
 
 			// Set the Observer in order to update it's position if balloon is out of bounds!
@@ -874,7 +872,6 @@ namespace OSFramework.OSUI.Patterns.Dropdown.ServerSide {
 		 * @memberof OSFramework.Patterns.Dropdown.ServerSide.OSUIDropdownServerSide
 		 */
 		protected setHtmlElements(): void {
-			this._layoutElement = Helper.Dom.ClassSelector(document.body, GlobalEnum.CssClassElements.Layout);
 			this._activeScreenElement = Helper.Dom.ClassSelector(
 				document.body,
 				GlobalEnum.CssClassElements.ActiveScreen
@@ -952,7 +949,6 @@ namespace OSFramework.OSUI.Patterns.Dropdown.ServerSide {
 			this._balloonWrapperElement.remove();
 
 			// unset the local properties
-			this._layoutElement = undefined;
 			this._activeScreenElement = undefined;
 			this._balloonContainerElement = undefined;
 			this._balloonFocusableElemsInFooter = [];

--- a/src/scripts/OSFramework/OSUI/Pattern/Dropdown/ServerSide/DropdownServerSide.ts
+++ b/src/scripts/OSFramework/OSUI/Pattern/Dropdown/ServerSide/DropdownServerSide.ts
@@ -108,7 +108,7 @@ namespace OSFramework.OSUI.Patterns.Dropdown.ServerSide {
 				this._selectValuesWrapper.focus();
 			}
 
-			// Remove isVisible class to the layout
+			// Remove isVisible class from the body
 			Helper.Dom.Styles.RemoveClass(document.body, Enum.CssClass.IsVisible);
 
 			// Update the touchMove when pattern is open!
@@ -367,7 +367,7 @@ namespace OSFramework.OSUI.Patterns.Dropdown.ServerSide {
 			// Update the touchMove when pattern is open!
 			this._touchMove();
 
-			// Add the isVisible class to the layout
+			// Add the isVisible class to body
 			Helper.Dom.Styles.AddClass(document.body, Enum.CssClass.IsVisible);
 			this._updatePatternState();
 

--- a/src/scripts/OSFramework/OSUI/Pattern/Tooltip/Tooltip.ts
+++ b/src/scripts/OSFramework/OSUI/Pattern/Tooltip/Tooltip.ts
@@ -1,6 +1,8 @@
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 namespace OSFramework.OSUI.Patterns.Tooltip {
 	export class Tooltip extends AbstractPattern<TooltipConfig> implements ITooltip {
+		// Store the HTML element for the ActiveScreen where a status class will be updated accoding balloon is open or not.
+		private _activeScreenElement: HTMLElement;
 		// Event OnMouseEnter at _tooltipBalloonWrapperElem
 		private _eventBalloonWrapperOnMouseEnter: GlobalCallbacks.Generic;
 		// Event OnMouseLeave at at _tooltipBalloonWrapperElem
@@ -61,11 +63,7 @@ namespace OSFramework.OSUI.Patterns.Tooltip {
 
 		// Move balloon element to active screen, outside of the pattern context
 		private _moveBalloonElement(): void {
-			const activeScreenElement = Helper.Dom.ClassSelector(
-				document.body,
-				GlobalEnum.CssClassElements.ActiveScreen
-			);
-			Helper.Dom.Move(this._tooltipBalloonWrapperElem, activeScreenElement);
+			Helper.Dom.Move(this._tooltipBalloonWrapperElem, this._activeScreenElement);
 		}
 
 		// Check if a clickable item has been clicked, otherwise stop the propagation!
@@ -632,6 +630,10 @@ namespace OSFramework.OSUI.Patterns.Tooltip {
 		 * @memberof OSFramework.Patterns.Tooltip.Tooltip
 		 */
 		protected setHtmlElements(): void {
+			this._activeScreenElement = Helper.Dom.ClassSelector(
+				document.body,
+				GlobalEnum.CssClassElements.ActiveScreen
+			);
 			// Set the html references that will be used to manage the cssClasses and atribute properties
 			this._tooltipIconElem = Helper.Dom.ClassSelector(this.selfElement, Enum.CssClass.Content);
 			this._tooltipBalloonContentElem = Helper.Dom.ClassSelector(this.selfElement, Enum.CssClass.BalloonContent);
@@ -692,6 +694,8 @@ namespace OSFramework.OSUI.Patterns.Tooltip {
 			// Remove the detached balloon html element!
 			this._tooltipBalloonWrapperElem.remove();
 
+			// unset the local properties
+			this._activeScreenElement = undefined;
 			this._tooltipIconElem = undefined;
 			this._tooltipBalloonContentElem = undefined;
 			this._tooltipBalloonWrapperElem = undefined;

--- a/src/scripts/OSFramework/OSUI/Pattern/Tooltip/Tooltip.ts
+++ b/src/scripts/OSFramework/OSUI/Pattern/Tooltip/Tooltip.ts
@@ -59,10 +59,13 @@ namespace OSFramework.OSUI.Patterns.Tooltip {
 			this._tooltipBalloonPositionClass = this.configs.Position;
 		}
 
-		// Move balloon element to outside of the pattern context
+		// Move balloon element to active screen, outside of the pattern context
 		private _moveBalloonElement(): void {
-			const layoutElement = Helper.Dom.ClassSelector(document.body, GlobalEnum.CssClassElements.Layout);
-			Helper.Dom.Move(this._tooltipBalloonWrapperElem, layoutElement);
+			const activeScreenElement = Helper.Dom.ClassSelector(
+				document.body,
+				GlobalEnum.CssClassElements.ActiveScreen
+			);
+			Helper.Dom.Move(this._tooltipBalloonWrapperElem, activeScreenElement);
 		}
 
 		// Check if a clickable item has been clicked, otherwise stop the propagation!


### PR DESCRIPTION
This PR is for change the target element of moved ballon from out of context of the pattern. The Tooltip and the DropdownServerSide were affected with this change.

### Checklist
-   [X] tested locally
-   [X] documented the code
-   [X] clean all warnings and errors of eslint
-   [ ] requires changes in OutSystems (if so, provide a module with changes)
-   [ ] requires new sample page in OutSystems (if so, provide a module with changes)
