### PR TITLE
ROU-4280:  rollback fix

### DIFF
--- a/dist/OutSystemsUI.css
+++ b/dist/OutSystemsUI.css
@@ -11352,9 +11352,6 @@ html[data-uieditorversion^="1"] .osui-timepicker__dropdown-ss-preview.time12h, h
   -ms-scroll-snap-type:x mandatory;
       scroll-snap-type:x mandatory;
 }
-.osui-tabs:not(.osui-tabs--has-drag) .osui-tabs__content-item:not(.osui-tabs--is-active){
-  display:none;
-}
 .osui-tabs__header{
   display:grid;
   height:-webkit-fit-content;

--- a/src/scripts/OSFramework/OSUI/Pattern/Tabs/scss/_tabs.scss
+++ b/src/scripts/OSFramework/OSUI/Pattern/Tabs/scss/_tabs.scss
@@ -148,12 +148,6 @@
 		}
 	}
 
-	&:not(.osui-tabs--has-drag) {
-		.osui-tabs__content-item:not(.osui-tabs--is-active){
-			display: none
-		}
-	}
-
 	&__header {
 		display: grid;
 		height: -webkit-fit-content; // this is important to fix Safari render issues on onRender changes


### PR DESCRIPTION
This PR is to rollback a fix for the Tabs, as it caused some impact on other patterns and its own behaviour.

### Checklist

-   [x] tested locally
-   [ ] documented the code
-   [ ] clean all warnings and errors of eslint
-   [ ] requires changes in OutSystems (if so, provide a module with changes)
-   [ ] requires new sample page in OutSystems (if so, provide a module with changes)
