### PR TITLE
Fixed issue that was preventing OnBodyScroll event to be triggered.

### DIFF
--- a/src/scripts/OSFramework/OSUI/Event/DOMEvents/Listeners/AbstractListener.ts
+++ b/src/scripts/OSFramework/OSUI/Event/DOMEvents/Listeners/AbstractListener.ts
@@ -16,12 +16,34 @@ namespace OSFramework.OSUI.Event.DOMEvents.Listeners {
 		private _eventTarget: HTMLElement;
 		// Store the listener type
 		private _eventType: GlobalEnum.HTMLEvent;
-		// Store the listener callback
+
+		/**
+		 * Store the listener callback
+		 *
+		 * @protected
+		 * @type {EventListenerObject}
+		 * @memberof AbstractListener
+		 */
 		protected eventCallback: EventListenerObject;
 
-		constructor(eventTarget, eventType) {
+		/**
+		 * Flag to indicate if event will be dispatched to the registered listener before being dispatched to any EventTarget beneath it in the DOM tree.
+		 *
+		 * @protected
+		 * @memberof AbstractListener
+		 */
+		protected useCapture = false;
+
+		/**
+		 * Creates an instance of AbstractListener.
+		 *
+		 * @param {unknown} eventTarget, window can be in use, so, HTMLElement can't be the type of the input by default
+		 * @param {GlobalEnum.HTMLEvent} eventType
+		 * @memberof AbstractListener
+		 */
+		constructor(eventTarget: unknown, eventType: GlobalEnum.HTMLEvent) {
 			super();
-			this._eventTarget = eventTarget;
+			this._eventTarget = eventTarget as HTMLElement;
 			this._eventType = eventType;
 			this._eventName = GlobalEnum.HTMLEvent.Prefix + this._eventType;
 
@@ -37,7 +59,7 @@ namespace OSFramework.OSUI.Event.DOMEvents.Listeners {
 		public addEvent(): void {
 			// Check if event exist in the window
 			if (this._eventName in window) {
-				this._eventTarget.addEventListener(this._eventType, this.eventCallback);
+				this._eventTarget.addEventListener(this._eventType, this.eventCallback, this.useCapture);
 			}
 		}
 

--- a/src/scripts/OSFramework/OSUI/Event/DOMEvents/Listeners/AbstractListener.ts
+++ b/src/scripts/OSFramework/OSUI/Event/DOMEvents/Listeners/AbstractListener.ts
@@ -13,7 +13,7 @@ namespace OSFramework.OSUI.Event.DOMEvents.Listeners {
 		// Store the listener name, to check later if event is supported on the window
 		private _eventName: string;
 		// Store the listener target
-		private _eventTarget: HTMLElement;
+		private _eventTarget: HTMLElement | Window;
 		// Store the listener type
 		private _eventType: GlobalEnum.HTMLEvent;
 
@@ -37,13 +37,13 @@ namespace OSFramework.OSUI.Event.DOMEvents.Listeners {
 		/**
 		 * Creates an instance of AbstractListener.
 		 *
-		 * @param {unknown} eventTarget, window can be in use, so, HTMLElement can't be the type of the input by default
+		 * @param {(HTMLElement | Window)} eventTarget
 		 * @param {GlobalEnum.HTMLEvent} eventType
 		 * @memberof AbstractListener
 		 */
-		constructor(eventTarget: unknown, eventType: GlobalEnum.HTMLEvent) {
+		constructor(eventTarget: HTMLElement | Window, eventType: GlobalEnum.HTMLEvent) {
 			super();
-			this._eventTarget = eventTarget as HTMLElement;
+			this._eventTarget = eventTarget;
 			this._eventType = eventType;
 			this._eventName = GlobalEnum.HTMLEvent.Prefix + this._eventType;
 

--- a/src/scripts/OSFramework/OSUI/Event/DOMEvents/Listeners/BodyOnScroll.ts
+++ b/src/scripts/OSFramework/OSUI/Event/DOMEvents/Listeners/BodyOnScroll.ts
@@ -10,7 +10,7 @@ namespace OSFramework.OSUI.Event.DOMEvents.Listeners {
 	export class BodyOnScroll extends AbstractListener<string> {
 		constructor() {
 			super(document.body, GlobalEnum.HTMLEvent.Scroll);
-			// Ensure capture is being set in order Event can be "listened" to the element where it has been set.
+			/* Since the scroll can be set to other elements than body, such as ".active-screen" container, we must enable this property in order to ensure it will be "listened" at the body where the event has been set!  */
 			this.useCapture = true;
 			this.eventCallback = this._bodyTrigger.bind(this);
 		}

--- a/src/scripts/OSFramework/OSUI/Event/DOMEvents/Listeners/BodyOnScroll.ts
+++ b/src/scripts/OSFramework/OSUI/Event/DOMEvents/Listeners/BodyOnScroll.ts
@@ -12,7 +12,6 @@ namespace OSFramework.OSUI.Event.DOMEvents.Listeners {
 			super(document.body, GlobalEnum.HTMLEvent.Scroll);
 			// Ensure capture is being set in order Event can be "listened" to the element where it has been set.
 			this.useCapture = true;
-			// super(document.querySelector('.active-screen'), GlobalEnum.HTMLEvent.Scroll);
 			this.eventCallback = this._bodyTrigger.bind(this);
 		}
 

--- a/src/scripts/OSFramework/OSUI/Event/DOMEvents/Listeners/BodyOnScroll.ts
+++ b/src/scripts/OSFramework/OSUI/Event/DOMEvents/Listeners/BodyOnScroll.ts
@@ -10,6 +10,9 @@ namespace OSFramework.OSUI.Event.DOMEvents.Listeners {
 	export class BodyOnScroll extends AbstractListener<string> {
 		constructor() {
 			super(document.body, GlobalEnum.HTMLEvent.Scroll);
+			// Ensure capture is being set in order Event can be "listened" to the element where it has been set.
+			this.useCapture = true;
+			// super(document.querySelector('.active-screen'), GlobalEnum.HTMLEvent.Scroll);
 			this.eventCallback = this._bodyTrigger.bind(this);
 		}
 


### PR DESCRIPTION
This PR will fix an issue related with the OnBodyScroll. 
Since the event is being set to the body element and in some cases the scroll is being set to other elements, such as ".active-screen" container, once scroll occurs inside this last one, the event was not being triggered at the body since body has an overflow hidden.
In order to grant all the use cases, **useCapture** property has been added in order to proper manage this event property accordingly.