### PR TITLE
[ROU-4333]: Replace changed CSS

### DIFF
--- a/src/scripts/OSFramework/OSUI/Pattern/DatePicker/scss/_datepicker.scss
+++ b/src/scripts/OSFramework/OSUI/Pattern/DatePicker/scss/_datepicker.scss
@@ -24,17 +24,17 @@
 			}
 		}
 
-		&.flatpickr-input {
-			// Hide the platform input which is set as hidden by the library and we're change it into the expected type, however we do not want it visible since library will add a clone to better deal with the selected dates.
+		// Hide the platform input which is set as hidden by the library and we're change it into the expected type, however we do not want it visible since library will add a clone to better deal with the selected dates.
+		&:first-of-type {
 			display: none !important;
+		}
 
-			// Disable states for Datepicker
-			&[disabled] + input {
-				background-color: var(--color-neutral-2);
-				border: var(--border-size-s) solid var(--color-neutral-4);
-				color: var(--color-neutral-6);
-				pointer-events: none;
-			}
+		// Disable states for Datepicker
+		&.flatpickr-input[disabled] + input {
+			background-color: var(--color-neutral-2);
+			border: var(--border-size-s) solid var(--color-neutral-4);
+			color: var(--color-neutral-6);
+			pointer-events: none;
 		}
 	}
 

--- a/src/scripts/OSFramework/OSUI/Pattern/MonthPicker/scss/_monthpicker.scss
+++ b/src/scripts/OSFramework/OSUI/Pattern/MonthPicker/scss/_monthpicker.scss
@@ -46,17 +46,17 @@
 	}
 
 	input {
-		&.flatpickr-input {
-			// Hide the platform input which is set as hidden by the library and we're change it into the expected type, however we do not want it visible since library will add a clone to better deal with the selected dates.
+		// Hide the platform input which is set as hidden by the library and we're change it into the expected type, however we do not want it visible since library will add a clone to better deal with the selected dates.
+		&:first-of-type {
 			display: none !important;
+		}
 
-			// Disable states for Datepicker
-			&[disabled] + input {
-				background-color: var(--color-neutral-2);
-				border: var(--border-size-s) solid var(--color-neutral-4);
-				color: var(--color-neutral-6);
-				pointer-events: none;
-			}
+		// Disable states for Datepicker
+		&[disabled] + input {
+			background-color: var(--color-neutral-2);
+			border: var(--border-size-s) solid var(--color-neutral-4);
+			color: var(--color-neutral-6);
+			pointer-events: none;
 		}
 	}
 }

--- a/src/scripts/OSFramework/OSUI/Pattern/TimePicker/scss/_timepicker.scss
+++ b/src/scripts/OSFramework/OSUI/Pattern/TimePicker/scss/_timepicker.scss
@@ -24,17 +24,17 @@
 			}
 		}
 
-		&.flatpickr-input {
-			// Hide the platform input which is set as hidden by the library and we're change it into the expected type, however we do not want it visible since library will add a clone to better deal with the selected dates.
+		// Hide the platform input which is set as hidden by the library and we're change it into the expected type, however we do not want it visible since library will add a clone to better deal with the selected dates.
+		&:first-of-type {
 			display: none !important;
+		}
 
-			// Disable states for Datepicker
-			&[disabled] + input {
-				background-color: var(--color-neutral-2);
-				border: var(--border-size-s) solid var(--color-neutral-4);
-				color: var(--color-neutral-6);
-				pointer-events: none;
-			}
+		// Disable states for Datepicker
+		&.flatpickr-input[disabled] + input {
+			background-color: var(--color-neutral-2);
+			border: var(--border-size-s) solid var(--color-neutral-4);
+			color: var(--color-neutral-6);
+			pointer-events: none;
 		}
 	}
 


### PR DESCRIPTION
This PR is for replace Pickers selector into first-of-type due to a use case where input losses this selector.
At form validation, this "hidden" inputs will loose this selector (flatpickr-input), and at that moment they will be visible, so, this approach must be kept.