### PR TITLE
[ROU-4360] - Dropdown Search/Tags doesn't close when is open before data is loaded

### DIFF
--- a/src/scripts/OSFramework/OSUI/Pattern/InlineSvg/InlineSvg.ts
+++ b/src/scripts/OSFramework/OSUI/Pattern/InlineSvg/InlineSvg.ts
@@ -70,10 +70,13 @@ namespace OSFramework.OSUI.Patterns.InlineSvg {
 			console.log(GlobalEnum.WarningMessages.MethodNotImplemented);
 		}
 
+		/**
+		 * Builds the pattern.
+		 *
+		 * @memberof OSFramework.Patterns.InlineSvg.InlineSvg
+		 */
 		public build(): void {
 			super.build();
-
-			this.setHtmlElements();
 
 			this._setSvgCode();
 
@@ -106,9 +109,6 @@ namespace OSFramework.OSUI.Patterns.InlineSvg {
 		public dispose(): void {
 			if (this.isBuilt) {
 				this.unsetCallbacks();
-
-				// Remove unused HTML elements
-				this.unsetHtmlElements();
 
 				//Destroying the base of pattern
 				super.dispose();

--- a/src/scripts/Providers/OSUI/Dropdown/VirtualSelect/AbstractVirtualSelect.ts
+++ b/src/scripts/Providers/OSUI/Dropdown/VirtualSelect/AbstractVirtualSelect.ts
@@ -51,9 +51,6 @@ namespace Providers.OSUI.Dropdown.VirtualSelect {
 
 		// Manage the disable status of the pattern
 		private _manageDisableStatus(): void {
-			// Ensure that is closed!
-			this.virtualselectConfigs.close();
-
 			if (this.configs.IsDisabled) {
 				OSFramework.OSUI.Helper.Dom.Attribute.Set(
 					this.selfElement,
@@ -263,6 +260,8 @@ namespace Providers.OSUI.Dropdown.VirtualSelect {
 		 * @memberof Providers.OSUI.Dropdown.VirtualSelect.AbstractVirtualSelect
 		 */
 		public changeProperty(propertyName: string, propertyValue: unknown): void {
+			// Ensure Dropdown will be closed before any possible redraw, since provider needs it!
+			this.virtualselectConfigs.close();
 			// If/When we've the dropdown outside an IsDataFetched IF and OnParametersChannge where we're receiving (for both cases) a JSON string that must be parsed into an Object
 			if (
 				(propertyName === Enum.Properties.OptionsList || propertyName === Enum.Properties.StartingSelection) &&
@@ -279,17 +278,9 @@ namespace Providers.OSUI.Dropdown.VirtualSelect {
 						this._manageDisableStatus();
 						break;
 					case Enum.Properties.NoOptionsText:
-						this.redraw();
-						break;
 					case Enum.Properties.NoResultsText:
-						this.redraw();
-						break;
 					case Enum.Properties.OptionsList:
-						this.redraw();
-						break;
 					case Enum.Properties.Prompt:
-						this.redraw();
-						break;
 					case Enum.Properties.SearchPrompt:
 						this.redraw();
 						break;


### PR DESCRIPTION
This PR is for fixing an issue that was preventing Dropdown to work when data was completed loaded and Dropdown was opened.