### PR TITLE
[ROU-4349 V2]: Fix a tab-navigation issue at notification!

### DIFF
--- a/src/scripts/OSFramework/OSUI/Pattern/Notification/Notification.ts
+++ b/src/scripts/OSFramework/OSUI/Pattern/Notification/Notification.ts
@@ -57,7 +57,7 @@ namespace OSFramework.OSUI.Patterns.Notification {
 		// Add Focus Trap to Pattern
 		private _handleFocusTrap(): void {
 			const opts = {
-				focusTargetElement: this.selfElement,
+				focusTargetElement: this._parentSelf,
 			} as Behaviors.FocusTrapParams;
 
 			this._focusTrapInstance = new Behaviors.FocusTrap(opts);


### PR DESCRIPTION
This PR is for fixed an issue (console.error) when there was no focusable items at Notification pattern and tabs-navigation was in use.