### PR TITLE
[ROU-3656 V3] - Add Initialized event to all new components - P2

### DIFF
--- a/src/scripts/OSFramework/OSUI/Pattern/AbstractPattern.ts
+++ b/src/scripts/OSFramework/OSUI/Pattern/AbstractPattern.ts
@@ -23,7 +23,7 @@ namespace OSFramework.OSUI.Patterns {
 		// Id of the widget. This will be the Id that the developer will be using in runtime.
 		private _widgetId: string;
 		// Flag to help on check if a pattern has a provider.
-		protected _isProviderBased = false;
+		protected isProviderBased = false;
 
 		/**
 		 * Creates an instance of AbstractPattern.
@@ -63,7 +63,7 @@ namespace OSFramework.OSUI.Patterns {
 
 			// Check if this is a provider based pattern, If true Initialization cb Event will be triggered at the new provider instance creation.
 			// For non provider based patterns this should be triggered here.
-			if (this._isProviderBased === false) {
+			if (this.isProviderBased === false) {
 				// Trigger the Initialized Callback Event
 				this.triggerPlatformInitializedEventCallback();
 			}

--- a/src/scripts/OSFramework/OSUI/Pattern/AbstractProviderPattern.ts
+++ b/src/scripts/OSFramework/OSUI/Pattern/AbstractProviderPattern.ts
@@ -16,9 +16,9 @@ namespace OSFramework.OSUI.Patterns {
 		// Holds the callback for the provider config applied event
 		private _platformEventProviderConfigsAppliedCallback: GlobalCallbacks.OSGeneric;
 		// Holds the provider
-		protected _provider: P;
+		private _provider: P;
 		// Holds the provider info
-		protected _providerInfo: ProviderInfo;
+		private _providerInfo: ProviderInfo;
 		// Holds the providerEvents instance, that manages the provider events
 		protected providerEventsManagerInstance: Event.ProviderEvents.IProviderEventManager;
 
@@ -32,7 +32,7 @@ namespace OSFramework.OSUI.Patterns {
 		constructor(uniqueId: string, configs: C) {
 			super(uniqueId, configs);
 
-			this._isProviderBased = true;
+			this.isProviderBased = true;
 		}
 
 		// Method to get an event index from an array

--- a/src/scripts/OSFramework/OSUI/Pattern/Dropdown/ServerSide/DropdownServerSide.ts
+++ b/src/scripts/OSFramework/OSUI/Pattern/Dropdown/ServerSide/DropdownServerSide.ts
@@ -814,6 +814,9 @@ namespace OSFramework.OSUI.Patterns.Dropdown.ServerSide {
 				} else {
 					this._balloonOptionsWrapperElement.focus();
 				}
+
+				// Trigger the toggle callback event
+				this._triggerToogleCalbackEvent();
 			} else {
 				// Remove IsOpend Class => Close it!
 				Helper.Dom.Styles.RemoveClass(this.selfElement, Enum.CssClass.IsOpened);
@@ -828,9 +831,6 @@ namespace OSFramework.OSUI.Patterns.Dropdown.ServerSide {
 					this._eventOnCloseTransitionEnd
 				);
 			}
-
-			// Trigger the toggle callback event
-			this._triggerToogleCalbackEvent();
 		}
 
 		/**

--- a/src/scripts/OSFramework/OSUI/Pattern/DropdownServerSideItem/DropdownServerSideItem.ts
+++ b/src/scripts/OSFramework/OSUI/Pattern/DropdownServerSideItem/DropdownServerSideItem.ts
@@ -243,7 +243,7 @@ namespace OSFramework.OSUI.Patterns.DropdownServerSideItem {
 					}
 					break;
 				default:
-					throw new Error(`The given '${eventName}' event name it's not defined.`);
+					super.registerCallback(eventName, callback);
 			}
 		}
 

--- a/src/scripts/Providers/OSUI/Carousel/Splide/Splide.ts
+++ b/src/scripts/Providers/OSUI/Carousel/Splide/Splide.ts
@@ -51,7 +51,7 @@ namespace Providers.OSUI.Carousel.Splide {
 		// Method to init the provider
 		private _initProvider(): void {
 			// Init provider
-			this._provider = new window.Splide(this._carouselProviderElem, this._splideOptions);
+			this.provider = new window.Splide(this._carouselProviderElem, this._splideOptions);
 
 			// Set provider Info to be used by setProviderConfigs API calls
 			this.updateProviderEvents({
@@ -70,7 +70,7 @@ namespace Providers.OSUI.Carousel.Splide {
 			this._setCarouselWidth();
 
 			// Init the provider
-			this._provider.mount();
+			this.provider.mount();
 
 			// Update pagination class, in case navigation was changed
 			this._togglePaginationClass();
@@ -112,14 +112,14 @@ namespace Providers.OSUI.Carousel.Splide {
 
 		// Method to set the OnInitializeEvent
 		private _setOnInitializedEvent(): void {
-			this._provider.on(Enum.SpliderEvents.Mounted, () => {
+			this.provider.on(Enum.SpliderEvents.Mounted, () => {
 				this.triggerPlatformInitializedEventCallback();
 			});
 		}
 
 		// Method to set the OnSlideMoved event
 		private _setOnSlideMovedEvent(): void {
-			this._provider.on(Enum.SpliderEvents.Moved, (index) => {
+			this.provider.on(Enum.SpliderEvents.Moved, (index) => {
 				if (index !== this._currentIndex) {
 					this.triggerPlatformEventCallback(this._platformEventOnSlideMoved, index);
 					this._currentIndex = index;
@@ -304,13 +304,13 @@ namespace Providers.OSUI.Carousel.Splide {
 						this.redraw();
 						break;
 					case OSFramework.OSUI.Patterns.Carousel.Enum.Properties.Height:
-						this._provider.options = { height: propertyValue as string | number };
+						this.provider.options = { height: propertyValue as string | number };
 						break;
 					case OSFramework.OSUI.Patterns.Carousel.Enum.Properties.Padding:
-						this._provider.options = { padding: propertyValue as string | number };
+						this.provider.options = { padding: propertyValue as string | number };
 						break;
 					case OSFramework.OSUI.Patterns.Carousel.Enum.Properties.ItemsGap:
-						this._provider.options = { gap: propertyValue as string | number };
+						this.provider.options = { gap: propertyValue as string | number };
 						break;
 				}
 			}
@@ -327,7 +327,7 @@ namespace Providers.OSUI.Carousel.Splide {
 		public dispose(): void {
 			// Check if provider is ready
 			if (this.isBuilt) {
-				this._provider.destroy();
+				this.provider.destroy();
 			}
 
 			this.unsetCallbacks();
@@ -343,7 +343,7 @@ namespace Providers.OSUI.Carousel.Splide {
 		 * @memberof Providers.OSUI.Carousel.Splide.OSUISplide
 		 */
 		public goTo(index: number): void {
-			this._provider.go(index);
+			this.provider.go(index);
 		}
 
 		/**
@@ -352,7 +352,7 @@ namespace Providers.OSUI.Carousel.Splide {
 		 * @memberof Providers.OSUI.Carousel.Splide.OSUISplide
 		 */
 		public next(): void {
-			this._provider.go(Enum.Go.Next);
+			this.provider.go(Enum.Go.Next);
 		}
 
 		/**
@@ -361,7 +361,7 @@ namespace Providers.OSUI.Carousel.Splide {
 		 * @memberof Providers.OSUI.Carousel.Splide.OSUISplide
 		 */
 		public previous(): void {
-			this._provider.go(Enum.Go.Previous);
+			this.provider.go(Enum.Go.Previous);
 		}
 
 		/**
@@ -419,7 +419,7 @@ namespace Providers.OSUI.Carousel.Splide {
 		 * @memberof Providers.OSUI.Carousel.Splide.OSUISplide
 		 */
 		public toggleDrag(hasDrag: boolean): void {
-			this._provider.options = { drag: hasDrag };
+			this.provider.options = { drag: hasDrag };
 		}
 
 		/**
@@ -442,7 +442,7 @@ namespace Providers.OSUI.Carousel.Splide {
 				this.setInitialCssClasses();
 
 				// Check if provider is ready
-				if (typeof this._provider === 'object') {
+				if (typeof this.provider === 'object') {
 					// Keep same position after update
 					// Check autoplay config, as that triggers the provider onChange and our onRender event, but doesn't udpate the _currentIndex property.
 					if (this._currentIndex !== undefined || this.configs.AutoPlay === true) {

--- a/src/scripts/Providers/OSUI/Carousel/Splide/SplideConfig.ts
+++ b/src/scripts/Providers/OSUI/Carousel/Splide/SplideConfig.ts
@@ -1,10 +1,10 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
 namespace Providers.OSUI.Carousel.Splide {
 	export class SplideConfig extends OSFramework.OSUI.Patterns.Carousel.AbstractCarouselConfig {
+		// Store configs set using extensibility
+		private _providerExtendedOptions: SplideOpts;
 		// Store provider configs
 		private _providerOptions: SplideOpts;
-		// Store configs set using extensibility
-		protected _providerExtendedOptions: SplideOpts;
 
 		// Prepare Arrows expected config
 		private _getArrowConfig(): boolean {

--- a/src/scripts/Providers/OSUI/Datepicker/Flatpickr/AbstractFlatpickr.ts
+++ b/src/scripts/Providers/OSUI/Datepicker/Flatpickr/AbstractFlatpickr.ts
@@ -11,13 +11,13 @@ namespace Providers.OSUI.Datepicker.Flatpickr {
 		// Validation of ZIndex position common behavior
 		private _zindexCommonBehavior: SharedProviderResources.Flatpickr.UpdateZindex;
 		// Store pattern input HTML element reference
-		protected _datePickerPlatformInputElem: HTMLInputElement;
+		protected datePickerPlatformInputElem: HTMLInputElement;
 		// Store the flatpickr input html element that will be added by library
-		protected _flatpickrInputElem: HTMLInputElement;
+		protected flatpickrInputElem: HTMLInputElement;
 		// Store the provider options
-		protected _flatpickrOpts: FlatpickrOptions;
+		protected flatpickrOpts: FlatpickrOptions;
 		// Flatpickr onChange (SelectedDate) event
-		protected _onSelectedCallbackEvent: OSFramework.OSUI.Patterns.DatePicker.Callbacks.OSOnChangeEvent;
+		protected onSelectedCallbackEvent: OSFramework.OSUI.Patterns.DatePicker.Callbacks.OSOnChangeEvent;
 
 		constructor(uniqueId: string, configs: C) {
 			super(uniqueId, configs);
@@ -29,20 +29,20 @@ namespace Providers.OSUI.Datepicker.Flatpickr {
 		// Method used to set the needed HTML attributes
 		private _setAttributes(): void {
 			// Since a new input will be added by the flatpickr library, we must address it only at onReady
-			if (this._datePickerPlatformInputElem.nextSibling) {
-				this._flatpickrInputElem = this._datePickerPlatformInputElem.nextSibling as HTMLInputElement;
+			if (this.datePickerPlatformInputElem.nextSibling) {
+				this.flatpickrInputElem = this.datePickerPlatformInputElem.nextSibling as HTMLInputElement;
 
 				// Added the data-input attribute in order to input be styled as all platform inputs
 				OSFramework.OSUI.Helper.Dom.Attribute.Set(
-					this._flatpickrInputElem,
+					this.flatpickrInputElem,
 					OSFramework.OSUI.GlobalEnum.HTMLAttributes.DataInput,
 					''
 				);
 
 				// If the provider cloned a disabled platform input, remove the disable attribute form the provider input
-				if (this._flatpickrInputElem.disabled) {
+				if (this.flatpickrInputElem.disabled) {
 					OSFramework.OSUI.Helper.Dom.Attribute.Remove(
-						this._flatpickrInputElem,
+						this.flatpickrInputElem,
 						OSFramework.OSUI.GlobalEnum.HTMLAttributes.Disabled
 					);
 				}
@@ -114,7 +114,7 @@ namespace Providers.OSUI.Datepicker.Flatpickr {
 		 */
 		protected createProviderInstance(): void {
 			// Init provider
-			this.provider = window.flatpickr(this._datePickerPlatformInputElem, this._flatpickrOpts);
+			this.provider = window.flatpickr(this.datePickerPlatformInputElem, this.flatpickrOpts);
 
 			// Set provider Info to be used by setProviderConfigs API calls
 			this.updateProviderEvents({
@@ -158,9 +158,9 @@ namespace Providers.OSUI.Datepicker.Flatpickr {
 			}
 
 			// Due to platform validations every time a new redraw occurs we must ensure we remove the class based on a clone from the platform input!
-			if (this._flatpickrInputElem !== undefined && this.isBuilt) {
+			if (this.flatpickrInputElem !== undefined && this.isBuilt) {
 				OSFramework.OSUI.Helper.Dom.Styles.RemoveClass(
-					this._flatpickrInputElem,
+					this.flatpickrInputElem,
 					OSFramework.OSUI.GlobalEnum.CssClassElements.InputNotValid
 				);
 			}
@@ -195,7 +195,7 @@ namespace Providers.OSUI.Datepicker.Flatpickr {
 		 */
 		protected prepareConfigs(): void {
 			// Get the library configurations
-			this._flatpickrOpts = this.configs.getProviderConfig();
+			this.flatpickrOpts = this.configs.getProviderConfig();
 
 			// Instance will be Created!
 			this.createProviderInstance();
@@ -220,23 +220,23 @@ namespace Providers.OSUI.Datepicker.Flatpickr {
 		 */
 		protected setA11YProperties(): void {
 			// Since native behaviour could be enabled, check if the calendar container exist!
-			if (this.provider.calendarContainer !== undefined && this._flatpickrInputElem !== undefined) {
+			if (this.provider.calendarContainer !== undefined && this.flatpickrInputElem !== undefined) {
 				// Set the default aria-label value attribute in case user didn't set it!
 				let ariaLabelValue = Enum.Attribute.DefaultAriaLabel as string;
 
 				// Check if aria-label attribute has been added to the default input
 				if (
-					this._datePickerPlatformInputElem.hasAttribute(OSFramework.OSUI.Constants.A11YAttributes.Aria.Label)
+					this.datePickerPlatformInputElem.hasAttribute(OSFramework.OSUI.Constants.A11YAttributes.Aria.Label)
 				) {
-					ariaLabelValue = this._datePickerPlatformInputElem.getAttribute(
+					ariaLabelValue = this.datePickerPlatformInputElem.getAttribute(
 						OSFramework.OSUI.Constants.A11YAttributes.Aria.Label
 					);
 				}
 
 				// Set the aria-label attribute value
-				OSFramework.OSUI.Helper.A11Y.AriaLabel(this._flatpickrInputElem, ariaLabelValue);
+				OSFramework.OSUI.Helper.A11Y.AriaLabel(this.flatpickrInputElem, ariaLabelValue);
 				// Set the aria-describedby attribute in order to give more context about how to navigate into calendar using keyboard
-				OSFramework.OSUI.Helper.A11Y.AriaDescribedBy(this._flatpickrInputElem, this._a11yInfoContainerElem.id);
+				OSFramework.OSUI.Helper.A11Y.AriaDescribedBy(this.flatpickrInputElem, this._a11yInfoContainerElem.id);
 				// Check if lang is not EN (default one)
 				if (this.configs.Lang !== OSFramework.OSUI.Constants.Language.short) {
 					// Update A11yContainer info based on the given language
@@ -264,7 +264,7 @@ namespace Providers.OSUI.Datepicker.Flatpickr {
 		 */
 		protected setHtmlElements(): void {
 			// Set the inputHTML element
-			this._datePickerPlatformInputElem = this.selfElement.querySelector('input.form-control');
+			this.datePickerPlatformInputElem = this.selfElement.querySelector('input.form-control');
 			// Store the reference to the info container about how to use keyboard to navigate through calendar
 			this._a11yInfoContainerElem = OSFramework.OSUI.Helper.Dom.TagSelector(
 				this.selfElement.parentElement,
@@ -272,7 +272,7 @@ namespace Providers.OSUI.Datepicker.Flatpickr {
 			);
 
 			// If the input hasn't be added
-			if (!this._datePickerPlatformInputElem) {
+			if (!this.datePickerPlatformInputElem) {
 				throw new Error(`The datepicker input at DatepickerId '${this.widgetId}' is missing`);
 			}
 		}
@@ -285,7 +285,7 @@ namespace Providers.OSUI.Datepicker.Flatpickr {
 		 */
 		protected unsetCallbacks(): void {
 			this.configs.OnChange = undefined;
-			this._onSelectedCallbackEvent = undefined;
+			this.onSelectedCallbackEvent = undefined;
 
 			super.unsetCallbacks();
 		}
@@ -298,7 +298,7 @@ namespace Providers.OSUI.Datepicker.Flatpickr {
 		 */
 		protected unsetHtmlElements(): void {
 			this._a11yInfoContainerElem = undefined;
-			this._datePickerPlatformInputElem = undefined;
+			this.datePickerPlatformInputElem = undefined;
 		}
 
 		/**
@@ -353,7 +353,7 @@ namespace Providers.OSUI.Datepicker.Flatpickr {
 		 * @memberof Providers.OSUI.DatePicker.Flatpickr.AbstractFlatpickr
 		 */
 		public clear(): void {
-			const isInputDisable = this._datePickerPlatformInputElem.disabled;
+			const isInputDisable = this.datePickerPlatformInputElem.disabled;
 			if (isInputDisable === false) {
 				this.provider.clear();
 			}
@@ -421,7 +421,7 @@ namespace Providers.OSUI.Datepicker.Flatpickr {
 		 * @memberof Providers.OSUI.DatePicker.Flatpickr.AbstractFlatpickr
 		 */
 		public open(): void {
-			const isInputDisable = this._datePickerPlatformInputElem.disabled;
+			const isInputDisable = this.datePickerPlatformInputElem.disabled;
 			if (this.provider.isOpen === false && isInputDisable === false) {
 				this.provider.open();
 			}
@@ -435,7 +435,7 @@ namespace Providers.OSUI.Datepicker.Flatpickr {
 		public registerCallback(eventName: string, callback: OSFramework.OSUI.GlobalCallbacks.OSGeneric): void {
 			switch (eventName) {
 				case OSFramework.OSUI.Patterns.DatePicker.Enum.DatePickerEvents.OnChange:
-					this._onSelectedCallbackEvent = callback;
+					this.onSelectedCallbackEvent = callback;
 					break;
 
 				default:
@@ -503,7 +503,7 @@ namespace Providers.OSUI.Datepicker.Flatpickr {
 		 * @memberof Providers.OSUI.DatePicker.Flatpickr.AbstractFlatpickr
 		 */
 		public updatePrompt(promptMessage: string): void {
-			this._flatpickrInputElem.placeholder = promptMessage;
+			this.flatpickrInputElem.placeholder = promptMessage;
 		}
 
 		// Common methods all DatePickers must implement

--- a/src/scripts/Providers/OSUI/Datepicker/Flatpickr/AbstractFlatpickrConfig.ts
+++ b/src/scripts/Providers/OSUI/Datepicker/Flatpickr/AbstractFlatpickrConfig.ts
@@ -25,7 +25,7 @@ namespace Providers.OSUI.Datepicker.Flatpickr {
 		private _providerOptions: FlatpickrOptions;
 
 		// Store configs set using extensibility
-		protected _providerExtendedOptions: FlatpickrOptions;
+		protected providerExtendedOptions: FlatpickrOptions;
 
 		// Stores the ability to allow inputs to be editable or not
 		public AllowInput = false;
@@ -219,7 +219,7 @@ namespace Providers.OSUI.Datepicker.Flatpickr {
 		 * @memberof Providers.OSUI.DatePicker.Flatpickr.AbstractFlatpickrConfig
 		 */
 		public setExtensibilityConfigs(newConfigs: FlatpickrOptions): void {
-			this._providerExtendedOptions = newConfigs;
+			this.providerExtendedOptions = newConfigs;
 		}
 
 		/**

--- a/src/scripts/Providers/OSUI/Datepicker/Flatpickr/RangeDate/FlatpickrRangeDate.ts
+++ b/src/scripts/Providers/OSUI/Datepicker/Flatpickr/RangeDate/FlatpickrRangeDate.ts
@@ -15,14 +15,14 @@ namespace Providers.OSUI.Datepicker.Flatpickr.RangeDate {
 				// Set the new Start DefaultDate value
 				this.configs.InitialStartDate = this.provider.formatDate(
 					this.provider.selectedDates[0],
-					this._flatpickrOpts.dateFormat
+					this.flatpickrOpts.dateFormat
 				);
 
 				// Set the new End DefaultDate value
 				if (this.provider.selectedDates[1]) {
 					this.configs.InitialEndDate = this.provider.formatDate(
 						this.provider.selectedDates[1],
-						this._flatpickrOpts.dateFormat
+						this.flatpickrOpts.dateFormat
 					);
 				}
 			}
@@ -70,23 +70,20 @@ namespace Providers.OSUI.Datepicker.Flatpickr.RangeDate {
 
 			// Check if any date has been selected, In case of Clear this will retunr empty array
 			if (selectedDates.length > 0) {
-				_selectedDate[0] = this.provider.formatDate(selectedDates[0], this._flatpickrOpts.dateFormat);
+				_selectedDate[0] = this.provider.formatDate(selectedDates[0], this.flatpickrOpts.dateFormat);
 				if (selectedDates[1]) {
-					_selectedDate[1] = this.provider.formatDate(selectedDates[1], this._flatpickrOpts.dateFormat);
+					_selectedDate[1] = this.provider.formatDate(selectedDates[1], this.flatpickrOpts.dateFormat);
 				}
 			}
 
 			// Trigger the platform update attribute value based on the flatpicker text input value!
 			// This can be done on this context since on this case the "hidden" input should be text type!
-			OSFramework.OSUI.Helper.Dom.SetInputValue(
-				this._datePickerPlatformInputElem,
-				this._flatpickrInputElem.value
-			);
+			OSFramework.OSUI.Helper.Dom.SetInputValue(this.datePickerPlatformInputElem, this.flatpickrInputElem.value);
 
 			// Ensure user has selected start and end dates before trigger the onSelectedDate callback, or user has clean the seelcted dates!
 			if (selectedDates.length === 0 || selectedDates.length === 2) {
 				// Trigger platform's onChange callback event
-				this.triggerPlatformEventCallback(this._onSelectedCallbackEvent, _selectedDate[0], _selectedDate[1]);
+				this.triggerPlatformEventCallback(this.onSelectedCallbackEvent, _selectedDate[0], _selectedDate[1]);
 			}
 		}
 
@@ -112,7 +109,7 @@ namespace Providers.OSUI.Datepicker.Flatpickr.RangeDate {
 			// Set the type attribute value
 			// This is needed once library set it as an hidden by default which can not be since otherwise the updating it's value will not be triggered the local variable update. That said it will be hidden through CSS!
 			OSFramework.OSUI.Helper.Dom.Attribute.Set(
-				this._datePickerPlatformInputElem,
+				this.datePickerPlatformInputElem,
 				OSFramework.OSUI.GlobalEnum.HTMLAttributes.type,
 				OSFramework.OSUI.GlobalEnum.InputTypeAttr.Text
 			);
@@ -165,7 +162,7 @@ namespace Providers.OSUI.Datepicker.Flatpickr.RangeDate {
 			if (
 				OSFramework.OSUI.Helper.Dates.IsNull(startDate) === false &&
 				OSFramework.OSUI.Helper.Dates.IsNull(endDate) === false &&
-				this._datePickerPlatformInputElem.disabled === false
+				this.datePickerPlatformInputElem.disabled === false
 			) {
 				// Redefine the Initial dates
 				this.configs.InitialStartDate = startDate;

--- a/src/scripts/Providers/OSUI/Datepicker/Flatpickr/RangeDate/FlatpickrRangeDateConfig.ts
+++ b/src/scripts/Providers/OSUI/Datepicker/Flatpickr/RangeDate/FlatpickrRangeDateConfig.ts
@@ -56,7 +56,7 @@ namespace Providers.OSUI.Datepicker.Flatpickr.RangeDate {
 				mode: OSFramework.OSUI.Patterns.DatePicker.Enum.Mode.Range,
 			};
 
-			return this.mergeConfigs(super.getProviderConfig(), flatpickrRangeDateOpts, this._providerExtendedOptions);
+			return this.mergeConfigs(super.getProviderConfig(), flatpickrRangeDateOpts, this.providerExtendedOptions);
 		}
 	}
 }

--- a/src/scripts/Providers/OSUI/Datepicker/Flatpickr/SingleDate/FlatpickrSingleDate.ts
+++ b/src/scripts/Providers/OSUI/Datepicker/Flatpickr/SingleDate/FlatpickrSingleDate.ts
@@ -24,16 +24,16 @@ namespace Providers.OSUI.Datepicker.Flatpickr.SingleDate {
 
 			// Check if any date has been selected, In case of Clear this will retunr empty array
 			if (selectedDates.length > 0) {
-				_selectedDate = this.provider.formatDate(selectedDates[0], this._flatpickrOpts.dateFormat);
+				_selectedDate = this.provider.formatDate(selectedDates[0], this.flatpickrOpts.dateFormat);
 			}
 
 			// Trigger the platform update attribute value change!
-			OSFramework.OSUI.Helper.Dom.SetInputValue(this._datePickerPlatformInputElem, _selectedDate);
+			OSFramework.OSUI.Helper.Dom.SetInputValue(this.datePickerPlatformInputElem, _selectedDate);
 
 			// Check if values are not beeing updated by UpdateInitialDate API Method!
 			if (this._isUpdatedInitialDateByClientAction === false) {
 				// Trigger platform's onChange callback event
-				this.triggerPlatformEventCallback(this._onSelectedCallbackEvent, _selectedDate);
+				this.triggerPlatformEventCallback(this.onSelectedCallbackEvent, _selectedDate);
 			}
 
 			// Reset Flag value;
@@ -83,7 +83,7 @@ namespace Providers.OSUI.Datepicker.Flatpickr.SingleDate {
 			// Set the type attribute value
 			// This is needed once library set it as an hidden by default which can not be since otherwise the updating it's value will not be triggered the local variable update. That said it will be hidden through CSS!
 			OSFramework.OSUI.Helper.Dom.Attribute.Set(
-				this._datePickerPlatformInputElem,
+				this.datePickerPlatformInputElem,
 				OSFramework.OSUI.GlobalEnum.HTMLAttributes.type,
 				dateType
 			);
@@ -139,7 +139,7 @@ namespace Providers.OSUI.Datepicker.Flatpickr.SingleDate {
 							// Set the new DefaultDate values
 							this.configs.InitialDate = this.provider.formatDate(
 								this.provider.selectedDates[0],
-								this._flatpickrOpts.dateFormat
+								this.flatpickrOpts.dateFormat
 							);
 						}
 						this.prepareToAndRedraw();
@@ -165,15 +165,15 @@ namespace Providers.OSUI.Datepicker.Flatpickr.SingleDate {
 		 * @memberof Providers.OSUI.DatePicker.Flatpickr.SingleDate.OSUIFlatpickrSingleDate
 		 */
 		public updateInitialDate(value: string): void {
-			if (this._datePickerPlatformInputElem.disabled === false) {
+			if (this.datePickerPlatformInputElem.disabled === false) {
 				// Enable Flag in order to prevent trigger OnDateSelected platform callback event
 				this._isUpdatedInitialDateByClientAction = true;
 				// Redefine the Initial date
 				this.configs.InitialDate = value;
 				// Redefine the value that is assigned to the input, since pattern will be redrawed it will be based on that value as well
 				OSFramework.OSUI.Helper.Dom.SetInputValue(
-					this._datePickerPlatformInputElem,
-					this.provider.formatDate(value, this._flatpickrOpts.dateFormat)
+					this.datePickerPlatformInputElem,
+					this.provider.formatDate(value, this.flatpickrOpts.dateFormat)
 				);
 				// Redraw calendar!
 				this.prepareToAndRedraw();

--- a/src/scripts/Providers/OSUI/Datepicker/Flatpickr/SingleDate/FlatpickrSingleDateConfig.ts
+++ b/src/scripts/Providers/OSUI/Datepicker/Flatpickr/SingleDate/FlatpickrSingleDateConfig.ts
@@ -33,7 +33,7 @@ namespace Providers.OSUI.Datepicker.Flatpickr.SingleDate {
 				onChange: this.OnChange,
 			};
 
-			return this.mergeConfigs(super.getProviderConfig(), flatpickrSingleDateOpts, this._providerExtendedOptions);
+			return this.mergeConfigs(super.getProviderConfig(), flatpickrSingleDateOpts, this.providerExtendedOptions);
 		}
 	}
 }

--- a/src/scripts/Providers/OSUI/Dropdown/VirtualSelect/AbstractVirtualSelect.ts
+++ b/src/scripts/Providers/OSUI/Dropdown/VirtualSelect/AbstractVirtualSelect.ts
@@ -12,11 +12,11 @@ namespace Providers.OSUI.Dropdown.VirtualSelect {
 		private _platformEventSelectedOptCallback: OSFramework.OSUI.Patterns.Dropdown.Callbacks.OSOnSelectEvent;
 
 		// Store the hidden input AriaLabel value
-		protected _hiddenInputWrapperAriaLabelVal: string;
+		protected hiddenInputWrapperAriaLabelVal: string;
 		// Store a reference of available provider methods
-		protected _virtualselectConfigs: VirtualSelectMethods;
+		protected virtualselectConfigs: VirtualSelectMethods;
 		// Store the provider options
-		protected _virtualselectOpts: VirtualSelectOpts;
+		protected virtualselectOpts: VirtualSelectOpts;
 
 		constructor(uniqueId: string, configs: C) {
 			super(uniqueId, configs);
@@ -52,7 +52,7 @@ namespace Providers.OSUI.Dropdown.VirtualSelect {
 		// Manage the disable status of the pattern
 		private _manageDisableStatus(): void {
 			// Ensure that is closed!
-			this._virtualselectConfigs.close();
+			this.virtualselectConfigs.close();
 
 			if (this.configs.IsDisabled) {
 				OSFramework.OSUI.Helper.Dom.Attribute.Set(
@@ -82,7 +82,7 @@ namespace Providers.OSUI.Dropdown.VirtualSelect {
 		// Close the dropdown if it's open!
 		private _onWindowResize() {
 			if (this.provider.isOpened()) {
-				this._virtualselectConfigs.close();
+				this.virtualselectConfigs.close();
 			}
 		}
 
@@ -130,13 +130,13 @@ namespace Providers.OSUI.Dropdown.VirtualSelect {
 		 */
 		protected createProviderInstance(): void {
 			// Create the provider instance
-			this.provider = window.VirtualSelect.init(this._virtualselectOpts);
+			this.provider = window.VirtualSelect.init(this.virtualselectOpts);
 
 			/* NOTE: When user change the URL and then click at browser back button we're getting an error. This happen because library (VS - VirtualSelect) creates a new instance of the same object and assign it into an array of VS objects that are in the same screen (in this case 2 equal VS objects since we're creating a new VS instance for each Dropdown), that said and in order to avoid this issue, we must follow this approach. 
 			Again, this only happens when user change directly the URL! */
 			this.provider = Array.isArray(this.provider) ? this.provider[0] : this.provider;
 
-			this._virtualselectConfigs = this.provider.$ele;
+			this.virtualselectConfigs = this.provider.$ele;
 			// Since at native devices we're detaching the balloon from pattern context we must set this attribute to it in order to be possible create a relation between pattern default structure and the detached balloon!
 			this.provider.$dropboxContainer.setAttribute(
 				OSFramework.OSUI.GlobalEnum.HTMLAttributes.Name,
@@ -147,7 +147,7 @@ namespace Providers.OSUI.Dropdown.VirtualSelect {
 			this.updateProviderEvents({
 				name: Enum.ProviderInfo.Name,
 				version: Enum.ProviderInfo.Version,
-				events: this._virtualselectConfigs,
+				events: this.virtualselectConfigs,
 			});
 
 			// Add attributes to the element if needed
@@ -219,8 +219,8 @@ namespace Providers.OSUI.Dropdown.VirtualSelect {
 		protected unsetCallbacks(): void {
 			this._eventOnWindowResize = undefined;
 			this._onSelectedOptionEvent = undefined;
-			this._virtualselectConfigs = undefined;
-			this._virtualselectOpts = undefined;
+			this.virtualselectConfigs = undefined;
+			this.virtualselectOpts = undefined;
 			this.provider = undefined;
 
 			super.unsetCallbacks();
@@ -309,7 +309,7 @@ namespace Providers.OSUI.Dropdown.VirtualSelect {
 		 * @memberof Providers.OSUI.Dropdown.VirtualSelect.AbstractVirtualSelect
 		 */
 		public clear(): void {
-			this._virtualselectConfigs.reset();
+			this.virtualselectConfigs.reset();
 		}
 
 		/**
@@ -319,7 +319,7 @@ namespace Providers.OSUI.Dropdown.VirtualSelect {
 		 */
 		public close(): void {
 			// SetTimeout is needed in order to ensure there is no conflit between OnClickBody and a button click that trigger this method.
-			OSFramework.OSUI.Helper.AsyncInvocation(this._virtualselectConfigs.close.bind(this._virtualselectConfigs));
+			OSFramework.OSUI.Helper.AsyncInvocation(this.virtualselectConfigs.close.bind(this.virtualselectConfigs));
 		}
 
 		/**
@@ -405,7 +405,7 @@ namespace Providers.OSUI.Dropdown.VirtualSelect {
 		 */
 		public open(): void {
 			// SetTimeout is needed in order to ensure there is no conflit between OnClickBody and a button click that trigger this method.
-			OSFramework.OSUI.Helper.AsyncInvocation(this._virtualselectConfigs.open.bind(this._virtualselectConfigs));
+			OSFramework.OSUI.Helper.AsyncInvocation(this.virtualselectConfigs.open.bind(this.virtualselectConfigs));
 		}
 
 		/**
@@ -436,9 +436,9 @@ namespace Providers.OSUI.Dropdown.VirtualSelect {
 		 * @memberof Providers.OSUI.Dropdown.VirtualSelect.AbstractVirtualSelect
 		 */
 		public setHiddenInputWrapperAriaLabelVal(value?: string): void {
-			this._hiddenInputWrapperAriaLabelVal = value === undefined ? this._hiddenInputWrapperAriaLabelVal : value;
+			this.hiddenInputWrapperAriaLabelVal = value === undefined ? this.hiddenInputWrapperAriaLabelVal : value;
 			// Set HiddenInput AriaLabel Value
-			OSFramework.OSUI.Helper.A11Y.AriaLabel(this.provider.$wrapper, this._hiddenInputWrapperAriaLabelVal);
+			OSFramework.OSUI.Helper.A11Y.AriaLabel(this.provider.$wrapper, this.hiddenInputWrapperAriaLabelVal);
 		}
 
 		/**
@@ -465,12 +465,12 @@ namespace Providers.OSUI.Dropdown.VirtualSelect {
 			let valuesToSelect = [];
 
 			if (optionsToSelect.length > 0) {
-				if (this._virtualselectOpts.multiple) valuesToSelect = optionsToSelect.map((option) => option.value);
+				if (this.virtualselectOpts.multiple) valuesToSelect = optionsToSelect.map((option) => option.value);
 				else valuesToSelect = [optionsToSelect[0].value];
 			}
 
 			if (valuesToSelect.sort().join(' ') !== selectedValues.sort().join(' '))
-				this._virtualselectConfigs.setValue(valuesToSelect, silentOnChangedEvent);
+				this.virtualselectConfigs.setValue(valuesToSelect, silentOnChangedEvent);
 		}
 
 		/**

--- a/src/scripts/Providers/OSUI/Dropdown/VirtualSelect/AbstractVirtualSelectConfig.ts
+++ b/src/scripts/Providers/OSUI/Dropdown/VirtualSelect/AbstractVirtualSelectConfig.ts
@@ -14,7 +14,7 @@ namespace Providers.OSUI.Dropdown.VirtualSelect {
 		// Store the Provider Options
 		private _providerOptions: VirtualSelectOpts;
 		// Store configs set using extensibility
-		protected _providerExtendedOptions: VirtualSelectOpts;
+		protected providerExtendedOptions: VirtualSelectOpts;
 		public ElementId: string;
 		public NoOptionsText: string;
 		public NoResultsText: string;
@@ -192,7 +192,7 @@ namespace Providers.OSUI.Dropdown.VirtualSelect {
 				search: true,
 				searchPlaceholderText: this.SearchPrompt,
 				selectAllOnlyVisible: true,
-				selectedValue: this._getSelectedValues() as [],
+				selectedValue: this.getSelectedValues() as [],
 				showDropboxAsPopup: this.ShowDropboxAsPopup,
 				silentInitialValueSet: true,
 				textDirection: OutSystems.OSUI.Utils.GetIsRTL()
@@ -218,7 +218,7 @@ namespace Providers.OSUI.Dropdown.VirtualSelect {
 					`The option description may be affected when modifying the property ${Enum.ExtendedConfigs.hasOptionDescription}.`
 				);
 
-			this._providerExtendedOptions = newConfigs;
+			this.providerExtendedOptions = newConfigs;
 		}
 
 		/**
@@ -247,6 +247,6 @@ namespace Providers.OSUI.Dropdown.VirtualSelect {
 		}
 
 		// Common methods all DropdownsConfigs must implement
-		protected abstract _getSelectedValues(): string[];
+		protected abstract getSelectedValues(): string[];
 	}
 }

--- a/src/scripts/Providers/OSUI/Dropdown/VirtualSelect/Search/VirtualSelectSearch.ts
+++ b/src/scripts/Providers/OSUI/Dropdown/VirtualSelect/Search/VirtualSelectSearch.ts
@@ -6,7 +6,7 @@ namespace Providers.OSUI.Dropdown.VirtualSelect.Search {
 			super(uniqueId, new VirtualSelectSearchConfig(configs));
 
 			// Set the AriaLabel text value for the hidden text input wrapper
-			this._hiddenInputWrapperAriaLabelVal = this.configs.AllowMultipleSelection
+			this.hiddenInputWrapperAriaLabelVal = this.configs.AllowMultipleSelection
 				? Dropdown.VirtualSelect.Enum.PropertiesValues.AriaLabelMultipleValue
 				: Dropdown.VirtualSelect.Enum.PropertiesValues.AriaLabelSingleValue;
 		}
@@ -24,12 +24,12 @@ namespace Providers.OSUI.Dropdown.VirtualSelect.Search {
 
 			// Check if it's multiple type
 			if (this.configs.AllowMultipleSelection) {
-				optionsSelected = this._virtualselectConfigs.getSelectedOptions(); // It returns an array of selected options
+				optionsSelected = this.virtualselectConfigs.getSelectedOptions(); // It returns an array of selected options
 			} else {
 				// It's single option type
 				// Check if there are any selected option
-				if (this._virtualselectConfigs.getSelectedOptions()) {
-					optionsSelected.push(this._virtualselectConfigs.getSelectedOptions()); // It returns an single object of selected option
+				if (this.virtualselectConfigs.getSelectedOptions()) {
+					optionsSelected.push(this.virtualselectConfigs.getSelectedOptions()); // It returns an single object of selected option
 				}
 			}
 
@@ -44,7 +44,7 @@ namespace Providers.OSUI.Dropdown.VirtualSelect.Search {
 		 */
 		protected prepareConfigs(): void {
 			// Get the library configurations
-			this._virtualselectOpts = this.configs.getProviderConfig();
+			this.virtualselectOpts = this.configs.getProviderConfig();
 
 			// Instance will be Created!
 			this.createProviderInstance();

--- a/src/scripts/Providers/OSUI/Dropdown/VirtualSelect/Search/VirtualSelectSearchConfig.ts
+++ b/src/scripts/Providers/OSUI/Dropdown/VirtualSelect/Search/VirtualSelectSearchConfig.ts
@@ -17,7 +17,7 @@ namespace Providers.OSUI.Dropdown.VirtualSelect.Search {
 		 * @return {*}  {string[]}
 		 * @memberof Providers.OSUI.Dropdown.VirtualSelect.Search.VirtualSelectSearchConfig
 		 */
-		protected _getSelectedValues(): string[] {
+		protected getSelectedValues(): string[] {
 			const selectedKeyvalues = [];
 
 			// Has selected values?
@@ -48,7 +48,7 @@ namespace Providers.OSUI.Dropdown.VirtualSelect.Search {
 				multiple: this.AllowMultipleSelection,
 			};
 
-			return this.mergeConfigs(super.getProviderConfig(), virtualSelectSearchOpts, this._providerExtendedOptions);
+			return this.mergeConfigs(super.getProviderConfig(), virtualSelectSearchOpts, this.providerExtendedOptions);
 		}
 
 		/**

--- a/src/scripts/Providers/OSUI/Dropdown/VirtualSelect/Tags/VirtualSelectTags.ts
+++ b/src/scripts/Providers/OSUI/Dropdown/VirtualSelect/Tags/VirtualSelectTags.ts
@@ -6,7 +6,7 @@ namespace Providers.OSUI.Dropdown.VirtualSelect.Tags {
 			super(uniqueId, new VirtualSelectTagsConfig(configs));
 
 			// Set the AriaLabel text value for the hidden text input wrapper
-			this._hiddenInputWrapperAriaLabelVal = Dropdown.VirtualSelect.Enum.PropertiesValues.AriaLabelMultipleValue;
+			this.hiddenInputWrapperAriaLabelVal = Dropdown.VirtualSelect.Enum.PropertiesValues.AriaLabelMultipleValue;
 		}
 
 		/**
@@ -18,7 +18,7 @@ namespace Providers.OSUI.Dropdown.VirtualSelect.Tags {
 		 */
 		protected getSelectedOptionsStructure(): DropDownOption[] {
 			// Store the options selected
-			const optionsSelected = this._virtualselectConfigs.getSelectedOptions();
+			const optionsSelected = this.virtualselectConfigs.getSelectedOptions();
 
 			return optionsSelected;
 		}
@@ -31,7 +31,7 @@ namespace Providers.OSUI.Dropdown.VirtualSelect.Tags {
 		 */
 		protected prepareConfigs(): void {
 			// Get the library configurations
-			this._virtualselectOpts = this.configs.getProviderConfig();
+			this.virtualselectOpts = this.configs.getProviderConfig();
 
 			// Instance will be Created!
 			this.createProviderInstance();

--- a/src/scripts/Providers/OSUI/Dropdown/VirtualSelect/Tags/VirtualSelectTagsConfig.ts
+++ b/src/scripts/Providers/OSUI/Dropdown/VirtualSelect/Tags/VirtualSelectTagsConfig.ts
@@ -15,7 +15,7 @@ namespace Providers.OSUI.Dropdown.VirtualSelect.Tags {
 		 * @return {*}  {string[]}
 		 * @memberof Providers.OSUI.Dropdown.VirtualSelect.Tags.VirtualSelectTagsConfig
 		 */
-		protected _getSelectedValues(): string[] {
+		protected getSelectedValues(): string[] {
 			const selectedKeyvalues = [];
 
 			// Has selected values
@@ -41,7 +41,7 @@ namespace Providers.OSUI.Dropdown.VirtualSelect.Tags {
 				showValueAsTags: true,
 			};
 
-			return this.mergeConfigs(super.getProviderConfig(), virtualSelectTagsOpts, this._providerExtendedOptions);
+			return this.mergeConfigs(super.getProviderConfig(), virtualSelectTagsOpts, this.providerExtendedOptions);
 		}
 	}
 }

--- a/src/scripts/Providers/OSUI/Monthpicker/Flatpickr/FlatpickrMonth.ts
+++ b/src/scripts/Providers/OSUI/Monthpicker/Flatpickr/FlatpickrMonth.ts
@@ -12,11 +12,11 @@ namespace Providers.OSUI.MonthPicker.Flatpickr {
 		// Validation of ZIndex position common behavior
 		private _zindexCommonBehavior: SharedProviderResources.Flatpickr.UpdateZindex;
 		// Store the flatpickr input html element that will be added by library
-		protected _flatpickrInputElem: HTMLInputElement;
+		protected flatpickrInputElem: HTMLInputElement;
 		// Store pattern input HTML element reference
-		protected _monthPickerProviderInputElem: HTMLInputElement;
+		protected monthPickerProviderInputElem: HTMLInputElement;
 		// Flatpickr onChange (SelectedMonth) event
-		protected _onSelectedCallbackEvent: OSFramework.OSUI.Patterns.MonthPicker.Callbacks.OSOnSelectedEvent;
+		protected onSelectedCallbackEvent: OSFramework.OSUI.Patterns.MonthPicker.Callbacks.OSOnSelectedEvent;
 
 		constructor(uniqueId: string, configs: JSON) {
 			super(uniqueId, new FlatpickrMonthConfig(configs));
@@ -28,19 +28,19 @@ namespace Providers.OSUI.MonthPicker.Flatpickr {
 		// Method used to set the needed HTML attributes
 		private _setAttributes(): void {
 			// Since a new input will be added by the flatpickr library, we must address it only at onReady
-			this._flatpickrInputElem = this._monthPickerProviderInputElem.nextSibling as HTMLInputElement;
+			this.flatpickrInputElem = this.monthPickerProviderInputElem.nextSibling as HTMLInputElement;
 
 			// Added the data-input attribute in order to input be styled as all platform inputs
 			OSFramework.OSUI.Helper.Dom.Attribute.Set(
-				this._flatpickrInputElem,
+				this.flatpickrInputElem,
 				OSFramework.OSUI.GlobalEnum.HTMLAttributes.DataInput,
 				OSFramework.OSUI.Constants.EmptyString
 			);
 
 			// If the provider cloned a disabled platform input, remove the disable attribute form the provider input
-			if (this._flatpickrInputElem.disabled) {
+			if (this.flatpickrInputElem.disabled) {
 				OSFramework.OSUI.Helper.Dom.Attribute.Remove(
-					this._flatpickrInputElem,
+					this.flatpickrInputElem,
 					OSFramework.OSUI.GlobalEnum.HTMLAttributes.Disabled
 				);
 			}
@@ -55,7 +55,7 @@ namespace Providers.OSUI.MonthPicker.Flatpickr {
 
 			if (
 				OSFramework.OSUI.Helper.Dom.Styles.ContainsClass(
-					this._flatpickrInputElem,
+					this.flatpickrInputElem,
 					OSFramework.OSUI.GlobalEnum.InputClassTypes.InputLarge
 				)
 			) {
@@ -65,7 +65,7 @@ namespace Providers.OSUI.MonthPicker.Flatpickr {
 				);
 			} else if (
 				OSFramework.OSUI.Helper.Dom.Styles.ContainsClass(
-					this._flatpickrInputElem,
+					this.flatpickrInputElem,
 					OSFramework.OSUI.GlobalEnum.InputClassTypes.InputSmall
 				)
 			) {
@@ -93,12 +93,12 @@ namespace Providers.OSUI.MonthPicker.Flatpickr {
 		 */
 		protected createProviderInstance(): void {
 			/* In order to avoid dateFormat convert issues done by provider when InitialMonth was not defined and input has a default month lets clean that value before creating provider instance. This happen when DateFormat is different from YYYY-MM-DD */
-			if (this._monthPickerProviderInputElem && this._flatpickrOpts.defaultDate === undefined) {
-				this._monthPickerProviderInputElem.value = '';
+			if (this.monthPickerProviderInputElem && this._flatpickrOpts.defaultDate === undefined) {
+				this.monthPickerProviderInputElem.value = '';
 			}
 
 			// Init provider
-			this.provider = window.flatpickr(this._monthPickerProviderInputElem, this._flatpickrOpts);
+			this.provider = window.flatpickr(this.monthPickerProviderInputElem, this._flatpickrOpts);
 			// Set the needed HTML attributes
 			this._setAttributes();
 
@@ -183,7 +183,7 @@ namespace Providers.OSUI.MonthPicker.Flatpickr {
 
 			// Trigger platform's onChange callback event
 			this.triggerPlatformEventCallback(
-				this._onSelectedCallbackEvent,
+				this.onSelectedCallbackEvent,
 				_selectedMonthYear.month,
 				_selectedMonthYear.monthOrder,
 				_selectedMonthYear.year
@@ -231,12 +231,12 @@ namespace Providers.OSUI.MonthPicker.Flatpickr {
 		 */
 		protected setHtmlElements(): void {
 			// Set the inputHTML element
-			this._monthPickerProviderInputElem = this.selfElement.querySelector(
+			this.monthPickerProviderInputElem = this.selfElement.querySelector(
 				OSFramework.OSUI.GlobalEnum.CSSSelectors.InputFormControl
 			);
 
 			// If the input hasn't be added
-			if (!this._monthPickerProviderInputElem) {
+			if (!this.monthPickerProviderInputElem) {
 				throw new Error(`The monthpicker input at MonthpickerId '${this.widgetId}' is missing`);
 			}
 		}
@@ -250,7 +250,7 @@ namespace Providers.OSUI.MonthPicker.Flatpickr {
 		protected unsetCallbacks(): void {
 			this.configs.OnChange = undefined;
 
-			this._onSelectedCallbackEvent = undefined;
+			this.onSelectedCallbackEvent = undefined;
 			super.unsetCallbacks();
 		}
 
@@ -261,7 +261,7 @@ namespace Providers.OSUI.MonthPicker.Flatpickr {
 		 * @memberof Providers.OSUI.MonthPicker.Flatpickr.OSUIFlatpickrMonth
 		 */
 		protected unsetHtmlElements(): void {
-			this._monthPickerProviderInputElem = undefined;
+			this.monthPickerProviderInputElem = undefined;
 		}
 
 		/**
@@ -318,7 +318,7 @@ namespace Providers.OSUI.MonthPicker.Flatpickr {
 		 * @memberof Providers.OSUI.MonthPicker.Flatpickr.OSUIFlatpickrMonth
 		 */
 		public clear(): void {
-			const isInputDisable = this._monthPickerProviderInputElem.disabled;
+			const isInputDisable = this.monthPickerProviderInputElem.disabled;
 			if (isInputDisable === false) {
 				this.provider.clear();
 			}
@@ -363,7 +363,7 @@ namespace Providers.OSUI.MonthPicker.Flatpickr {
 		 * @memberof Providers.OSUI.MonthPicker.Flatpickr.OSUIFlatpickrMonth
 		 */
 		public open(): void {
-			const isInputDisable = this._monthPickerProviderInputElem.disabled;
+			const isInputDisable = this.monthPickerProviderInputElem.disabled;
 			if (this.provider.isOpen === false && isInputDisable === false) {
 				this.provider.open();
 			}
@@ -377,7 +377,7 @@ namespace Providers.OSUI.MonthPicker.Flatpickr {
 		public registerCallback(eventName: string, callback: OSFramework.OSUI.GlobalCallbacks.OSGeneric): void {
 			switch (eventName) {
 				case OSFramework.OSUI.Patterns.MonthPicker.Enum.Events.OnSelected:
-					this._onSelectedCallbackEvent = callback;
+					this.onSelectedCallbackEvent = callback;
 					break;
 
 				default:
@@ -433,7 +433,7 @@ namespace Providers.OSUI.MonthPicker.Flatpickr {
 		 * @memberof OSUIFlatpickrMonth
 		 */
 		public updateInitialMonth(monthYear: MonthYear): void {
-			if (this._monthPickerProviderInputElem.disabled === false) {
+			if (this.monthPickerProviderInputElem.disabled === false) {
 				// Redefine the Initial month
 				this.configs.InitialMonth = monthYear;
 
@@ -449,7 +449,7 @@ namespace Providers.OSUI.MonthPicker.Flatpickr {
 		 * @memberof OSUIFlatpickrMonth
 		 */
 		public updatePrompt(promptMessage: string): void {
-			this._flatpickrInputElem.placeholder = promptMessage;
+			this.flatpickrInputElem.placeholder = promptMessage;
 		}
 	}
 }

--- a/src/scripts/Providers/OSUI/Monthpicker/Flatpickr/FlatpickrMonthConfig.ts
+++ b/src/scripts/Providers/OSUI/Monthpicker/Flatpickr/FlatpickrMonthConfig.ts
@@ -15,7 +15,7 @@ namespace Providers.OSUI.MonthPicker.Flatpickr {
 		private _providerOptions: FlatpickrOptions;
 
 		// Store configs set using extensibility
-		protected _providerExtendedOptions: FlatpickrOptions;
+		protected providerExtendedOptions: FlatpickrOptions;
 
 		// Stores the ability to allow inputs to be editable or not
 		public AllowInput = false;
@@ -155,7 +155,7 @@ namespace Providers.OSUI.MonthPicker.Flatpickr {
 				this._providerOptions.locale = this._checkLocale();
 			}
 
-			return this.mergeConfigs(this._providerOptions, undefined, this._providerExtendedOptions);
+			return this.mergeConfigs(this._providerOptions, undefined, this.providerExtendedOptions);
 		}
 
 		/**
@@ -165,7 +165,7 @@ namespace Providers.OSUI.MonthPicker.Flatpickr {
 		 * @memberof Providers.OSUI.MonthPicker.Flatpickr.FlatpickrMonthConfig
 		 */
 		public setExtensibilityConfigs(newConfigs: FlatpickrOptions): void {
-			this._providerExtendedOptions = newConfigs;
+			this.providerExtendedOptions = newConfigs;
 		}
 
 		/**

--- a/src/scripts/Providers/OSUI/RangeSlider/NoUISlider/AbstractNoUiSliderConfig.ts
+++ b/src/scripts/Providers/OSUI/RangeSlider/NoUISlider/AbstractNoUiSliderConfig.ts
@@ -14,7 +14,7 @@ namespace Providers.OSUI.RangeSlider.NoUiSlider {
 		// Store the Provider Options
 		private _providerOptions: NoUiSliderOptions;
 		// Store configs set using extensibility
-		protected _providerExtendedOptions: NoUiSliderOptions;
+		protected providerExtendedOptions: NoUiSliderOptions;
 		// Store rangeslider mode is in use
 		public rangeSliderMode: OSFramework.OSUI.Patterns.RangeSlider.Enum.Mode;
 
@@ -85,7 +85,7 @@ namespace Providers.OSUI.RangeSlider.NoUiSlider {
 				tooltips: this.getTooltipFormat(),
 			};
 
-			return this.mergeConfigs(this._providerOptions, this._providerExtendedOptions);
+			return this.mergeConfigs(this._providerOptions, this.providerExtendedOptions);
 		}
 
 		/**
@@ -127,7 +127,7 @@ namespace Providers.OSUI.RangeSlider.NoUiSlider {
 		 * @memberof Providers.OSUI.RangeSlider.NoUiSlider.AbstractNoUiSliderConfig
 		 */
 		public setExtensibilityConfigs(newConfigs: NoUiSliderOptions): void {
-			this._providerExtendedOptions = newConfigs;
+			this.providerExtendedOptions = newConfigs;
 		}
 	}
 }

--- a/src/scripts/Providers/OSUI/RangeSlider/NoUISlider/SliderInterval/NoUiSliderIntervalConfig.ts
+++ b/src/scripts/Providers/OSUI/RangeSlider/NoUISlider/SliderInterval/NoUiSliderIntervalConfig.ts
@@ -20,7 +20,7 @@ namespace Providers.OSUI.RangeSlider.NoUISlider.SliderInterval {
 				connect: true,
 			};
 
-			return this.mergeConfigs(super.getProviderConfig(), rangeSliderOptions, this._providerExtendedOptions);
+			return this.mergeConfigs(super.getProviderConfig(), rangeSliderOptions, this.providerExtendedOptions);
 		}
 	}
 }

--- a/src/scripts/Providers/OSUI/RangeSlider/NoUISlider/SliderSingle/NoUiSliderSingleConfig.ts
+++ b/src/scripts/Providers/OSUI/RangeSlider/NoUISlider/SliderSingle/NoUiSliderSingleConfig.ts
@@ -20,7 +20,7 @@ namespace Providers.OSUI.RangeSlider.NoUISlider.SliderSingle {
 				connect: NoUiSlider.Enum.NoUiSliderConnectOptions.Lower,
 			};
 
-			return this.mergeConfigs(super.getProviderConfig(), singleSliderOptions, this._providerExtendedOptions);
+			return this.mergeConfigs(super.getProviderConfig(), singleSliderOptions, this.providerExtendedOptions);
 		}
 	}
 }

--- a/src/scripts/Providers/OSUI/Timepicker/Flatpickr/FlatpickrTime.ts
+++ b/src/scripts/Providers/OSUI/Timepicker/Flatpickr/FlatpickrTime.ts
@@ -12,11 +12,11 @@ namespace Providers.OSUI.TimePicker.Flatpickr {
 		// Validation of ZIndex position common behavior
 		private _zindexCommonBehavior: SharedProviderResources.Flatpickr.UpdateZindex;
 		// Store the flatpickr input html element that will be added by library
-		protected _flatpickrInputElem: HTMLInputElement;
+		protected flatpickrInputElem: HTMLInputElement;
 		// Flatpickr onChange (SelectedTime) event
-		protected _onChangeCallbackEvent: OSFramework.OSUI.Patterns.TimePicker.Callbacks.OSOnChangeEvent;
+		protected onChangeCallbackEvent: OSFramework.OSUI.Patterns.TimePicker.Callbacks.OSOnChangeEvent;
 		// Store pattern input HTML element reference
-		protected _timePickerProviderInputElem: HTMLInputElement;
+		protected timePickerProviderInputElem: HTMLInputElement;
 
 		constructor(uniqueId: string, configs: JSON) {
 			super(uniqueId, new FlatpickrTimeConfig(configs));
@@ -28,19 +28,19 @@ namespace Providers.OSUI.TimePicker.Flatpickr {
 		// Method used to set the needed HTML attributes
 		private _setAttributes(): void {
 			// Since a new input will be added by the flatpickr library, we must address it only at onReady
-			this._flatpickrInputElem = this._timePickerProviderInputElem.nextSibling as HTMLInputElement;
+			this.flatpickrInputElem = this.timePickerProviderInputElem.nextSibling as HTMLInputElement;
 
 			// Added the data-input attribute in order to input be styled as all platform inputs
 			OSFramework.OSUI.Helper.Dom.Attribute.Set(
-				this._flatpickrInputElem,
+				this.flatpickrInputElem,
 				OSFramework.OSUI.GlobalEnum.HTMLAttributes.DataInput,
 				OSFramework.OSUI.Constants.EmptyString
 			);
 
 			// If the provider cloned a disabled platform input, remove the disable attribute form the provider input
-			if (this._flatpickrInputElem.disabled) {
+			if (this.flatpickrInputElem.disabled) {
 				OSFramework.OSUI.Helper.Dom.Attribute.Remove(
-					this._flatpickrInputElem,
+					this.flatpickrInputElem,
 					OSFramework.OSUI.GlobalEnum.HTMLAttributes.Disabled
 				);
 			}
@@ -55,7 +55,7 @@ namespace Providers.OSUI.TimePicker.Flatpickr {
 
 			if (
 				OSFramework.OSUI.Helper.Dom.Styles.ContainsClass(
-					this._flatpickrInputElem,
+					this.flatpickrInputElem,
 					OSFramework.OSUI.GlobalEnum.InputClassTypes.InputLarge
 				)
 			) {
@@ -65,7 +65,7 @@ namespace Providers.OSUI.TimePicker.Flatpickr {
 				);
 			} else if (
 				OSFramework.OSUI.Helper.Dom.Styles.ContainsClass(
-					this._flatpickrInputElem,
+					this.flatpickrInputElem,
 					OSFramework.OSUI.GlobalEnum.InputClassTypes.InputSmall
 				)
 			) {
@@ -93,12 +93,12 @@ namespace Providers.OSUI.TimePicker.Flatpickr {
 		 */
 		protected createProviderInstance(): void {
 			/* In order to avoid dateFormat convert issues done by provider when InitialTime was not defined and input has a default time lets clean that value before creating provider instance. This happen when DateFormat is different from YYYY-MM-DD */
-			if (this._timePickerProviderInputElem && this._flatpickrOpts.defaultDate === undefined) {
-				this._timePickerProviderInputElem.value = '';
+			if (this.timePickerProviderInputElem && this._flatpickrOpts.defaultDate === undefined) {
+				this.timePickerProviderInputElem.value = '';
 			}
 
 			// Init provider
-			this.provider = window.flatpickr(this._timePickerProviderInputElem, this._flatpickrOpts);
+			this.provider = window.flatpickr(this.timePickerProviderInputElem, this._flatpickrOpts);
 			// Set the needed HTML attributes
 			this._setAttributes();
 
@@ -165,7 +165,7 @@ namespace Providers.OSUI.TimePicker.Flatpickr {
 			}
 
 			// Trigger platform's onChange callback event
-			this.triggerPlatformEventCallback(this._onChangeCallbackEvent, _selectedTime);
+			this.triggerPlatformEventCallback(this.onChangeCallbackEvent, _selectedTime);
 		}
 
 		/**
@@ -209,12 +209,12 @@ namespace Providers.OSUI.TimePicker.Flatpickr {
 		 */
 		protected setHtmlElements(): void {
 			// Set the inputHTML element
-			this._timePickerProviderInputElem = this.selfElement.querySelector(
+			this.timePickerProviderInputElem = this.selfElement.querySelector(
 				OSFramework.OSUI.GlobalEnum.CSSSelectors.InputFormControl
 			);
 
 			// If the input hasn't be added
-			if (!this._timePickerProviderInputElem) {
+			if (!this.timePickerProviderInputElem) {
 				throw new Error(`The timepicker input at TimepickerId '${this.widgetId}' is missing`);
 			}
 		}
@@ -228,7 +228,7 @@ namespace Providers.OSUI.TimePicker.Flatpickr {
 		protected unsetCallbacks(): void {
 			this.configs.OnChange = undefined;
 
-			this._onChangeCallbackEvent = undefined;
+			this.onChangeCallbackEvent = undefined;
 			super.unsetCallbacks();
 		}
 
@@ -239,7 +239,7 @@ namespace Providers.OSUI.TimePicker.Flatpickr {
 		 * @memberof Providers.OSUI.TimePicker.Flatpickr.OSUIFlatpickrTime
 		 */
 		protected unsetHtmlElements(): void {
-			this._timePickerProviderInputElem = undefined;
+			this.timePickerProviderInputElem = undefined;
 		}
 
 		public build(): void {
@@ -292,7 +292,7 @@ namespace Providers.OSUI.TimePicker.Flatpickr {
 		 * @memberof Providers.OSUI.TimePicker.Flatpickr.OSUIFlatpickrTime
 		 */
 		public clear(): void {
-			const isInputDisable = this._timePickerProviderInputElem.disabled;
+			const isInputDisable = this.timePickerProviderInputElem.disabled;
 			if (isInputDisable === false) {
 				this.provider.clear();
 			}
@@ -337,7 +337,7 @@ namespace Providers.OSUI.TimePicker.Flatpickr {
 		 * @memberof Providers.OSUI.TimePicker.Flatpickr.OSUIFlatpickrTime
 		 */
 		public open(): void {
-			const isInputDisable = this._timePickerProviderInputElem.disabled;
+			const isInputDisable = this.timePickerProviderInputElem.disabled;
 			if (this.provider.isOpen === false && isInputDisable === false) {
 				this.provider.open();
 			}
@@ -351,7 +351,7 @@ namespace Providers.OSUI.TimePicker.Flatpickr {
 		public registerCallback(eventName: string, callback: OSFramework.OSUI.GlobalCallbacks.OSGeneric): void {
 			switch (eventName) {
 				case OSFramework.OSUI.Patterns.TimePicker.Enum.TimePickerEvents.OnChange:
-					this._onChangeCallbackEvent = callback;
+					this.onChangeCallbackEvent = callback;
 					break;
 
 				default:
@@ -420,7 +420,7 @@ namespace Providers.OSUI.TimePicker.Flatpickr {
 		 * @memberof OSUIFlatpickrTime
 		 */
 		public updateInitialTime(value: string): void {
-			if (this._timePickerProviderInputElem.disabled === false) {
+			if (this.timePickerProviderInputElem.disabled === false) {
 				// Redefine the Initial time
 				this.configs.InitialTime = value;
 				// Trigger the Redraw method in order to update calendar with this new value
@@ -435,7 +435,7 @@ namespace Providers.OSUI.TimePicker.Flatpickr {
 		 * @memberof OSUIFlatpickrTime
 		 */
 		public updatePrompt(promptMessage: string): void {
-			this._flatpickrInputElem.placeholder = promptMessage;
+			this.flatpickrInputElem.placeholder = promptMessage;
 		}
 	}
 }

--- a/src/scripts/Providers/OSUI/Timepicker/Flatpickr/FlatpickrTimeConfig.ts
+++ b/src/scripts/Providers/OSUI/Timepicker/Flatpickr/FlatpickrTimeConfig.ts
@@ -15,7 +15,7 @@ namespace Providers.OSUI.TimePicker.Flatpickr {
 		private _providerOptions: FlatpickrOptions;
 
 		// Store configs set using extensibility
-		protected _providerExtendedOptions: FlatpickrOptions;
+		protected providerExtendedOptions: FlatpickrOptions;
 
 		// Stores the ability to allow inputs to be editable or not
 		public AllowInput = false;
@@ -97,7 +97,7 @@ namespace Providers.OSUI.TimePicker.Flatpickr {
 				this._providerOptions.locale = this._checkLocale();
 			}
 
-			return this.mergeConfigs(this._providerOptions, undefined, this._providerExtendedOptions);
+			return this.mergeConfigs(this._providerOptions, undefined, this.providerExtendedOptions);
 		}
 
 		/**
@@ -107,7 +107,7 @@ namespace Providers.OSUI.TimePicker.Flatpickr {
 		 * @memberof Providers.OSUI.TimePicker.Flatpickr.FlatpickrTimeConfig
 		 */
 		public setExtensibilityConfigs(newConfigs: FlatpickrOptions): void {
-			this._providerExtendedOptions = newConfigs;
+			this.providerExtendedOptions = newConfigs;
 		}
 
 		/**


### PR DESCRIPTION
This PR is for add code consistency and also fix some issues related with the previous ROU-3565 PRs versions.
- **Improvements**:
- > Removed underscore to all Protected members.

- **Fixed Issues**:
- > Avoid DropdownServerSide toggleEvent be trigger twice.
- > Initialized Event of DropdownServerSideItem is now being fired.