### PR TITLE
ROU-4245: Fix MaxDate validation when using DateTime

### DIFF
--- a/dist/OutSystemsUI.d.ts
+++ b/dist/OutSystemsUI.d.ts
@@ -266,6 +266,7 @@ declare namespace OSFramework.OSUI.GlobalEnum {
     }
     enum HTMLAttributes {
         AllowEventPropagation = "[data-allow-event-propagation=true], [data-allow-event-propagation=True]",
+        Class = "class",
         DataInput = "data-input",
         Disabled = "disabled",
         Id = "id",
@@ -692,7 +693,7 @@ declare namespace OSFramework.OSUI.Event.DOMEvents.Observers.MutationObservers.R
     }
 }
 declare namespace OSFramework.OSUI.Event {
-    abstract class AbstractGestureEvent implements GestureEvent.IAbstractGestureEvent {
+    abstract class AbstractGestureEvent implements GestureEvent.IGestureEvent {
         private _endEvent;
         private _endTriggerCallback;
         private _gestureParams;
@@ -744,7 +745,7 @@ declare namespace OSFramework.OSUI.Event.GestureEvent {
     }
 }
 declare namespace OSFramework.OSUI.Event.GestureEvent {
-    interface IAbstractGestureEvent {
+    interface IGestureEvent {
         targetElement: HTMLElement;
         unsetTouchEvents(): void;
     }
@@ -822,6 +823,7 @@ declare namespace OSFramework.OSUI.Helper {
         private static _serverFormat;
         static IsBeforeThan(date1: string, date2: string): boolean;
         static IsNull(date: string | Date): boolean;
+        static NormalizeDateTime(date: string | Date, normalizeToMax?: boolean): Date;
         static SetServerDateFormat(date: string): void;
         static get ServerFormat(): string;
     }
@@ -4308,6 +4310,7 @@ declare namespace Providers.OSUI.Datepicker.Flatpickr {
         .AbstractDatePickerConfig {
         private _disabledDays;
         private _disabledWeekDays;
+        private _isUsingDateTime;
         private _lang;
         private _providerOptions;
         protected _providerExtendedOptions: FlatpickrOptions;
@@ -4322,6 +4325,7 @@ declare namespace Providers.OSUI.Datepicker.Flatpickr {
         private _checkLocale;
         private _mapProviderDateFormat;
         private _setDisable;
+        private _validateDate;
         getProviderConfig(): FlatpickrOptions;
         setExtensibilityConfigs(newConfigs: FlatpickrOptions): void;
         get Lang(): string;

--- a/src/scripts/OSFramework/OSUI/Helper/Dates.ts
+++ b/src/scripts/OSFramework/OSUI/Helper/Dates.ts
@@ -53,6 +53,33 @@ namespace OSFramework.OSUI.Helper {
 		}
 
 		/**
+		 * Funciton used to normalize the OUtSystems DateTimes, used on scopes expecting a Date
+		 *
+		 * @static
+		 * @param {(string | Date)} date
+		 * @param {boolean} [normalizeToMax=true]
+		 * @return {*}  {Date}
+		 * @memberof Dates
+		 */
+		public static NormalizeDateTime(date: string | Date, normalizeToMax = true): Date {
+			let _newDate = date;
+
+			if (typeof _newDate === 'string') {
+				_newDate = new Date(date);
+			}
+
+			if (normalizeToMax) {
+				// To make sure that if time is not being used, the hours are as high as possible, to not interfer with other date comparisons
+				_newDate.setHours(23, 59, 59, 59);
+			} else {
+				// To make sure that if time is not being used, the hours are as low as possible, to not interfer with other date comparisons
+				_newDate.setHours(0, 0, 0, 0);
+			}
+
+			return _newDate;
+		}
+
+		/**
 		 * Function responsible for setting up the the server date format.
 		 *
 		 * @export

--- a/src/scripts/OSFramework/OSUI/Helper/Dates.ts
+++ b/src/scripts/OSFramework/OSUI/Helper/Dates.ts
@@ -53,7 +53,7 @@ namespace OSFramework.OSUI.Helper {
 		}
 
 		/**
-		 * Funciton used to normalize the OUtSystems DateTimes, used on scopes expecting a Date
+		 * Function used to normalize the OutSystems DateTimes, used on scopes expecting a Date
 		 *
 		 * @static
 		 * @param {(string | Date)} date

--- a/src/scripts/Providers/OSUI/Datepicker/Flatpickr/AbstractFlatpickrConfig.ts
+++ b/src/scripts/Providers/OSUI/Datepicker/Flatpickr/AbstractFlatpickrConfig.ts
@@ -15,6 +15,9 @@ namespace Providers.OSUI.Datepicker.Flatpickr {
 		// Store a integer list of weekdays
 		private _disabledWeekDays = [];
 
+		// Store if DateTime is being used
+		private _isUsingDateTime: boolean;
+
 		// Store the language that will be assigned as a locale to the DatePicker
 		private _lang: string;
 
@@ -157,6 +160,19 @@ namespace Providers.OSUI.Datepicker.Flatpickr {
 			}
 		}
 
+		// Method to check the date config passed and set the correct hours, according to date time being used
+		private _validateDate(date: string): Date | string {
+			const _finalDate = date;
+
+			if (OSFramework.OSUI.Helper.Dates.IsNull(_finalDate)) {
+				return undefined;
+			} else if (this._isUsingDateTime) {
+				return _finalDate;
+			} else {
+				return OSFramework.OSUI.Helper.Dates.NormalizeDateTime(_finalDate);
+			}
+		}
+
 		/**
 		 * Method used to get all the global Flatpickr properties across the different types of instances
 		 *
@@ -164,6 +180,8 @@ namespace Providers.OSUI.Datepicker.Flatpickr {
 		 * @memberof Providers.OSUI.DatePicker.Flatpickr.AbstractFlatpickrConfig
 		 */
 		public getProviderConfig(): FlatpickrOptions {
+			this._isUsingDateTime =
+				this.TimeFormat !== OSFramework.OSUI.Patterns.DatePicker.Enum.TimeFormatMode.Disable;
 			// Check the disabled days to be applied on datepicker
 			this._setDisable();
 
@@ -175,12 +193,11 @@ namespace Providers.OSUI.Datepicker.Flatpickr {
 				allowInput: this.AllowInput,
 				disable: this.Disable.length === 0 ? undefined : this.Disable,
 				disableMobile: this.DisableMobile,
-				dateFormat:
-					this.TimeFormat !== OSFramework.OSUI.Patterns.DatePicker.Enum.TimeFormatMode.Disable
-						? this.ServerDateFormat + ' H:i:S' // do not change 'H:i:S' since it's absoluted needed due to platform conversions!
-						: this.ServerDateFormat,
-				maxDate: OSFramework.OSUI.Helper.Dates.IsNull(this.MaxDate) ? undefined : this.MaxDate,
-				minDate: OSFramework.OSUI.Helper.Dates.IsNull(this.MinDate) ? undefined : this.MinDate,
+				dateFormat: this._isUsingDateTime
+					? this.ServerDateFormat + ' H:i:S' // do not change 'H:i:S' since it's absoluted needed due to platform conversions!
+					: this.ServerDateFormat,
+				maxDate: this._validateDate(this.MaxDate),
+				minDate: this._validateDate(this.MinDate),
 				onChange: this.OnChange,
 				time_24hr: this.TimeFormat === OSFramework.OSUI.Patterns.DatePicker.Enum.TimeFormatMode.Time24hFormat,
 				updateInputVal: false, // (*)


### PR DESCRIPTION
This PR is for fixing am issue that was causing the Today Button to trigger a null Date, when the MaxDate was set to 'today'.

This was happening because inside Service Studio, the parameters are DateTime type, and when used to set Date types, the Date would come with a fixed hour ,even if not used, which could make the validations comparisons on the provider to fail, as it could happen that the Date on the Today Button would have a later hour, or even just minutes.

### What was done
- Added a new private method to check if TimeFormat is disabled. If it is, then we set the MaxDate to 23:59:59 hour and the MinDate to 0:0:0:0 hour.

### Checklist

-   [x] tested locally
-   [x] documented the code
-   [x] clean all warnings and errors of eslint
-   [ ] requires changes in OutSystems (if so, provide a module with changes)
-   [ ] requires new sample page in OutSystems (if so, provide a module with changes)
