### PR TITLE
ROU-3349: InlineSVG - Implement with the new architecture

### DIFF
--- a/dist/OutSystemsUI.css
+++ b/dist/OutSystemsUI.css
@@ -12929,6 +12929,7 @@ body:has(.popup-dialog):has(.osui-dropdown-serverside--is-opened) .osui-dropdown
   min-height:40px;
   overflow:hidden;
   padding:var(--space-s) var(--space-base);
+  position:relative;
   -webkit-transition:background 250ms ease;
   -o-transition:background 250ms ease;
   transition:background 250ms ease;
@@ -16243,6 +16244,12 @@ input.OSFillParent.calendar-input{
 }
 .bold{
   font-weight:var(--font-bold);
+}
+.italic{
+  font-style:italic;
+}
+.oblique{
+  font-style:oblique;
 }
 .text-lowercase{
   text-transform:lowercase;

--- a/dist/OutSystemsUI.d.ts
+++ b/dist/OutSystemsUI.d.ts
@@ -449,6 +449,11 @@ declare namespace OSFramework.OSUI.GlobalEnum {
         Initialized = "Initialized",
         OnProviderConfigsApplied = "OnProviderConfigsApplied"
     }
+    enum SVGHelperConstants {
+        DOMType = "image/svg+xml",
+        ParserError = "parsererror",
+        SVG = "svg"
+    }
 }
 declare namespace OSFramework.OSUI.Behaviors {
     type SpringAnimationProperties = {

--- a/dist/OutSystemsUI.d.ts
+++ b/dist/OutSystemsUI.d.ts
@@ -162,6 +162,9 @@ declare namespace OSFramework.OSUI.ErrorCodes {
     const Sidebar: {
         FailRegisterCallback: string;
     };
+    const InlineSvg: {
+        FailRegisterCallback: string;
+    };
 }
 declare namespace OSFramework.OSUI.GlobalCallbacks {
     type Generic = {
@@ -364,6 +367,7 @@ declare namespace OSFramework.OSUI.GlobalEnum {
         FloatingActions = "Floating Actions",
         FloatingActionsItem = "Floating Actions Item",
         Gallery = "Gallery",
+        InlineSvg = "InlineSVG",
         MonthPicker = "MonthPicker",
         Notification = "Notification",
         ProgressBar = "Progress Bar",
@@ -975,6 +979,11 @@ declare namespace OSFramework.OSUI.Helper {
 declare namespace OSFramework.OSUI.Helper.MapOperation {
     function FindInMap(patternName: string, patternId: string, map: Map<string, Interface.IPattern>): Interface.IPattern;
     function ExportKeys(map: Map<string, Interface.IPattern>): Array<string>;
+}
+declare namespace OSFramework.OSUI.Helper {
+    abstract class SVG {
+        static IsValid(svgString: string): boolean;
+    }
 }
 declare namespace OSFramework.OSUI.Helper {
     function Sanitize(value: string): string;
@@ -2080,6 +2089,51 @@ declare namespace OSFramework.OSUI.Patterns.Gallery {
 }
 declare namespace OSFramework.OSUI.Patterns.Gallery {
     interface IGallery extends Interface.IPattern {
+    }
+}
+declare namespace OSFramework.OSUI.Patterns.InlineSvg.Callbacks {
+    type OSInitializedEvent = {
+        (inlineSvgId: string): void;
+    };
+}
+declare namespace OSFramework.OSUI.Patterns.InlineSvg.Enum {
+    enum CssClass {
+        Pattern = "osui-inline-svg"
+    }
+    enum Events {
+        OnInitialize = "Initialized"
+    }
+    enum Properties {
+        SVGCode = "SVGCode"
+    }
+}
+declare namespace OSFramework.OSUI.Patterns.InlineSvg {
+    interface IInlineSvg extends Interface.IPattern {
+        registerCallback(eventName: string, callback: GlobalCallbacks.OSGeneric): void;
+    }
+}
+declare namespace OSFramework.OSUI.Patterns.InlineSvg {
+    class InlineSvg extends AbstractPattern<InlineSvgConfig> implements IInlineSvg {
+        private _parentSelf;
+        private _platformEventOnInitialize;
+        constructor(uniqueId: string, configs: JSON);
+        private _setSvgCode;
+        protected setA11YProperties(): void;
+        protected setCallbacks(): void;
+        protected setHtmlElements(): void;
+        protected unsetCallbacks(): void;
+        protected unsetHtmlElements(): void;
+        build(): void;
+        changeProperty(propertyName: string, propertyValue: any): void;
+        dispose(): void;
+        registerCallback(eventName: string, callback: GlobalCallbacks.OSGeneric): void;
+    }
+}
+declare namespace OSFramework.OSUI.Patterns.InlineSvg {
+    class InlineSvgConfig extends AbstractConfiguration {
+        SVGCode: string;
+        constructor(config: any);
+        validateDefault(key: string, value: unknown): unknown;
     }
 }
 declare namespace OSFramework.OSUI.Patterns.MonthPicker {
@@ -3684,6 +3738,11 @@ declare namespace OutSystems.OSUI.ErrorCodes {
         FailSetExtendedMenuShow: string;
         FailCheckIsRTL: string;
     };
+    const InlineSvg: {
+        FailChangeProperty: string;
+        FailDispose: string;
+        FailRegisterCallback: string;
+    };
     const Legacy: {
         FailAddFavicon_Legacy: string;
         MoveElement_Legacy: string;
@@ -3840,6 +3899,15 @@ declare namespace OutSystems.OSUI.Patterns.GalleryAPI {
     function GetAllGalleries(): Array<string>;
     function GetGalleryById(galleryId: string): OSFramework.OSUI.Patterns.Gallery.IGallery;
     function Initialize(galleryId: string): OSFramework.OSUI.Patterns.Gallery.IGallery;
+}
+declare namespace OutSystems.OSUI.Patterns.InlineSvgAPI {
+    function ChangeProperty(inlineSvgId: string, propertyName: string, propertyValue: any): string;
+    function Create(inlineSvgId: string, configs: string): OSFramework.OSUI.Patterns.InlineSvg.IInlineSvg;
+    function Dispose(inlineSvgId: string): string;
+    function GetAllInlineSvgs(): Array<string>;
+    function GetInlineSvgById(inlineSvgId: string): OSFramework.OSUI.Patterns.InlineSvg.IInlineSvg;
+    function Initialize(inlineSvgId: string): OSFramework.OSUI.Patterns.InlineSvg.IInlineSvg;
+    function RegisterCallback(inlineSvgId: string, eventName: string, callback: OSFramework.OSUI.GlobalCallbacks.OSGeneric): string;
 }
 declare namespace OutSystems.OSUI.Patterns.MonthPickerAPI {
     function ChangeProperty(monthPickerId: string, propertyName: string, propertyValue: any): string;

--- a/dist/OutSystemsUI.d.ts
+++ b/dist/OutSystemsUI.d.ts
@@ -2108,8 +2108,7 @@ declare namespace OSFramework.OSUI.Patterns.InlineSvg.Enum {
     }
 }
 declare namespace OSFramework.OSUI.Patterns.InlineSvg {
-    interface IInlineSvg extends Interface.IPattern {
-        registerCallback(eventName: string, callback: GlobalCallbacks.OSGeneric): void;
+    interface IInlineSvg extends Interface.IPattern, Interface.ICallback {
     }
 }
 declare namespace OSFramework.OSUI.Patterns.InlineSvg {
@@ -2126,7 +2125,7 @@ declare namespace OSFramework.OSUI.Patterns.InlineSvg {
         build(): void;
         changeProperty(propertyName: string, propertyValue: any): void;
         dispose(): void;
-        registerCallback(eventName: string, callback: GlobalCallbacks.OSGeneric): void;
+        registerCallback(callback: GlobalCallbacks.OSGeneric, eventName: string): void;
     }
 }
 declare namespace OSFramework.OSUI.Patterns.InlineSvg {

--- a/dist/OutSystemsUI.js
+++ b/dist/OutSystemsUI.js
@@ -6195,24 +6195,23 @@ var OSFramework;
                         console.log(OSUI.GlobalEnum.WarningMessages.MethodNotImplemented);
                     }
                     setCallbacks() {
-                        console.log(OSUI.GlobalEnum.WarningMessages.MethodNotImplemented);
+                        OSUI.Helper.AsyncInvocation(this._platformEventOnInitialize, this.widgetId);
                     }
                     setHtmlElements() {
                         this._parentSelf = OSUI.Helper.Dom.GetElementById(this.widgetId);
-                        OSUI.Helper.AsyncInvocation(this._platformEventOnInitialize, this.widgetId);
                     }
                     unsetCallbacks() {
-                        console.log(OSUI.GlobalEnum.WarningMessages.MethodNotImplemented);
+                        this._platformEventOnInitialize = undefined;
                     }
                     unsetHtmlElements() {
                         this._parentSelf = undefined;
-                        this._platformEventOnInitialize = undefined;
                     }
                     build() {
                         super.build();
                         this._setSvgCode();
                         this.setHtmlElements();
                         this.finishBuild();
+                        this.setCallbacks();
                     }
                     changeProperty(propertyName, propertyValue) {
                         super.changeProperty(propertyName, propertyValue);
@@ -6229,11 +6228,12 @@ var OSFramework;
                     }
                     dispose() {
                         if (this.isBuilt) {
+                            this.unsetCallbacks();
                             this.unsetHtmlElements();
                             super.dispose();
                         }
                     }
-                    registerCallback(eventName, callback) {
+                    registerCallback(callback, eventName) {
                         switch (eventName) {
                             case Patterns.InlineSvg.Enum.Events.OnInitialize:
                                 if (this._platformEventOnInitialize === undefined) {

--- a/dist/OutSystemsUI.js
+++ b/dist/OutSystemsUI.js
@@ -541,6 +541,12 @@ var OSFramework;
                 ProviderEvents["Initialized"] = "Initialized";
                 ProviderEvents["OnProviderConfigsApplied"] = "OnProviderConfigsApplied";
             })(ProviderEvents = GlobalEnum.ProviderEvents || (GlobalEnum.ProviderEvents = {}));
+            let SVGHelperConstants;
+            (function (SVGHelperConstants) {
+                SVGHelperConstants["DOMType"] = "image/svg+xml";
+                SVGHelperConstants["ParserError"] = "parsererror";
+                SVGHelperConstants["SVG"] = "svg";
+            })(SVGHelperConstants = GlobalEnum.SVGHelperConstants || (GlobalEnum.SVGHelperConstants = {}));
         })(GlobalEnum = OSUI.GlobalEnum || (OSUI.GlobalEnum = {}));
     })(OSUI = OSFramework.OSUI || (OSFramework.OSUI = {}));
 })(OSFramework || (OSFramework = {}));
@@ -2713,9 +2719,9 @@ var OSFramework;
                 static IsValid(svgString) {
                     const parser = new DOMParser();
                     try {
-                        const doc = parser.parseFromString(svgString, 'image/svg+xml');
-                        const parserError = doc.getElementsByTagName('parsererror');
-                        if (parserError.length > 0 || doc.documentElement.tagName !== 'svg') {
+                        const doc = parser.parseFromString(svgString, OSUI.GlobalEnum.SVGHelperConstants.DOMType);
+                        const parserError = doc.getElementsByTagName(OSUI.GlobalEnum.SVGHelperConstants.ParserError);
+                        if (parserError.length > 0 || doc.documentElement.tagName !== OSUI.GlobalEnum.SVGHelperConstants.SVG) {
                             return false;
                         }
                     }
@@ -6195,7 +6201,7 @@ var OSFramework;
                         console.log(OSUI.GlobalEnum.WarningMessages.MethodNotImplemented);
                     }
                     setCallbacks() {
-                        OSUI.Helper.AsyncInvocation(this._platformEventOnInitialize, this.widgetId);
+                        console.log(OSUI.GlobalEnum.WarningMessages.MethodNotImplemented);
                     }
                     setHtmlElements() {
                         this._parentSelf = OSUI.Helper.Dom.GetElementById(this.widgetId);
@@ -6211,7 +6217,7 @@ var OSFramework;
                         this._setSvgCode();
                         this.setHtmlElements();
                         this.finishBuild();
-                        this.setCallbacks();
+                        OSUI.Helper.AsyncInvocation(this._platformEventOnInitialize, this.widgetId);
                     }
                     changeProperty(propertyName, propertyValue) {
                         super.changeProperty(propertyName, propertyValue);
@@ -12480,7 +12486,7 @@ var OutSystems;
                         errorCode: OSUI.ErrorCodes.InlineSvg.FailRegisterCallback,
                         callback: () => {
                             const _InlineSvgItem = this.GetInlineSvgById(inlineSvgId);
-                            _InlineSvgItem.registerCallback(eventName, callback);
+                            _InlineSvgItem.registerCallback(callback, eventName);
                         },
                     });
                     return result;

--- a/dist/OutSystemsUI.js
+++ b/dist/OutSystemsUI.js
@@ -224,6 +224,9 @@ var OSFramework;
             ErrorCodes.Sidebar = {
                 FailRegisterCallback: 'OSUI-GEN-14001',
             };
+            ErrorCodes.InlineSvg = {
+                FailRegisterCallback: 'OSUI-GEN-15001',
+            };
         })(ErrorCodes = OSUI.ErrorCodes || (OSUI.ErrorCodes = {}));
     })(OSUI = OSFramework.OSUI || (OSFramework.OSUI = {}));
 })(OSFramework || (OSFramework = {}));
@@ -444,6 +447,7 @@ var OSFramework;
                 PatternName["FloatingActions"] = "Floating Actions";
                 PatternName["FloatingActionsItem"] = "Floating Actions Item";
                 PatternName["Gallery"] = "Gallery";
+                PatternName["InlineSvg"] = "InlineSVG";
                 PatternName["MonthPicker"] = "MonthPicker";
                 PatternName["Notification"] = "Notification";
                 PatternName["ProgressBar"] = "Progress Bar";
@@ -2696,6 +2700,32 @@ var OSFramework;
                 }
                 MapOperation.ExportKeys = ExportKeys;
             })(MapOperation = Helper.MapOperation || (Helper.MapOperation = {}));
+        })(Helper = OSUI.Helper || (OSUI.Helper = {}));
+    })(OSUI = OSFramework.OSUI || (OSFramework.OSUI = {}));
+})(OSFramework || (OSFramework = {}));
+var OSFramework;
+(function (OSFramework) {
+    var OSUI;
+    (function (OSUI) {
+        var Helper;
+        (function (Helper) {
+            class SVG {
+                static IsValid(svgString) {
+                    const parser = new DOMParser();
+                    try {
+                        const doc = parser.parseFromString(svgString, 'image/svg+xml');
+                        const parserError = doc.getElementsByTagName('parsererror');
+                        if (parserError.length > 0 || doc.documentElement.tagName !== 'svg') {
+                            return false;
+                        }
+                    }
+                    catch (error) {
+                        return false;
+                    }
+                    return true;
+                }
+            }
+            Helper.SVG = SVG;
         })(Helper = OSUI.Helper || (OSUI.Helper = {}));
     })(OSUI = OSFramework.OSUI || (OSFramework.OSUI = {}));
 })(OSFramework || (OSFramework = {}));
@@ -6110,6 +6140,140 @@ var OSFramework;
                 }
                 Gallery.GalleryConfig = GalleryConfig;
             })(Gallery = Patterns.Gallery || (Patterns.Gallery = {}));
+        })(Patterns = OSUI.Patterns || (OSUI.Patterns = {}));
+    })(OSUI = OSFramework.OSUI || (OSFramework.OSUI = {}));
+})(OSFramework || (OSFramework = {}));
+var OSFramework;
+(function (OSFramework) {
+    var OSUI;
+    (function (OSUI) {
+        var Patterns;
+        (function (Patterns) {
+            var InlineSvg;
+            (function (InlineSvg) {
+                var Enum;
+                (function (Enum) {
+                    let CssClass;
+                    (function (CssClass) {
+                        CssClass["Pattern"] = "osui-inline-svg";
+                    })(CssClass = Enum.CssClass || (Enum.CssClass = {}));
+                    let Events;
+                    (function (Events) {
+                        Events["OnInitialize"] = "Initialized";
+                    })(Events = Enum.Events || (Enum.Events = {}));
+                    let Properties;
+                    (function (Properties) {
+                        Properties["SVGCode"] = "SVGCode";
+                    })(Properties = Enum.Properties || (Enum.Properties = {}));
+                })(Enum = InlineSvg.Enum || (InlineSvg.Enum = {}));
+            })(InlineSvg = Patterns.InlineSvg || (Patterns.InlineSvg = {}));
+        })(Patterns = OSUI.Patterns || (OSUI.Patterns = {}));
+    })(OSUI = OSFramework.OSUI || (OSFramework.OSUI = {}));
+})(OSFramework || (OSFramework = {}));
+var OSFramework;
+(function (OSFramework) {
+    var OSUI;
+    (function (OSUI) {
+        var Patterns;
+        (function (Patterns) {
+            var InlineSvg;
+            (function (InlineSvg_1) {
+                class InlineSvg extends Patterns.AbstractPattern {
+                    constructor(uniqueId, configs) {
+                        super(uniqueId, new InlineSvg_1.InlineSvgConfig(configs));
+                    }
+                    _setSvgCode() {
+                        if (this.configs.SVGCode !== '' && !OSUI.Helper.SVG.IsValid(this.configs.SVGCode)) {
+                            throw new Error('Please provide a valid SVGCode.');
+                        }
+                        this.selfElement.innerHTML = this.configs.SVGCode;
+                    }
+                    setA11YProperties() {
+                        console.log(OSUI.GlobalEnum.WarningMessages.MethodNotImplemented);
+                    }
+                    setCallbacks() {
+                        console.log(OSUI.GlobalEnum.WarningMessages.MethodNotImplemented);
+                    }
+                    setHtmlElements() {
+                        this._parentSelf = OSUI.Helper.Dom.GetElementById(this.widgetId);
+                        OSUI.Helper.AsyncInvocation(this._platformEventOnInitialize, this.widgetId);
+                    }
+                    unsetCallbacks() {
+                        console.log(OSUI.GlobalEnum.WarningMessages.MethodNotImplemented);
+                    }
+                    unsetHtmlElements() {
+                        this._parentSelf = undefined;
+                        this._platformEventOnInitialize = undefined;
+                    }
+                    build() {
+                        super.build();
+                        this._setSvgCode();
+                        this.setHtmlElements();
+                        this.finishBuild();
+                    }
+                    changeProperty(propertyName, propertyValue) {
+                        super.changeProperty(propertyName, propertyValue);
+                        if (this.isBuilt) {
+                            switch (propertyName) {
+                                case InlineSvg_1.Enum.Properties.SVGCode:
+                                    this._setSvgCode();
+                                    break;
+                                case OSUI.GlobalEnum.CommonPatternsProperties.ExtendedClass:
+                                    OSUI.Helper.Dom.Styles.ExtendedClass(this.selfElement, this.configs.ExtendedClass, propertyValue);
+                                    break;
+                            }
+                        }
+                    }
+                    dispose() {
+                        if (this.isBuilt) {
+                            this.unsetHtmlElements();
+                            super.dispose();
+                        }
+                    }
+                    registerCallback(eventName, callback) {
+                        switch (eventName) {
+                            case Patterns.InlineSvg.Enum.Events.OnInitialize:
+                                if (this._platformEventOnInitialize === undefined) {
+                                    this._platformEventOnInitialize = callback;
+                                }
+                                break;
+                            default:
+                                throw new Error(`${OSUI.ErrorCodes.InlineSvg.FailRegisterCallback}:	The given '${eventName}' event name is not defined.`);
+                        }
+                    }
+                }
+                InlineSvg_1.InlineSvg = InlineSvg;
+            })(InlineSvg = Patterns.InlineSvg || (Patterns.InlineSvg = {}));
+        })(Patterns = OSUI.Patterns || (OSUI.Patterns = {}));
+    })(OSUI = OSFramework.OSUI || (OSFramework.OSUI = {}));
+})(OSFramework || (OSFramework = {}));
+var OSFramework;
+(function (OSFramework) {
+    var OSUI;
+    (function (OSUI) {
+        var Patterns;
+        (function (Patterns) {
+            var InlineSvg;
+            (function (InlineSvg) {
+                class InlineSvgConfig extends Patterns.AbstractConfiguration {
+                    constructor(config) {
+                        super(config);
+                    }
+                    validateDefault(key, value) {
+                        let validatedValue = undefined;
+                        switch (key) {
+                            case InlineSvg.Enum.Properties.SVGCode:
+                                validatedValue = super.validateString(value, '');
+                                break;
+                            default:
+                                validatedValue = super.validateDefault(key, value);
+                                break;
+                        }
+                        return validatedValue;
+                    }
+                }
+                InlineSvg.InlineSvgConfig = InlineSvgConfig;
+            })(InlineSvg = Patterns.InlineSvg || (Patterns.InlineSvg = {}));
         })(Patterns = OSUI.Patterns || (OSUI.Patterns = {}));
     })(OSUI = OSFramework.OSUI || (OSFramework.OSUI = {}));
 })(OSFramework || (OSFramework = {}));
@@ -10955,6 +11119,11 @@ var OutSystems;
                 FailSetExtendedMenuShow: 'OSUI-API-28025',
                 FailCheckIsRTL: 'OSUI-API-28026',
             };
+            ErrorCodes.InlineSvg = {
+                FailChangeProperty: 'OSUI-API-29001',
+                FailDispose: 'OSUI-API-29002',
+                FailRegisterCallback: 'OSUI-API-29003',
+            };
             ErrorCodes.Legacy = {
                 FailAddFavicon_Legacy: 'OSUI-LEG-000001',
                 MoveElement_Legacy: 'OSUI-LEG-000002',
@@ -12245,6 +12414,76 @@ var OutSystems;
                 }
                 GalleryAPI.Initialize = Initialize;
             })(GalleryAPI = Patterns.GalleryAPI || (Patterns.GalleryAPI = {}));
+        })(Patterns = OSUI.Patterns || (OSUI.Patterns = {}));
+    })(OSUI = OutSystems.OSUI || (OutSystems.OSUI = {}));
+})(OutSystems || (OutSystems = {}));
+var OutSystems;
+(function (OutSystems) {
+    var OSUI;
+    (function (OSUI) {
+        var Patterns;
+        (function (Patterns) {
+            var InlineSvgAPI;
+            (function (InlineSvgAPI) {
+                const _inlineSvgMap = new Map();
+                function ChangeProperty(inlineSvgId, propertyName, propertyValue) {
+                    const result = OutSystems.OSUI.Utils.CreateApiResponse({
+                        errorCode: OSUI.ErrorCodes.InlineSvg.FailChangeProperty,
+                        callback: () => {
+                            const inlineSvg = GetInlineSvgById(inlineSvgId);
+                            inlineSvg.changeProperty(propertyName, propertyValue);
+                        },
+                    });
+                    return result;
+                }
+                InlineSvgAPI.ChangeProperty = ChangeProperty;
+                function Create(inlineSvgId, configs) {
+                    if (_inlineSvgMap.has(inlineSvgId)) {
+                        throw new Error(`There is already a ${OSFramework.OSUI.GlobalEnum.PatternName.InlineSvg} registered under id: ${inlineSvgId}`);
+                    }
+                    const _newInlineSvg = new OSFramework.OSUI.Patterns.InlineSvg.InlineSvg(inlineSvgId, JSON.parse(configs));
+                    _inlineSvgMap.set(inlineSvgId, _newInlineSvg);
+                    return _newInlineSvg;
+                }
+                InlineSvgAPI.Create = Create;
+                function Dispose(inlineSvgId) {
+                    const result = OutSystems.OSUI.Utils.CreateApiResponse({
+                        errorCode: OSUI.ErrorCodes.InlineSvg.FailDispose,
+                        callback: () => {
+                            const inlineSvg = GetInlineSvgById(inlineSvgId);
+                            inlineSvg.dispose();
+                            _inlineSvgMap.delete(inlineSvgId);
+                        },
+                    });
+                    return result;
+                }
+                InlineSvgAPI.Dispose = Dispose;
+                function GetAllInlineSvgs() {
+                    return OSFramework.OSUI.Helper.MapOperation.ExportKeys(_inlineSvgMap);
+                }
+                InlineSvgAPI.GetAllInlineSvgs = GetAllInlineSvgs;
+                function GetInlineSvgById(inlineSvgId) {
+                    return OSFramework.OSUI.Helper.MapOperation.FindInMap('InlineSvg', inlineSvgId, _inlineSvgMap);
+                }
+                InlineSvgAPI.GetInlineSvgById = GetInlineSvgById;
+                function Initialize(inlineSvgId) {
+                    const inlineSvg = GetInlineSvgById(inlineSvgId);
+                    inlineSvg.build();
+                    return inlineSvg;
+                }
+                InlineSvgAPI.Initialize = Initialize;
+                function RegisterCallback(inlineSvgId, eventName, callback) {
+                    const result = OutSystems.OSUI.Utils.CreateApiResponse({
+                        errorCode: OSUI.ErrorCodes.InlineSvg.FailRegisterCallback,
+                        callback: () => {
+                            const _InlineSvgItem = this.GetInlineSvgById(inlineSvgId);
+                            _InlineSvgItem.registerCallback(eventName, callback);
+                        },
+                    });
+                    return result;
+                }
+                InlineSvgAPI.RegisterCallback = RegisterCallback;
+            })(InlineSvgAPI = Patterns.InlineSvgAPI || (Patterns.InlineSvgAPI = {}));
         })(Patterns = OSUI.Patterns || (OSUI.Patterns = {}));
     })(OSUI = OutSystems.OSUI || (OutSystems.OSUI = {}));
 })(OutSystems || (OutSystems = {}));

--- a/dist/OutSystemsUI.js
+++ b/dist/OutSystemsUI.js
@@ -6184,9 +6184,12 @@ var OSFramework;
                     }
                     _setSvgCode() {
                         if (this.configs.SVGCode !== '' && !OSUI.Helper.SVG.IsValid(this.configs.SVGCode)) {
-                            throw new Error('Please provide a valid SVGCode.');
+                            this.selfElement.innerHTML = '';
+                            console.error('Please provide a valid SVGCode.');
                         }
-                        this.selfElement.innerHTML = this.configs.SVGCode;
+                        else {
+                            this.selfElement.innerHTML = this.configs.SVGCode;
+                        }
                     }
                     setA11YProperties() {
                         console.log(OSUI.GlobalEnum.WarningMessages.MethodNotImplemented);

--- a/src/scripts/OSFramework/OSUI/ErrorCodes.ts
+++ b/src/scripts/OSFramework/OSUI/ErrorCodes.ts
@@ -98,4 +98,8 @@ namespace OSFramework.OSUI.ErrorCodes {
 	export const Sidebar = {
 		FailRegisterCallback: 'OSUI-GEN-14001',
 	};
+
+	export const InlineSvg = {
+		FailRegisterCallback: 'OSUI-GEN-15001',
+	};
 }

--- a/src/scripts/OSFramework/OSUI/GlobalEnum.ts
+++ b/src/scripts/OSFramework/OSUI/GlobalEnum.ts
@@ -385,4 +385,10 @@ namespace OSFramework.OSUI.GlobalEnum {
 		Initialized = 'Initialized',
 		OnProviderConfigsApplied = 'OnProviderConfigsApplied',
 	}
+
+	export enum SVGHelperConstants {
+		DOMType = 'image/svg+xml',
+		ParserError = 'parsererror',
+		SVG = 'svg',
+	}
 }

--- a/src/scripts/OSFramework/OSUI/GlobalEnum.ts
+++ b/src/scripts/OSFramework/OSUI/GlobalEnum.ts
@@ -273,6 +273,7 @@ namespace OSFramework.OSUI.GlobalEnum {
 		FloatingActions = 'Floating Actions',
 		FloatingActionsItem = 'Floating Actions Item',
 		Gallery = 'Gallery',
+		InlineSvg = 'InlineSVG',
 		MonthPicker = 'MonthPicker',
 		Notification = 'Notification',
 		ProgressBar = 'Progress Bar',

--- a/src/scripts/OSFramework/OSUI/Helper/SVG.ts
+++ b/src/scripts/OSFramework/OSUI/Helper/SVG.ts
@@ -1,0 +1,25 @@
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+namespace OSFramework.OSUI.Helper {
+	// eslint-disable-next-line @typescript-eslint/naming-convention
+	export abstract class SVG {
+		/**
+		 * Function that validates if a given svgString is a valid SVG
+		 *
+		 * @param url
+		 * @memberof OSFramework.Helper.URL
+		 */
+		public static IsValid(svgString: string): boolean {
+			const parser = new DOMParser();
+			try {
+				const doc = parser.parseFromString(svgString, 'image/svg+xml');
+				const parserError = doc.getElementsByTagName('parsererror'); // If there are parser errors or the root element is not <svg>, it's an invalid SVG
+				if (parserError.length > 0 || doc.documentElement.tagName !== 'svg') {
+					return false;
+				}
+			} catch (error) {
+				return false;
+			}
+			return true;
+		}
+	}
+}

--- a/src/scripts/OSFramework/OSUI/Helper/SVG.ts
+++ b/src/scripts/OSFramework/OSUI/Helper/SVG.ts
@@ -11,9 +11,9 @@ namespace OSFramework.OSUI.Helper {
 		public static IsValid(svgString: string): boolean {
 			const parser = new DOMParser();
 			try {
-				const doc = parser.parseFromString(svgString, 'image/svg+xml');
-				const parserError = doc.getElementsByTagName('parsererror'); // If there are parser errors or the root element is not <svg>, it's an invalid SVG
-				if (parserError.length > 0 || doc.documentElement.tagName !== 'svg') {
+				const doc = parser.parseFromString(svgString, GlobalEnum.SVGHelperConstants.DOMType);
+				const parserError = doc.getElementsByTagName(GlobalEnum.SVGHelperConstants.ParserError); // If there are parser errors or the root element is not <svg>, it's an invalid SVG
+				if (parserError.length > 0 || doc.documentElement.tagName !== GlobalEnum.SVGHelperConstants.SVG) {
 					return false;
 				}
 			} catch (error) {

--- a/src/scripts/OSFramework/OSUI/Pattern/InlineSvg/Callbacks.ts
+++ b/src/scripts/OSFramework/OSUI/Pattern/InlineSvg/Callbacks.ts
@@ -1,0 +1,6 @@
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+namespace OSFramework.OSUI.Patterns.InlineSvg.Callbacks {
+	export type OSInitializedEvent = {
+		(inlineSvgId: string): void;
+	};
+}

--- a/src/scripts/OSFramework/OSUI/Pattern/InlineSvg/Enum.ts
+++ b/src/scripts/OSFramework/OSUI/Pattern/InlineSvg/Enum.ts
@@ -1,0 +1,23 @@
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+namespace OSFramework.OSUI.Patterns.InlineSvg.Enum {
+	/**
+	 * InlineSvg Enum for CSS Classes
+	 */
+	export enum CssClass {
+		Pattern = 'osui-inline-svg',
+	}
+
+	/**
+	 * InlineSvg Events
+	 */
+	export enum Events {
+		OnInitialize = 'Initialized',
+	}
+
+	/**
+	 * InlineSvg Properties
+	 */
+	export enum Properties {
+		SVGCode = 'SVGCode',
+	}
+}

--- a/src/scripts/OSFramework/OSUI/Pattern/InlineSvg/IInlineSvg.ts
+++ b/src/scripts/OSFramework/OSUI/Pattern/InlineSvg/IInlineSvg.ts
@@ -3,7 +3,5 @@ namespace OSFramework.OSUI.Patterns.InlineSvg {
 	/**
 	 * Defines the interface for OutSystemsUI InlineSvg Pattern
 	 */
-	export interface IInlineSvg extends Interface.IPattern {
-		registerCallback(eventName: string, callback: GlobalCallbacks.OSGeneric): void;
-	}
+	export interface IInlineSvg extends Interface.IPattern, Interface.ICallback {}
 }

--- a/src/scripts/OSFramework/OSUI/Pattern/InlineSvg/IInlineSvg.ts
+++ b/src/scripts/OSFramework/OSUI/Pattern/InlineSvg/IInlineSvg.ts
@@ -1,0 +1,9 @@
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+namespace OSFramework.OSUI.Patterns.InlineSvg {
+	/**
+	 * Defines the interface for OutSystemsUI InlineSvg Pattern
+	 */
+	export interface IInlineSvg extends Interface.IPattern {
+		registerCallback(eventName: string, callback: GlobalCallbacks.OSGeneric): void;
+	}
+}

--- a/src/scripts/OSFramework/OSUI/Pattern/InlineSvg/InlineSvg.ts
+++ b/src/scripts/OSFramework/OSUI/Pattern/InlineSvg/InlineSvg.ts
@@ -39,7 +39,7 @@ namespace OSFramework.OSUI.Patterns.InlineSvg {
 		 * @memberof OSFramework.Patterns.InlineSvg.InlineSvg
 		 */
 		protected setCallbacks(): void {
-			Helper.AsyncInvocation(this._platformEventOnInitialize, this.widgetId);
+			console.log(GlobalEnum.WarningMessages.MethodNotImplemented);
 		}
 
 		/**
@@ -81,7 +81,7 @@ namespace OSFramework.OSUI.Patterns.InlineSvg {
 
 			this.finishBuild();
 
-			this.setCallbacks();
+			Helper.AsyncInvocation(this._platformEventOnInitialize, this.widgetId);
 		}
 
 		/**

--- a/src/scripts/OSFramework/OSUI/Pattern/InlineSvg/InlineSvg.ts
+++ b/src/scripts/OSFramework/OSUI/Pattern/InlineSvg/InlineSvg.ts
@@ -39,7 +39,7 @@ namespace OSFramework.OSUI.Patterns.InlineSvg {
 		 * @memberof OSFramework.Patterns.InlineSvg.InlineSvg
 		 */
 		protected setCallbacks(): void {
-			console.log(GlobalEnum.WarningMessages.MethodNotImplemented);
+			Helper.AsyncInvocation(this._platformEventOnInitialize, this.widgetId);
 		}
 
 		/**
@@ -50,8 +50,6 @@ namespace OSFramework.OSUI.Patterns.InlineSvg {
 		 */
 		protected setHtmlElements(): void {
 			this._parentSelf = Helper.Dom.GetElementById(this.widgetId);
-
-			Helper.AsyncInvocation(this._platformEventOnInitialize, this.widgetId);
 		}
 
 		/**
@@ -61,7 +59,7 @@ namespace OSFramework.OSUI.Patterns.InlineSvg {
 		 * @memberof OSFramework.Patterns.InlineSvg.InlineSvg
 		 */
 		protected unsetCallbacks(): void {
-			console.log(GlobalEnum.WarningMessages.MethodNotImplemented);
+			this._platformEventOnInitialize = undefined;
 		}
 
 		/**
@@ -72,7 +70,6 @@ namespace OSFramework.OSUI.Patterns.InlineSvg {
 		 */
 		protected unsetHtmlElements(): void {
 			this._parentSelf = undefined;
-			this._platformEventOnInitialize = undefined;
 		}
 
 		public build(): void {
@@ -83,6 +80,8 @@ namespace OSFramework.OSUI.Patterns.InlineSvg {
 			this.setHtmlElements();
 
 			this.finishBuild();
+
+			this.setCallbacks();
 		}
 
 		/**
@@ -120,6 +119,8 @@ namespace OSFramework.OSUI.Patterns.InlineSvg {
 		 */
 		public dispose(): void {
 			if (this.isBuilt) {
+				this.unsetCallbacks();
+
 				// Remove unused HTML elements
 				this.unsetHtmlElements();
 
@@ -131,11 +132,11 @@ namespace OSFramework.OSUI.Patterns.InlineSvg {
 		/**
 		 * Method used to register the callback
 		 *
-		 * @param {string} eventName
 		 * @param {GlobalCallbacks.OSGeneric} callback
+		 * @param {string} eventName
 		 * @memberof OSFramework.Patterns.InlineSvg.InlineSvg
 		 */
-		public registerCallback(eventName: string, callback: GlobalCallbacks.OSGeneric): void {
+		public registerCallback(callback: GlobalCallbacks.OSGeneric, eventName: string): void {
 			switch (eventName) {
 				case Patterns.InlineSvg.Enum.Events.OnInitialize:
 					if (this._platformEventOnInitialize === undefined) {

--- a/src/scripts/OSFramework/OSUI/Pattern/InlineSvg/InlineSvg.ts
+++ b/src/scripts/OSFramework/OSUI/Pattern/InlineSvg/InlineSvg.ts
@@ -118,9 +118,6 @@ namespace OSFramework.OSUI.Patterns.InlineSvg {
 		 */
 		public dispose(): void {
 			if (this.isBuilt) {
-				// Remove Callbacks
-				// this.unsetCallbacks();
-
 				// Remove unused HTML elements
 				this.unsetHtmlElements();
 

--- a/src/scripts/OSFramework/OSUI/Pattern/InlineSvg/InlineSvg.ts
+++ b/src/scripts/OSFramework/OSUI/Pattern/InlineSvg/InlineSvg.ts
@@ -15,9 +15,11 @@ namespace OSFramework.OSUI.Patterns.InlineSvg {
 
 		private _setSvgCode(): void {
 			if (this.configs.SVGCode !== '' && !Helper.SVG.IsValid(this.configs.SVGCode)) {
-				throw new Error('Please provide a valid SVGCode.');
+				this.selfElement.innerHTML = '';
+				console.error('Please provide a valid SVGCode.');
+			} else {
+				this.selfElement.innerHTML = this.configs.SVGCode;
 			}
-			this.selfElement.innerHTML = this.configs.SVGCode;
 		}
 
 		/**

--- a/src/scripts/OSFramework/OSUI/Pattern/InlineSvg/InlineSvg.ts
+++ b/src/scripts/OSFramework/OSUI/Pattern/InlineSvg/InlineSvg.ts
@@ -1,0 +1,154 @@
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+namespace OSFramework.OSUI.Patterns.InlineSvg {
+	/**
+	 * Defines the interface for OutSystemsUI Patterns
+	 */
+	export class InlineSvg extends AbstractPattern<InlineSvgConfig> implements IInlineSvg {
+		// Store the parent element
+		private _parentSelf: HTMLElement;
+		// Store the platform events
+		private _platformEventOnInitialize: Callbacks.OSInitializedEvent;
+
+		constructor(uniqueId: string, configs: JSON) {
+			super(uniqueId, new InlineSvgConfig(configs));
+		}
+
+		private _setSvgCode(): void {
+			if (this.configs.SVGCode !== '' && !Helper.SVG.IsValid(this.configs.SVGCode)) {
+				throw new Error('Please provide a valid SVGCode.');
+			}
+			this.selfElement.innerHTML = this.configs.SVGCode;
+		}
+
+		/**
+		 * Sets the A11Y properties when the pattern is built.
+		 *
+		 * @protected
+		 * @memberof OSFramework.Patterns.InlineSvg.InlineSvg
+		 */
+		protected setA11YProperties(): void {
+			console.log(GlobalEnum.WarningMessages.MethodNotImplemented);
+		}
+
+		/**
+		 * Set the callbacks that will be assigned to the pattern
+		 *
+		 * @protected
+		 * @memberof OSFramework.Patterns.InlineSvg.InlineSvg
+		 */
+		protected setCallbacks(): void {
+			console.log(GlobalEnum.WarningMessages.MethodNotImplemented);
+		}
+
+		/**
+		 * Set the html references that will be used to manage the cssClasses and atribute properties
+		 *
+		 * @protected
+		 * @memberof OSFramework.Patterns.InlineSvg.InlineSvg
+		 */
+		protected setHtmlElements(): void {
+			this._parentSelf = Helper.Dom.GetElementById(this.widgetId);
+
+			Helper.AsyncInvocation(this._platformEventOnInitialize, this.widgetId);
+		}
+
+		/**
+		 * Set the callbacks that will be assigned to the pattern
+		 *
+		 * @protected
+		 * @memberof OSFramework.Patterns.InlineSvg.InlineSvg
+		 */
+		protected unsetCallbacks(): void {
+			console.log(GlobalEnum.WarningMessages.MethodNotImplemented);
+		}
+
+		/**
+		 * Reassign the HTML elements to undefined, preventing memory leaks
+		 *
+		 * @protected
+		 * @memberof OSFramework.Patterns.InlineSvg.InlineSvg
+		 */
+		protected unsetHtmlElements(): void {
+			this._parentSelf = undefined;
+			this._platformEventOnInitialize = undefined;
+		}
+
+		public build(): void {
+			super.build();
+
+			this._setSvgCode();
+
+			this.setHtmlElements();
+
+			this.finishBuild();
+		}
+
+		/**
+		 * Update value when a parameters changed occurs
+		 *
+		 * @param {string} propertyName
+		 * @param {unknown} propertyValue
+		 * @memberof OSFramework.Patterns.InlineSvg.InlineSvg
+		 */
+		// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any
+		public changeProperty(propertyName: string, propertyValue: any): void {
+			super.changeProperty(propertyName, propertyValue);
+
+			if (this.isBuilt) {
+				// Check which property changed and call respective method to update it
+				switch (propertyName) {
+					case Enum.Properties.SVGCode:
+						this._setSvgCode();
+						break;
+					case GlobalEnum.CommonPatternsProperties.ExtendedClass:
+						Helper.Dom.Styles.ExtendedClass(
+							this.selfElement,
+							this.configs.ExtendedClass,
+							propertyValue as string
+						);
+						break;
+				}
+			}
+		}
+
+		/**
+		 * Destroy the InlineSvg
+		 *
+		 * @memberof OSFramework.Patterns.InlineSvg.InlineSvg
+		 */
+		public dispose(): void {
+			if (this.isBuilt) {
+				// Remove Callbacks
+				// this.unsetCallbacks();
+
+				// Remove unused HTML elements
+				this.unsetHtmlElements();
+
+				//Destroying the base of pattern
+				super.dispose();
+			}
+		}
+
+		/**
+		 * Method used to register the callback
+		 *
+		 * @param {string} eventName
+		 * @param {GlobalCallbacks.OSGeneric} callback
+		 * @memberof OSFramework.Patterns.InlineSvg.InlineSvg
+		 */
+		public registerCallback(eventName: string, callback: GlobalCallbacks.OSGeneric): void {
+			switch (eventName) {
+				case Patterns.InlineSvg.Enum.Events.OnInitialize:
+					if (this._platformEventOnInitialize === undefined) {
+						this._platformEventOnInitialize = callback;
+					}
+					break;
+
+				default:
+					throw new Error(
+						`${ErrorCodes.InlineSvg.FailRegisterCallback}:	The given '${eventName}' event name is not defined.`
+					);
+			}
+		}
+	}
+}

--- a/src/scripts/OSFramework/OSUI/Pattern/InlineSvg/InlineSvgConfig.ts
+++ b/src/scripts/OSFramework/OSUI/Pattern/InlineSvg/InlineSvgConfig.ts
@@ -1,0 +1,33 @@
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+namespace OSFramework.OSUI.Patterns.InlineSvg {
+	export class InlineSvgConfig extends AbstractConfiguration {
+		public SVGCode: string;
+
+		constructor(config) {
+			super(config);
+		}
+
+		/**
+		 * Method that will check if a given property (key) value is the type expected!
+		 *
+		 * @param key property name
+		 * @param value value to be check
+		 * @returns {unknown} value
+		 * @memberof  OSFramework.Patterns.InlineSvg.InlineSvgConfig
+		 */
+		public validateDefault(key: string, value: unknown): unknown {
+			let validatedValue = undefined;
+
+			switch (key) {
+				case Enum.Properties.SVGCode:
+					validatedValue = super.validateString(value as string, '');
+					break;
+				default:
+					validatedValue = super.validateDefault(key, value);
+					break;
+			}
+
+			return validatedValue;
+		}
+	}
+}

--- a/src/scripts/OutSystems/OSUI/ErrorCodes.ts
+++ b/src/scripts/OutSystems/OSUI/ErrorCodes.ts
@@ -295,6 +295,12 @@ namespace OutSystems.OSUI.ErrorCodes {
 		FailCheckIsRTL: 'OSUI-API-28026',
 	};
 
+	export const InlineSvg = {
+		FailChangeProperty: 'OSUI-API-29001',
+		FailDispose: 'OSUI-API-29002',
+		FailRegisterCallback: 'OSUI-API-29003',
+	};
+
 	// Error Codes used in Legacy Client Action
 	export const Legacy = {
 		FailAddFavicon_Legacy: 'OSUI-LEG-000001',

--- a/src/scripts/OutSystems/OSUI/Patterns/InlineSvgAPI.ts
+++ b/src/scripts/OutSystems/OSUI/Patterns/InlineSvgAPI.ts
@@ -1,0 +1,132 @@
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+namespace OutSystems.OSUI.Patterns.InlineSvgAPI {
+	const _inlineSvgMap = new Map<string, OSFramework.OSUI.Patterns.InlineSvg.IInlineSvg>();
+	/**
+	 * Function that will change the property of a given InlineSvg.
+	 *
+	 * @export
+	 * @param {string} inlineSvgId
+	 * @param {string} propertyName
+	 * @param {*} propertyValue
+	 */
+	// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any
+	export function ChangeProperty(inlineSvgId: string, propertyName: string, propertyValue: any): string {
+		const result = OutSystems.OSUI.Utils.CreateApiResponse({
+			errorCode: ErrorCodes.InlineSvg.FailChangeProperty,
+			callback: () => {
+				const inlineSvg = GetInlineSvgById(inlineSvgId);
+
+				inlineSvg.changeProperty(propertyName, propertyValue);
+			},
+		});
+
+		return result;
+	}
+
+	/**
+	 * Create the new InlineSvg instance and add it to the InlineSvgsMap
+	 *
+	 * @export
+	 * @param {string} inlineSvgId
+	 * @param {string} configs
+	 * @return {*}  {OSFramework.OSUI.Patterns.InlineSvg.IInlineSvg}
+	 */
+	export function Create(inlineSvgId: string, configs: string): OSFramework.OSUI.Patterns.InlineSvg.IInlineSvg {
+		if (_inlineSvgMap.has(inlineSvgId)) {
+			throw new Error(
+				`There is already a ${OSFramework.OSUI.GlobalEnum.PatternName.InlineSvg} registered under id: ${inlineSvgId}`
+			);
+		}
+
+		const _newInlineSvg = new OSFramework.OSUI.Patterns.InlineSvg.InlineSvg(inlineSvgId, JSON.parse(configs));
+		_inlineSvgMap.set(inlineSvgId, _newInlineSvg);
+		return _newInlineSvg;
+	}
+
+	/**
+	 * Function that will destroy the instance of the given InlineSvg
+	 *
+	 * @export
+	 * @param {string} inlineSvgId
+	 */
+	export function Dispose(inlineSvgId: string): string {
+		const result = OutSystems.OSUI.Utils.CreateApiResponse({
+			errorCode: ErrorCodes.InlineSvg.FailDispose,
+			callback: () => {
+				const inlineSvg = GetInlineSvgById(inlineSvgId);
+
+				inlineSvg.dispose();
+
+				_inlineSvgMap.delete(inlineSvgId);
+			},
+		});
+
+		return result;
+	}
+
+	/**
+	 * Fucntion that will return the Map with all the InlineSvg instances at the page
+	 *
+	 * @export
+	 * @return {*}  {Array<string>}
+	 */
+	export function GetAllInlineSvgs(): Array<string> {
+		return OSFramework.OSUI.Helper.MapOperation.ExportKeys(_inlineSvgMap);
+	}
+
+	/**
+	 * Function that gets the instance of InlineSvg, by a given ID.
+	 *
+	 * @export
+	 * @param {string} inlineSvgId
+	 * @return {*}  {OSFramework.OSUI.Patterns.InlineSvg.IInlineSvg}
+	 */
+	export function GetInlineSvgById(inlineSvgId: string): OSFramework.OSUI.Patterns.InlineSvg.IInlineSvg {
+		return OSFramework.OSUI.Helper.MapOperation.FindInMap(
+			'InlineSvg',
+			inlineSvgId,
+			_inlineSvgMap
+		) as OSFramework.OSUI.Patterns.InlineSvg.IInlineSvg;
+	}
+
+	/**
+	 * Function that will initialize the pattern instance.
+	 *
+	 * @export
+	 * @param {string} inlineSvgId
+	 * @return {*}  {OSFramework.OSUI.Patterns.InlineSvg.IInlineSvg}
+	 */
+	export function Initialize(inlineSvgId: string): OSFramework.OSUI.Patterns.InlineSvg.IInlineSvg {
+		const inlineSvg = GetInlineSvgById(inlineSvgId);
+
+		inlineSvg.build();
+
+		return inlineSvg;
+	}
+
+	/**
+	 * Function to register a provider callback
+	 *
+	 * @export
+	 * @param {string} inlineSvgId
+	 * @param {string} eventName
+	 * @param {OSFramework.OSUI.GlobalCallbacks.OSGeneric} callback
+	 * @return {*} {string} Return Message Success or message of error info if it's the case.
+	 */
+	export function RegisterCallback(
+		inlineSvgId: string,
+		eventName: string,
+		callback: OSFramework.OSUI.GlobalCallbacks.OSGeneric
+	): string {
+		const result = OutSystems.OSUI.Utils.CreateApiResponse({
+			errorCode: ErrorCodes.InlineSvg.FailRegisterCallback,
+			callback: () => {
+				const _InlineSvgItem = this.GetInlineSvgById(inlineSvgId);
+
+				_InlineSvgItem.registerCallback(eventName, callback);
+			},
+		});
+
+		return result;
+	}
+}

--- a/src/scripts/OutSystems/OSUI/Patterns/InlineSvgAPI.ts
+++ b/src/scripts/OutSystems/OSUI/Patterns/InlineSvgAPI.ts
@@ -123,7 +123,7 @@ namespace OutSystems.OSUI.Patterns.InlineSvgAPI {
 			callback: () => {
 				const _InlineSvgItem = this.GetInlineSvgById(inlineSvgId);
 
-				_InlineSvgItem.registerCallback(eventName, callback);
+				_InlineSvgItem.registerCallback(callback, eventName);
 			},
 		});
 


### PR DESCRIPTION
This PR is for implement the new InlineSVG

### What was done
- Created the OSFramework.OSUI.Patterns.InlineSvg.InlineSvg
   - Now the Initialized event should be triggered after component's build.
   - Now the SVGCode in validated before assign it to the config.
- Created the OSFramework.OSUI.Patterns.InlineSvg.InlineSvgConfig
- Created the OSFramework.OSUI.Helper.SVG that contains the isValid method to validate the SVGCode.
- Created the OutSystems.OSUI.Patterns.InlineSvgAPI
- Added the necessary interfaces and errorCodes.

### Checklist

-   [x] tested locally
-   [x] documented the code
-   [x] clean all warnings and errors of eslint
-   [x] requires changes in OutSystems (if so, provide a module with changes)
-   [ ] requires new sample page in OutSystems (if so, provide a module with changes)
