### PR TITLE
ROU-4280: Fix tabs render and observer errors

### DIFF
--- a/dist/OutSystemsUI.css
+++ b/dist/OutSystemsUI.css
@@ -11352,6 +11352,10 @@ html[data-uieditorversion^="1"] .osui-timepicker__dropdown-ss-preview.time12h, h
   -ms-scroll-snap-type:x mandatory;
       scroll-snap-type:x mandatory;
 }
+.osui-tabs:not(.osui-tabs--has-drag) .osui-tabs__content:not(:focus-within){
+  -ms-scroll-snap-type:x mandatory;
+      scroll-snap-type:x mandatory;
+}
 .osui-tabs__header{
   display:grid;
   height:-webkit-fit-content;

--- a/dist/OutSystemsUI.js
+++ b/dist/OutSystemsUI.js
@@ -9196,7 +9196,8 @@ var OSFramework;
                         OSUI.Helper.AsyncInvocation(this._handleTabIndicator.bind(this));
                     }
                     _handleTabIndicator() {
-                        if (this._activeTabHeaderElement) {
+                        var _a;
+                        if ((_a = this._activeTabHeaderElement) === null || _a === void 0 ? void 0 : _a.selfElement) {
                             if (!OSUI.Helper.Dom.Attribute.Get(this._activeTabHeaderElement.selfElement, OSUI.GlobalEnum.HTMLAttributes.Disabled)) {
                                 OSUI.Helper.Dom.Attribute.Remove(this._tabsIndicatorElement, OSUI.GlobalEnum.HTMLAttributes.Disabled);
                             }
@@ -9214,7 +9215,7 @@ var OSFramework;
                             }
                             const newScaleValue = (pixelRatio * newSize) / Math.round(pixelRatio);
                             function updateIndicatorUI() {
-                                if (this._activeTabHeaderElement) {
+                                if (this._tabsIndicatorElement) {
                                     OSUI.Helper.Dom.Styles.SetStyleAttribute(this._tabsIndicatorElement, Tabs_1.Enum.CssProperty.TabsIndicatorTransform, transformValue + OSUI.GlobalEnum.Units.Pixel);
                                     OSUI.Helper.Dom.Styles.SetStyleAttribute(this._tabsIndicatorElement, Tabs_1.Enum.CssProperty.TabsIndicatorScale, Math.floor(newScaleValue));
                                 }
@@ -9661,15 +9662,15 @@ var OSFramework;
                     }
                     setA11YProperties(isUpdate = true) {
                         if (isUpdate) {
-                            OSUI.Helper.A11Y.RoleTabPanel(this.selfElement.parentElement);
+                            OSUI.Helper.A11Y.RoleTabPanel(this.selfElement);
                         }
                         if (this._isActive) {
-                            OSUI.Helper.A11Y.TabIndexTrue(this.selfElement.parentElement);
-                            OSUI.Helper.A11Y.AriaHiddenFalse(this.selfElement.parentElement);
+                            OSUI.Helper.A11Y.TabIndexTrue(this.selfElement);
+                            OSUI.Helper.A11Y.AriaHiddenFalse(this.selfElement);
                         }
                         else {
-                            OSUI.Helper.A11Y.TabIndexFalse(this.selfElement.parentElement);
-                            OSUI.Helper.A11Y.AriaHiddenTrue(this.selfElement.parentElement);
+                            OSUI.Helper.A11Y.TabIndexFalse(this.selfElement);
+                            OSUI.Helper.A11Y.AriaHiddenTrue(this.selfElement);
                         }
                         OSUI.Helper.A11Y.SetElementsTabIndex(this._isActive, this._focusableElements);
                     }

--- a/src/scripts/OSFramework/OSUI/Pattern/Tabs/Tabs.ts
+++ b/src/scripts/OSFramework/OSUI/Pattern/Tabs/Tabs.ts
@@ -255,7 +255,7 @@ namespace OSFramework.OSUI.Patterns.Tabs {
 
 		// Method that handles the indicator size and transition
 		private _handleTabIndicator(): void {
-			if (this._activeTabHeaderElement) {
+			if (this._activeTabHeaderElement?.selfElement) {
 				// Check if it comes form a disabled tab, to remove the disable class
 				if (
 					!Helper.Dom.Attribute.Get(
@@ -291,7 +291,7 @@ namespace OSFramework.OSUI.Patterns.Tabs {
 
 				// Update the css variables, that will trigger a transform transition
 				function updateIndicatorUI() {
-					if (this._activeTabHeaderElement) {
+					if (this._tabsIndicatorElement) {
 						// Apply transform: translate
 						Helper.Dom.Styles.SetStyleAttribute(
 							this._tabsIndicatorElement,

--- a/src/scripts/OSFramework/OSUI/Pattern/Tabs/scss/_tabs.scss
+++ b/src/scripts/OSFramework/OSUI/Pattern/Tabs/scss/_tabs.scss
@@ -148,6 +148,13 @@
 		}
 	}
 
+	&:not(.osui-tabs--has-drag) {
+		// To prevent render/position issues after repaints that affect the Tabs size
+		.osui-tabs__content:not(:focus-within) {
+			scroll-snap-type: x mandatory;
+		}
+	}
+
 	&__header {
 		display: grid;
 		height: -webkit-fit-content; // this is important to fix Safari render issues on onRender changes

--- a/src/scripts/OSFramework/OSUI/Pattern/TabsContentItem/TabsContentItem.ts
+++ b/src/scripts/OSFramework/OSUI/Pattern/TabsContentItem/TabsContentItem.ts
@@ -28,15 +28,15 @@ namespace OSFramework.OSUI.Patterns.TabsContentItem {
 		 */
 		protected setA11YProperties(isUpdate = true): void {
 			if (isUpdate) {
-				Helper.A11Y.RoleTabPanel(this.selfElement.parentElement);
+				Helper.A11Y.RoleTabPanel(this.selfElement);
 			}
 
 			if (this._isActive) {
-				Helper.A11Y.TabIndexTrue(this.selfElement.parentElement);
-				Helper.A11Y.AriaHiddenFalse(this.selfElement.parentElement);
+				Helper.A11Y.TabIndexTrue(this.selfElement);
+				Helper.A11Y.AriaHiddenFalse(this.selfElement);
 			} else {
-				Helper.A11Y.TabIndexFalse(this.selfElement.parentElement);
-				Helper.A11Y.AriaHiddenTrue(this.selfElement.parentElement);
+				Helper.A11Y.TabIndexFalse(this.selfElement);
+				Helper.A11Y.AriaHiddenTrue(this.selfElement);
 			}
 
 			// Will handle the tabindex value of the elements inside pattern, depending if is active


### PR DESCRIPTION
This PR is for fixing the Tabs when there's a repaint caused by changes outside of the Tabs.

To fix this, the CSS snap property is added always when the focus is not inside the tabs, to make sure, the Snap takes care of correctly adapting the items size. 

With this change, the target of the accessibility attributes was changed to the selfElement of each Content Item, instead of the parent OS block. This not only prevents the the arrow key navigation when the focus inside the Tabs, but also fixes the Accessibility behaviour, that [according to guidelines](https://www.w3.org/WAI/ARIA/apg/patterns/tabs/examples/tabs-automatic/) should have a visible tabindex=0 element, before entering on the content inside:

<img width="1002" alt="Screenshot 2023-05-04 at 14 45 53" src="https://user-images.githubusercontent.com/32780808/236225226-8ea99645-78ae-467a-93c1-e675ad8f7b19.png">

Some validations were also improved on the observers callback, to prevent console errors when navigating to another screen.

### Checklist

-   [x] tested locally
-   [x] documented the code
-   [x] clean all warnings and errors of eslint
-   [ ] requires changes in OutSystems (if so, provide a module with changes)
-   [ ] requires new sample page in OutSystems (if so, provide a module with changes)
