### PR TITLE
ROU-4390: Fix InlineSVG inside progress-circle

### DIFF
--- a/dist/OutSystemsUI.css
+++ b/dist/OutSystemsUI.css
@@ -12116,7 +12116,7 @@ html[data-uieditorversion^="1"] .wizard-wrapper-item{
   width:80%;
   z-index:var(--layer-local-tier-1);
 }
-.osui-progress-circle .svg-wrapper{
+.osui-progress-circle .osui-inline-svg{
   display:-webkit-inline-box;
   display:-ms-inline-flexbox;
   display:inline-flex;
@@ -12124,7 +12124,7 @@ html[data-uieditorversion^="1"] .wizard-wrapper-item{
   position:relative;
   width:var(--circle-size);
 }
-.osui-progress-circle .svg-wrapper svg{
+.osui-progress-circle .osui-inline-svg svg{
   height:var(--circle-size);
   width:var(--circle-size);
 }

--- a/src/scripts/OSFramework/OSUI/Pattern/Progress/Circle/scss/_progresscircle.scss
+++ b/src/scripts/OSFramework/OSUI/Pattern/Progress/Circle/scss/_progresscircle.scss
@@ -77,7 +77,7 @@
 		z-index: var(--layer-local-tier-1);
 	}
 
-	.svg-wrapper {
+	.osui-inline-svg {
 		display: inline-flex;
 		// the !important is used to override the inline style
 		height: var(--circle-size) !important;


### PR DESCRIPTION
This PR is for fixing a breaking-change on the SVGInline when used inside the ProgressCircle, due to the CSS Class change on the SVG Pattern.

### Checklist

-   [x] tested locally
-   [x] documented the code
-   [x] clean all warnings and errors of eslint
-   [x] requires changes in OutSystems (if so, provide a module with changes)
-   [ ] requires new sample page in OutSystems (if so, provide a module with changes)
