### PR TITLE
ROU-4263: Fix issue on input date icon positioning

### DIFF
--- a/dist/OutSystemsUI.css
+++ b/dist/OutSystemsUI.css
@@ -473,6 +473,9 @@ input[type=time], input[type=date], input[type=datetime], input[type=datetime-lo
   display:-ms-inline-flexbox;
   display:inline-flex;
 }
+.chrome input[type=time], .chrome input[type=date], .chrome input[type=datetime], .chrome input[type=datetime-local], .chrome input[type=time], .chrome input[type=time]:empty{
+  display:inline-block;
+}
 ::-webkit-file-upload-button{
   -webkit-appearance:button;
           appearance:button;

--- a/dist/OutSystemsUI.css
+++ b/dist/OutSystemsUI.css
@@ -468,12 +468,12 @@ button{
   -webkit-appearance:none;
           appearance:none;
 }
-input[type=time], input[type=date], input[type=datetime], input[type=datetime-local], input[type=time], input[type=time]:empty{
+input[type=time], input[type=date], input[type=datetime], input[type=datetime-local], input[type=time]:empty{
   display:-webkit-inline-box;
   display:-ms-inline-flexbox;
   display:inline-flex;
 }
-.chrome input[type=time], .chrome input[type=date], .chrome input[type=datetime], .chrome input[type=datetime-local], .chrome input[type=time], .chrome input[type=time]:empty{
+.chrome input[type=time], .chrome input[type=date], .chrome input[type=datetime], .chrome input[type=datetime-local], .chrome input[type=time]:empty{
   display:inline-block;
 }
 ::-webkit-file-upload-button{

--- a/src/scss/01-foundations/_resets.scss
+++ b/src/scss/01-foundations/_resets.scss
@@ -148,6 +148,18 @@ input {
 }
 
 ///
+.chrome input {
+	&[type='time'],
+	&[type='date'],
+	&[type='datetime'],
+	&[type='datetime-local'],
+	&[type='time'],
+	&[type='time']:empty {
+		display: inline-block;
+	}
+}
+
+///
 ::-webkit-file-upload-button {
 	appearance: button;
 }

--- a/src/scss/01-foundations/_resets.scss
+++ b/src/scss/01-foundations/_resets.scss
@@ -141,7 +141,6 @@ input {
 	&[type='date'],
 	&[type='datetime'],
 	&[type='datetime-local'],
-	&[type='time'],
 	&[type='time']:empty {
 		display: inline-flex;
 	}
@@ -153,7 +152,6 @@ input {
 	&[type='date'],
 	&[type='datetime'],
 	&[type='datetime-local'],
-	&[type='time'],
 	&[type='time']:empty {
 		display: inline-block;
 	}


### PR DESCRIPTION
This PR is for fixing the positioning of datepicker native icon on chrome

### What was happening
![image](https://user-images.githubusercontent.com/25321845/236470294-779b3aa3-df0e-40cb-bb7f-072cf61eb41c.png)

### What was done
![image](https://user-images.githubusercontent.com/25321845/236470200-e5c06180-07e8-4073-94ed-e655db9597f0.png)

### Checklist
-   [X] tested locally
-   [X] documented the code
-   [X] clean all warnings and errors of eslint
-   [ ] requires changes in OutSystems (if so, provide a module with changes)
-   [ ] requires new sample page in OutSystems (if so, provide a module with changes)
