### PR TITLE
[ROU-3656-v4]: Add Initialized event to all new components - P2

### DIFF
--- a/src/scripts/OutSystems/OSUI/Patterns/TabsContentItemAPI.ts
+++ b/src/scripts/OutSystems/OSUI/Patterns/TabsContentItemAPI.ts
@@ -1,35 +1,6 @@
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 namespace OutSystems.OSUI.Patterns.TabsContentItemAPI {
-	const _tabsMap = new Map<string, string>();
 	const _tabsContentItemMap = new Map<string, OSFramework.OSUI.Patterns.TabsContentItem.ITabsContentItem>();
-	/**
-	 * Gets the Tabd pattern the Item belongs to
-	 *
-	 * @return {*}  {Map<string, OSFramework.OSUI.Patterns.TabsContentItem.ITabsContentItem>}
-	 */
-	export function GetTabsByItem(tabsContentItemId: string): OSFramework.OSUI.Patterns.Tabs.ITabs {
-		let tabs: OSFramework.OSUI.Patterns.Tabs.ITabs;
-
-		if (_tabsMap.has(tabsContentItemId)) {
-			tabs = TabsAPI.GetTabsById(_tabsMap.get(tabsContentItemId));
-		} else {
-			// Try to find its reference on DOM
-			const elem = OSFramework.OSUI.Helper.Dom.GetElementByUniqueId(tabsContentItemId);
-			const tabsElem = elem.closest(
-				OSFramework.OSUI.Constants.Dot + OSFramework.OSUI.Patterns.Tabs.Enum.CssClasses.TabsWrapper
-			);
-
-			if (!tabsElem) {
-				throw Error(
-					`This ${OSFramework.OSUI.GlobalEnum.PatternName.TabsContentItem} does not belong to any ${OSFramework.OSUI.GlobalEnum.PatternName.Tabs} pattern.`
-				);
-			}
-			const uniqueId = tabsElem.getAttribute('name');
-			tabs = TabsAPI.GetTabsById(uniqueId);
-		}
-
-		return tabs;
-	}
 
 	/**
 	 * Function that will change the property of a given Tabs pattern.
@@ -70,7 +41,6 @@ namespace OutSystems.OSUI.Patterns.TabsContentItemAPI {
 				`There is already a ${OSFramework.OSUI.GlobalEnum.PatternName.TabsContentItem} registered under id: ${tabsContentItemId}`
 			);
 		}
-		const tabs = GetTabsByItem(tabsContentItemId);
 
 		const _newTabsContentItem = new OSFramework.OSUI.Patterns.TabsContentItem.TabsContentItem(
 			tabsContentItemId,
@@ -78,11 +48,6 @@ namespace OutSystems.OSUI.Patterns.TabsContentItemAPI {
 		);
 
 		_tabsContentItemMap.set(tabsContentItemId, _newTabsContentItem);
-		_newTabsContentItem.build();
-
-		if (tabs !== undefined) {
-			_tabsMap.set(tabsContentItemId, tabs.uniqueId);
-		}
 
 		return _newTabsContentItem;
 	}
@@ -133,6 +98,21 @@ namespace OutSystems.OSUI.Patterns.TabsContentItemAPI {
 			tabsContentItemId,
 			_tabsContentItemMap
 		) as OSFramework.OSUI.Patterns.TabsContentItem.ITabsContentItem;
+	}
+
+	/**
+	 * Function that will initialize the pattern instance.
+	 *
+	 * @export
+	 * @param {string} tabsContentItemId ID of the TabsContentItem pattern that will be initialized.
+	 * @return {*}  {OSFramework.OSUI.Patterns.TabsContentItem.ITabsContentItem}
+	 */
+	export function Initialize(tabsContentItemId: string): OSFramework.OSUI.Patterns.TabsContentItem.ITabsContentItem {
+		const tabsContentItem = GetTabsContentItemById(tabsContentItemId);
+
+		tabsContentItem.build();
+
+		return tabsContentItem;
 	}
 
 	/**

--- a/src/scripts/OutSystems/OSUI/Patterns/TabsHeaderItemAPI.ts
+++ b/src/scripts/OutSystems/OSUI/Patterns/TabsHeaderItemAPI.ts
@@ -1,35 +1,6 @@
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 namespace OutSystems.OSUI.Patterns.TabsHeaderItemAPI {
-	const _tabsMap = new Map<string, string>();
 	const _tabsHeaderItemMap = new Map<string, OSFramework.OSUI.Patterns.TabsHeaderItem.ITabsHeaderItem>();
-	/**
-	 * Gets the Tabd pattern the Item belongs to
-	 *
-	 * @return {*}  {Map<string, OSFramework.OSUI.Patterns.TabsHeaderItem.ITabsHeaderItem>}
-	 */
-	export function GetTabsByItem(tabsHeaderItemId: string): OSFramework.OSUI.Patterns.Tabs.ITabs {
-		let tabs: OSFramework.OSUI.Patterns.Tabs.ITabs;
-
-		if (_tabsMap.has(tabsHeaderItemId)) {
-			tabs = TabsAPI.GetTabsById(_tabsMap.get(tabsHeaderItemId));
-		} else {
-			// Try to find its reference on DOM
-			const elem = OSFramework.OSUI.Helper.Dom.GetElementByUniqueId(tabsHeaderItemId);
-			const tabsElem = elem.closest(
-				OSFramework.OSUI.Constants.Dot + OSFramework.OSUI.Patterns.Tabs.Enum.CssClasses.TabsWrapper
-			);
-
-			if (!tabsElem) {
-				throw Error(
-					`This ${OSFramework.OSUI.GlobalEnum.PatternName.TabsHeaderItem} does not belong to any ${OSFramework.OSUI.GlobalEnum.PatternName.Tabs} pattern.`
-				);
-			}
-			const uniqueId = tabsElem.getAttribute('name');
-			tabs = TabsAPI.GetTabsById(uniqueId);
-		}
-
-		return tabs;
-	}
 
 	/**
 	 * Function that will change the property of a given Tabs pattern.
@@ -70,7 +41,6 @@ namespace OutSystems.OSUI.Patterns.TabsHeaderItemAPI {
 				`There is already a ${OSFramework.OSUI.GlobalEnum.PatternName.TabsHeaderItem} registered under id: ${tabsHeaderItemId}`
 			);
 		}
-		const tabs = GetTabsByItem(tabsHeaderItemId);
 
 		const _newTabsHeaderItem = new OSFramework.OSUI.Patterns.TabsHeaderItem.TabsHeaderItem(
 			tabsHeaderItemId,
@@ -78,11 +48,6 @@ namespace OutSystems.OSUI.Patterns.TabsHeaderItemAPI {
 		);
 
 		_tabsHeaderItemMap.set(tabsHeaderItemId, _newTabsHeaderItem);
-		_newTabsHeaderItem.build();
-
-		if (tabs !== undefined) {
-			_tabsMap.set(tabsHeaderItemId, tabs.uniqueId);
-		}
 
 		return _newTabsHeaderItem;
 	}
@@ -160,7 +125,7 @@ namespace OutSystems.OSUI.Patterns.TabsHeaderItemAPI {
 	 * Function that gets the instance of Tabs by a given ID.
 	 *
 	 * @export
-	 * @param {string} tabsHeaderItemId ID of the Tabs that will be looked for.
+	 * @param {string} tabsHeaderItemId ID of the TabsHeaderItem that will be looked for.
 	 * @return {*}  {OSFramework.OSUI.Patterns.Tabs.ITabs}
 	 */
 	export function GetTabsHeaderItemById(
@@ -191,6 +156,21 @@ namespace OutSystems.OSUI.Patterns.TabsHeaderItemAPI {
 		});
 
 		return result;
+	}
+
+	/**
+	 * Function that will initialize the pattern instance.
+	 *
+	 * @export
+	 * @param {string} tabsHeaderItemId ID of the TabsHeaderItem pattern that will be initialized.
+	 * @return {*}  {OSFramework.OSUI.Patterns.TabsHeaderItem.ITabsHeaderItem}
+	 */
+	export function Initialize(tabsHeaderItemId: string): OSFramework.OSUI.Patterns.TabsHeaderItem.ITabsHeaderItem {
+		const tabsHeaderItem = GetTabsHeaderItemById(tabsHeaderItemId);
+
+		tabsHeaderItem.build();
+
+		return tabsHeaderItem;
 	}
 
 	/**


### PR DESCRIPTION
This PR is for fixing an issue at TabsContentItem and TabsHeaderItem that was preventing to set the Initialized callback event.