### PR TITLE
ROU-4225: Fix positioning layer systems for datepicker

### DIFF
--- a/dist/OutSystemsUI.css
+++ b/dist/OutSystemsUI.css
@@ -8360,6 +8360,9 @@ span.flatpickr-weekday{
 .phone .is-rtl .flatpickr-mobile::-webkit-date-and-time-value{
   text-align:right;
 }
+.is-rtl:has(.layout-side) .flatpickr-calendar{
+  --osui-flatpickr-layer:calc(var(--osui-menu-layer) + var(--layer-local-tier-1));
+}
 .is-rtl .flatpickr-calendar{
   width:330px;
 }
@@ -8401,6 +8404,11 @@ span.flatpickr-weekday{
 }
 .flatpickr-calendar.static.open{
   z-index:var(--osui-flatpickr-layer);
+}
+@supports not selector(:has(*)){
+  .is-rtl .flatpickr-calendar{
+    --osui-flatpickr-layer:calc(var(--osui-menu-layer) + var(--layer-local-tier-1));
+  }
 }
 .osui-datepicker input[type=date]::-webkit-inner-spin-button, .osui-datepicker input[type=date]::-webkit-calendar-picker-indicator, .osui-datepicker input[type=date]::-webkit-datetime-edit-year-field, .osui-datepicker input[type=date]::-webkit-datetime-edit-month-field, .osui-datepicker input[type=date]::-webkit-datetime-edit-day-field, .osui-datepicker input[type=date]::-webkit-datetime-edit-fields-wrapper{
   display:none;

--- a/src/scripts/Providers/OSUI/SharedProviderResources/Flatpickr/scss/_flatpickr.scss
+++ b/src/scripts/Providers/OSUI/SharedProviderResources/Flatpickr/scss/_flatpickr.scss
@@ -2,6 +2,7 @@
 	Overriding styles for Flatpickr library.
 	Shared between SingleDatePicker, RangeDatePicker and TimePicker
 */
+
 .flatpickr-calendar {
 	--osui-flatpickr-layer: var(--layer-global-elevated);
 	border-radius: var(--border-radius-soft);
@@ -329,7 +330,6 @@ span.flatpickr-weekday {
 		}
 	}
 
-
 	&.selected.startRange,
 	&.startRange.startRange {
 		border-radius: 50px;
@@ -480,6 +480,10 @@ span.flatpickr-weekday {
 // IsRTL -------------------------------------------------------------------------
 ///
 .is-rtl {
+	&:has(.layout-side) .flatpickr-calendar {
+		--osui-flatpickr-layer: calc(var(--osui-menu-layer) + var(--layer-local-tier-1));
+	}
+
 	.flatpickr-calendar {
 		// This +10px will be used to better contain all the text without cropping it since RTL texts are bigger
 		width: 330px;
@@ -541,4 +545,11 @@ span.flatpickr-weekday {
 // Layer Library Overrides
 .flatpickr-calendar.static.open {
 	z-index: var(--osui-flatpickr-layer);
+}
+
+// Exception for firefox support for :has()
+@supports not selector(:has(*)) {
+	.is-rtl .flatpickr-calendar {
+		--osui-flatpickr-layer: calc(var(--osui-menu-layer) + var(--layer-local-tier-1));
+	}
 }


### PR DESCRIPTION
This PR is for fixing the positioning of datpicker ballon whe used insed a LayoutSide with thr RTL enabled.

### What was happening
![image](https://user-images.githubusercontent.com/25321845/236855355-f35e4538-ec9a-42b7-93b9-7513bddaf888.png)

### What was done
![image](https://user-images.githubusercontent.com/25321845/236855428-a3b577fc-4564-434b-9d6a-84424d72b469.png)

### Test Steps

- Open the Sample page
- Enable the RTL on switch element
- Open each picker
Expected: The ballon of each picker will open above the sidemenu

### Screenshots
![image](https://user-images.githubusercontent.com/25321845/236855428-a3b577fc-4564-434b-9d6a-84424d72b469.png)

### Checklist
-   [X] tested locally
-   [X] documented the code
-   [X] clean all warnings and errors of eslint
-   [ ] requires changes in OutSystems (if so, provide a module with changes)
-   [ ] requires new sample page in OutSystems (if so, provide a module with changes)
