### PR TITLE
Update AnimatedLabel.ts

### DIFF
--- a/src/scripts/OSFramework/OSUI/Pattern/AnimatedLabel/AnimatedLabel.ts
+++ b/src/scripts/OSFramework/OSUI/Pattern/AnimatedLabel/AnimatedLabel.ts
@@ -60,7 +60,7 @@ namespace OSFramework.OSUI.Patterns.AnimatedLabel {
 
 		// Method that implements the toggle of the state of the input.
 		// It can either add or remove the class "active" of the input.
-		private _inputStateToggle(isFocus: boolean | undefined): void {
+		private _inputStateToggle(isFocus: boolean | false): void {
 			const inputHasText = this._inputElement && this._inputElement.value !== '';
 
 			//let's check if we have something to do. Is the pattern built or (it's building) and we have text in the input?
@@ -127,7 +127,7 @@ namespace OSFramework.OSUI.Patterns.AnimatedLabel {
 				// clear the input's prompt, as it not supported when used inside AnimatedLabel
 				this._inputElement.placeholder = '';
 
-				this._inputStateToggle(undefined);
+				this._inputStateToggle(false);
 			} else {
 				throw new Error(Enum.Messages.InputNotFound);
 			}
@@ -204,7 +204,7 @@ namespace OSFramework.OSUI.Patterns.AnimatedLabel {
 		public updateOnRender(): void {
 			// Do not run this instead the pattern is totally built
 			if (this.isBuilt) {
-				this._inputStateToggle(undefined);
+				this._inputStateToggle(false);
 			}
 		}
 	}


### PR DESCRIPTION
Updating _inputStateToggle input default value to false. Update uses from undefined to false

This PR is for fixing this issue #760 


### What was happening

When data was already loaded and it was removed programmatically, the pattern wasn't being updated

### What was done

Fixed the function that decided if the class "active" should be removed or added. It was failing because the input isFocus was undefined in some cases (explicit) and by default which was making the function to do nothing. 
Now, the function has a focus default which is false.

### Test Steps

1. Removed content programmatically
2. Check class 'active' was removed from animated label parent

### Checklist

-   [x] tested locally
-   [x] documented the code
-   [x] requires changes in OutSystems (if so, provide a module with changes)
