### PR TITLE
Fixed a glitch in DatePickerRange

### DIFF
--- a/src/scripts/Providers/OSUI/SharedProviderResources/Flatpickr/scss/_flatpickr.scss
+++ b/src/scripts/Providers/OSUI/SharedProviderResources/Flatpickr/scss/_flatpickr.scss
@@ -300,7 +300,6 @@ span.flatpickr-weekday {
 			color: var(--color-neutral-0);
 		}
 	}
-
 	// InRange Styles
 	&.selected.startRange,
 	&.startRange.startRange,
@@ -320,9 +319,20 @@ span.flatpickr-weekday {
 		}
 	}
 
-	&.selected.startRange,
-	&.startRange.startRange,
+	&.selected.startRange.endRange,
+	&.startRange.endRange,
+	&.selected.endRange.startRange,
 	&.endRange.startRange {
+		border-radius: 50px;
+
+		&:before {
+			border-radius: 50px;
+		}
+	}
+
+
+	&.selected.startRange,
+	&.startRange.startRange {
 		border-radius: 50px;
 
 		&:before {
@@ -333,7 +343,6 @@ span.flatpickr-weekday {
 	}
 
 	&.selected.endRange,
-	&.startRange.endRange,
 	&.endRange.endRange {
 		border-radius: 50px;
 

--- a/src/scripts/Providers/OSUI/SharedProviderResources/Flatpickr/scss/_flatpickr.scss
+++ b/src/scripts/Providers/OSUI/SharedProviderResources/Flatpickr/scss/_flatpickr.scss
@@ -323,8 +323,7 @@ span.flatpickr-weekday {
 	&.startRange.endRange,
 	&.selected.endRange.startRange,
 	&.endRange.startRange {
-		border-radius: 50px;
-
+		&,
 		&:before {
 			border-radius: 50px;
 		}


### PR DESCRIPTION
This PR is for fixing a glitch in DatePickerRange where the gray part was still shown when both start- and enddate were on the same date.

[Sample page](https://dekkinga.outsystemscloud.com/OutsystemsUITests/Screen1)

### What was happening

- The gray part was still shown on the left side of the selected date range when both start- and enddate were on the same date

### What was done

- Added a rule to the SCSS code to separate the date ranges where both the startRange and endRange classes were on the same day from the existing date ranges where both classes are on different days.

### Test Steps

1. Open a DateRangePicker
2. Select the same day twice to get a range of 1 day.
3. Open the DateRangePicker again.
4. The gray part on the left should be gone after the fix is implemented.

### Screenshots

Before the fix:
![image](https://user-images.githubusercontent.com/33290081/233105412-0af046a3-4a14-4860-8ea6-267bec96812c.png)

After the fix:
![image](https://user-images.githubusercontent.com/33290081/233105032-b0e8fab8-f730-40ef-90e6-fcc5462103fc.png)


### Checklist

-   [X] tested locally
-   [ ] documented the code - the code speaks for itself.
-   [X] clean all warnings and errors of eslint
-   [ ] requires changes in OutSystems (if so, provide a module with changes)
-   [ ] requires new sample page in OutSystems (if so, provide a module with changes)
