### PR TITLE
Rou 4328

### DIFF
--- a/dist/OutSystemsUI.js
+++ b/dist/OutSystemsUI.js
@@ -15239,12 +15239,17 @@ var OutSystems;
                 const result = OutSystems.OSUI.Utils.CreateApiResponse({
                     errorCode: OSUI.ErrorCodes.Utilities.FailAddFavicon,
                     callback: () => {
-                        const link = (OSFramework.OSUI.Helper.Dom.TagSelector(document.head, "link[rel*='icon']") ||
-                            document.createElement('link'));
-                        link.type = 'image/x-icon';
-                        link.rel = 'shortcut icon';
-                        link.href = URL;
-                        document.getElementsByTagName('head')[0].appendChild(link);
+                        const existingFavicon = OSFramework.OSUI.Helper.Dom.TagSelector(document.head, "link[rel*='icon']");
+                        if (existingFavicon) {
+                            existingFavicon.href = URL;
+                        }
+                        else {
+                            const link = document.createElement('link');
+                            link.type = 'image/x-icon';
+                            link.rel = 'shortcut icon';
+                            link.href = URL;
+                            document.getElementsByTagName('head')[0].appendChild(link);
+                        }
                     },
                 });
                 return result;

--- a/src/scripts/OutSystems/OSUI/Utils/Utilities.ts
+++ b/src/scripts/OutSystems/OSUI/Utils/Utilities.ts
@@ -1,22 +1,30 @@
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 namespace OutSystems.OSUI.Utils {
 	/**
-	 * Add a favicon to your web application by providing the icon's URL. This action should be used in the Layout OnReady event or on an OnApplicationStart event.
+	 * Add a favicon to your web application by providing the icon's URL. If the tag already exists, only the URL will be updated.
+	 * This action should be used in the Layout OnReady event or on an OnApplicationStart event.
 	 * @param URL
 	 */
 	export function AddFavicon(URL: string): string {
 		const result = OutSystems.OSUI.Utils.CreateApiResponse({
 			errorCode: ErrorCodes.Utilities.FailAddFavicon,
 			callback: () => {
-				const link = (OSFramework.OSUI.Helper.Dom.TagSelector(document.head, "link[rel*='icon']") ||
-					document.createElement('link')) as HTMLLinkElement;
-				link.type = 'image/x-icon';
-				link.rel = 'shortcut icon';
-				link.href = URL;
-				document.getElementsByTagName('head')[0].appendChild(link);
+				const existingFavicon = OSFramework.OSUI.Helper.Dom.TagSelector(
+					document.head,
+					"link[rel*='icon']"
+				) as HTMLLinkElement;
+
+				if (existingFavicon) {
+					existingFavicon.href = URL;
+				} else {
+					const link = document.createElement('link');
+					link.type = 'image/x-icon';
+					link.rel = 'shortcut icon';
+					link.href = URL;
+					document.getElementsByTagName('head')[0].appendChild(link);
+				}
 			},
 		});
-
 		return result;
 	}
 


### PR DESCRIPTION
This PR is to improve the AddFavicon method in order to make sure that if the tag already exists, only the URL will be updated, instead of only relying on the browser as we did on the last approach.

### What was happening

- Despite we were not able to reproduce this and this being already taken into account in the previous implementation, we got feedback [here](https://www.outsystems.com/forums/discussion/88231/outsystems-ui-bug-when-orientation-change-on-mobile/) about scenarios where multiple favicon tags were being stacked in the DOM.


### What was done

- Added a more explicit validation in order to make sure that if the tag already exists, only the URL will be updated so that we never have multiple favicon tags in the DOM.
- On the OutSystems side, the client action _AddFavicon_Legacy_ was also updated to reflect the same approach.


### Test Steps

**Test Case 1:**
- Go to TaskSample_DEV_ROU4328.
- Check that the OutSystems favicon was added.
- Navigate to Screen 2.
- Check that the Travel favicon was added and no tags are duplicated on the DOM.
- Navigate to Screen 3.
- Check that the OutSystems favicon was added and no tags are duplicated on the DOM. 
- Navigate to Screen 4.
- Check that the Travel favicon was added and no tags are duplicated on the DOM.
- Use back to navigate to Screen 3.
- Check that the OutSystems favicon was added and no tags are duplicated on the DOM.  
- Reload the screen.
- Check that the OutSystems favicon was kept and no tags are duplicated on the DOM. 

**Test Case 2:**
- Go to OSUIReactive_FunctionalTests_ROU432/TestClientActions_NoLayout.
- Click in AddFavicon.
- Check that the favicon was changed and no tags are duplicated on the DOM.
- Repeat the same steps for OSUIReactive_FunctionalTests_ROU432/TestClientActions.


### Checklist

-   [X] tested locally
-   [X] documented the code
-   [X] clean all warnings and errors of eslint
-   [X] requires changes in OutSystems (if so, provide a module with changes)
-   [ ] requires new sample page in OutSystems (if so, provide a module with changes)
