### PR TITLE
ROU-4355 Update Virtual Select v1.0.39

### DIFF
--- a/dist/OutSystemsUI.css
+++ b/dist/OutSystemsUI.css
@@ -503,7 +503,6 @@ a{
 a, a:visited{
   color:var(--color-primary);
   -webkit-transition:all 180ms linear;
-  -o-transition:all 180ms linear;
   transition:all 180ms linear;
 }
 a:hover, a:focus{
@@ -1102,7 +1101,6 @@ body,
   position:fixed;
   top:0;
   -webkit-transition:opacity 130ms ease-in;
-  -o-transition:opacity 130ms ease-in;
   transition:opacity 130ms ease-in;
   width:100vw;
   will-change:opacity;
@@ -1115,7 +1113,6 @@ body,
   opacity:1;
   pointer-events:auto;
   -webkit-transition:opacity 330ms ease-out;
-  -o-transition:opacity 330ms ease-out;
   transition:opacity 330ms ease-out;
 }
 .layout .app-menu-content{
@@ -1173,7 +1170,6 @@ body,
           transform:translateX(0) translateZ(0);
   -webkit-transition:-webkit-transform 130ms ease-in;
   transition:-webkit-transform 130ms ease-in;
-  -o-transition:transform 130ms ease-in;
   transition:transform 130ms ease-in;
   transition:transform 130ms ease-in, -webkit-transform 130ms ease-in;
   width:var(--side-menu-size);
@@ -1186,7 +1182,6 @@ body,
           transform:translateX(var(--side-menu-size)) translateZ(0);
   -webkit-transition:-webkit-transform 330ms ease-out;
   transition:-webkit-transform 330ms ease-out;
-  -o-transition:transform 330ms ease-out;
   transition:transform 330ms ease-out;
   transition:transform 330ms ease-out, -webkit-transform 330ms ease-out;
 }
@@ -1227,7 +1222,6 @@ body,
   -webkit-transform:translateX(0) translateZ(0);
           transform:translateX(0) translateZ(0);
   -webkit-transition:all 330ms ease-out;
-  -o-transition:all 330ms ease-out;
   transition:all 330ms ease-out;
 }
 /*! 3.6. Layout Native - Menu */
@@ -1310,7 +1304,6 @@ body,
           transform:translateX(0) translateZ(0);
   -webkit-transition:-webkit-transform 130ms ease-in;
   transition:-webkit-transform 130ms ease-in;
-  -o-transition:transform 130ms ease-in;
   transition:transform 130ms ease-in;
   transition:transform 130ms ease-in, -webkit-transform 130ms ease-in;
   width:var(--side-menu-size);
@@ -1322,7 +1315,6 @@ body,
           transform:translateX(var(--side-menu-size)) translateZ(0);
   -webkit-transition:-webkit-transform 330ms ease-out;
   transition:-webkit-transform 330ms ease-out;
-  -o-transition:transform 330ms ease-out;
   transition:transform 330ms ease-out;
   transition:transform 330ms ease-out, -webkit-transform 330ms ease-out;
 }
@@ -1353,7 +1345,6 @@ body,
       -ms-transform:none;
           transform:none;
   -webkit-transition:none;
-  -o-transition:none;
   transition:none;
 }
 .is-rtl.desktop .aside-expandable.menu-visible .main{
@@ -1363,7 +1354,6 @@ body,
 .is-rtl.tablet .app-menu-content, .is-rtl.phone .app-menu-content{
   right:calc(-1 * var(--side-menu-size));
   -webkit-transition:all 330ms ease-out;
-  -o-transition:all 330ms ease-out;
   transition:all 330ms ease-out;
 }
 .is-rtl:not(.portrait) .layout-side.layout-native.aside-visible .app-menu-content{
@@ -1377,7 +1367,6 @@ body,
   -webkit-transform:translateX(0) translateZ(0);
           transform:translateX(0) translateZ(0);
   -webkit-transition:all 330ms ease-out;
-  -o-transition:all 330ms ease-out;
   transition:all 330ms ease-out;
 }
 /*! 3.8. Menu - Header Logo */
@@ -1800,7 +1789,6 @@ body .app-menu-content .app-menu-links{
   color:var(--color-neutral-9);
   font-size:var(--font-size-s);
   -webkit-transition:all 180ms linear;
-  -o-transition:all 180ms linear;
   transition:all 180ms linear;
 }
 .form-control[data-input]:hover, .form-control[data-textarea]:hover{
@@ -1900,7 +1888,6 @@ body .app-menu-content .app-menu-links{
   height:30px;
   opacity:1;
   -webkit-transition:all 180ms linear;
-  -o-transition:all 180ms linear;
   transition:all 180ms linear;
   width:48px;
 }
@@ -1916,7 +1903,6 @@ body .app-menu-content .app-menu-links{
   -webkit-transform:translateX(4px) translateZ(0);
           transform:translateX(4px) translateZ(0);
   -webkit-transition:all 180ms linear;
-  -o-transition:all 180ms linear;
   transition:all 180ms linear;
   width:24px;
 }
@@ -1974,7 +1960,6 @@ body .app-menu-content .app-menu-links{
   height:22px;
   opacity:1;
   -webkit-transition:all 180ms linear;
-  -o-transition:all 180ms linear;
   transition:all 180ms linear;
   width:22px;
 }
@@ -2058,7 +2043,6 @@ body .app-menu-content .app-menu-links{
       -ms-transform:rotate(-45deg) translateY(0) translateX(0);
           transform:rotate(-45deg) translateY(0) translateX(0);
   -webkit-transition:all 300ms ease-in-out;
-  -o-transition:all 300ms ease-in-out;
   transition:all 300ms ease-in-out;
   width:8px;
 }
@@ -2125,8 +2109,7 @@ body .app-menu-content .app-menu-links{
 }
 .dropdown-container .dropdown-popup-row span{
   overflow:hidden;
-  -o-text-overflow:ellipsis;
-     text-overflow:ellipsis;
+  text-overflow:ellipsis;
   white-space:nowrap;
 }
 .dropdown-container .scrollable-list-with-scroll{
@@ -2240,7 +2223,6 @@ select.dropdown-display[disabled]{
   margin:0;
   padding:var(--space-none) var(--space-base);
   -webkit-transition:all 100ms linear;
-  -o-transition:all 100ms linear;
   transition:all 100ms linear;
 }
 .btn:hover:active{
@@ -3028,7 +3010,6 @@ div.feedback-message-warning{
   height:24px;
   position:relative;
   -webkit-transition:all 180ms linear;
-  -o-transition:all 180ms linear;
   transition:all 180ms linear;
   width:24px;
 }
@@ -3046,7 +3027,6 @@ div.feedback-message-warning{
   display:flex;
   height:100%;
   -webkit-transition:all 180ms linear;
-  -o-transition:all 180ms linear;
   transition:all 180ms linear;
   width:100%;
 }
@@ -3374,7 +3354,6 @@ div.feedback-message-warning{
 .flatpickr-months .flatpickr-prev-month svg path,
 .flatpickr-months .flatpickr-next-month svg path{
   -webkit-transition:fill 0.1s;
-  -o-transition:fill 0.1s;
   transition:fill 0.1s;
   fill:inherit;
 }
@@ -4097,7 +4076,6 @@ span.flatpickr-weekday{
   -webkit-transition:transform 0.3s;
   -webkit-transition:-webkit-transform 0.3s;
   transition:-webkit-transform 0.3s;
-  -o-transition:transform 0.3s;
   transition:transform 0.3s;
   transition:transform 0.3s, -webkit-transform 0.3s;
 }
@@ -4537,7 +4515,6 @@ span.flatpickr-weekday{
   position:relative;
   -webkit-transition:-webkit-transform 0.2s linear;
   transition:-webkit-transform 0.2s linear;
-  -o-transition:transform 0.2s linear;
   transition:transform 0.2s linear;
   transition:transform 0.2s linear, -webkit-transform 0.2s linear;
   width:8px;
@@ -4671,7 +4648,7 @@ span.flatpickr-weekday{
 }
 /*! 5.4. VirtualSelect */
 /*!
- * Virtual Select v1.0.37
+ * Virtual Select v1.0.39
  * https://sa-si-dev.github.io/virtual-select
  * Licensed under MIT (https://github.com/sa-si-dev/virtual-select/blob/master/LICENSE)
  */
@@ -4738,8 +4715,7 @@ span.flatpickr-weekday{
   line-height:20px;
   max-width:100%;
   overflow:hidden;
-  -o-text-overflow:ellipsis;
-     text-overflow:ellipsis;
+  text-overflow:ellipsis;
   white-space:nowrap;
 }
 .vscomp-arrow{
@@ -4934,8 +4910,7 @@ span.flatpickr-weekday{
 }
 .vscomp-option-text{
   overflow:hidden;
-  -o-text-overflow:ellipsis;
-     text-overflow:ellipsis;
+  text-overflow:ellipsis;
   white-space:nowrap;
   -webkit-user-select:none;
   -moz-user-select:none;
@@ -4945,8 +4920,7 @@ span.flatpickr-weekday{
 }
 .vscomp-option-description{
   overflow:hidden;
-  -o-text-overflow:ellipsis;
-     text-overflow:ellipsis;
+  text-overflow:ellipsis;
   white-space:nowrap;
   color:#666;
   font-size:13px;
@@ -4963,6 +4937,18 @@ span.flatpickr-weekday{
   display:flex;
   height:40px;
   padding:0 5px 0 15px;
+}
+.vscomp-search-label,
+.vscomp-live-region{
+  border:0;
+  clip:rect(0 0 0 0);
+  height:1px;
+  margin:-1px;
+  overflow:hidden;
+  padding:0;
+  position:absolute;
+  white-space:nowrap;
+  width:1px;
 }
 .vscomp-search-input{
   background-color:rgba(0, 0, 0, 0);
@@ -5051,7 +5037,6 @@ span.flatpickr-weekday{
 }
 .vscomp-wrapper .checkbox-icon::after{
   -webkit-transition-duration:0.2s;
-       -o-transition-duration:0.2s;
           transition-duration:0.2s;
   border:2px solid #888;
   content:"";
@@ -5203,7 +5188,6 @@ span.flatpickr-weekday{
 }
 .vscomp-wrapper.keep-always-open .vscomp-dropbox{
   -webkit-transition-duration:0s;
-       -o-transition-duration:0s;
           transition-duration:0s;
   border:1px solid #ddd;
   -webkit-box-shadow:none;
@@ -5236,14 +5220,12 @@ span.flatpickr-weekday{
   height:auto;
   min-height:28px;
   overflow:auto;
-  -o-text-overflow:unset;
-     text-overflow:unset;
+  text-overflow:unset;
   white-space:normal;
 }
 .vscomp-wrapper.show-value-as-tags .vscomp-value-tag{
   overflow:hidden;
-  -o-text-overflow:ellipsis;
-     text-overflow:ellipsis;
+  text-overflow:ellipsis;
   white-space:nowrap;
   -webkit-box-align:center;
       -ms-flex-align:center;
@@ -5264,8 +5246,7 @@ span.flatpickr-weekday{
 }
 .vscomp-wrapper.show-value-as-tags .vscomp-value-tag-content{
   overflow:hidden;
-  -o-text-overflow:ellipsis;
-     text-overflow:ellipsis;
+  text-overflow:ellipsis;
   white-space:nowrap;
   width:calc(100% - 20px);
 }
@@ -5772,7 +5753,6 @@ span.flatpickr-weekday{
   -webkit-transform:translateX(100%) translateZ(0);
           transform:translateX(100%) translateZ(0);
   -webkit-transition:all 190ms ease-in;
-  -o-transition:all 190ms ease-in;
   transition:all 190ms ease-in;
   width:100%;
   will-change:transform;
@@ -5782,7 +5762,6 @@ span.flatpickr-weekday{
   -webkit-transform:translateX(0) translateZ(0);
           transform:translateX(0) translateZ(0);
   -webkit-transition:all 330ms ease-out;
-  -o-transition:all 330ms ease-out;
   transition:all 330ms ease-out;
 }
 .phone .split-screen-wrapper .split-right{
@@ -5908,7 +5887,6 @@ span.flatpickr-weekday{
   border-color:var(--color-primary);
   opacity:1;
   -webkit-transition:opacity 300ms ease-in;
-  -o-transition:opacity 300ms ease-in;
   transition:opacity 300ms ease-in;
 }
 .osui-accordion-item--is-disabled{
@@ -5936,8 +5914,7 @@ span.flatpickr-weekday{
   width:100%;
 }
 .osui-accordion-item__title__placeholder{
-  -o-text-overflow:ellipsis;
-     text-overflow:ellipsis;
+  text-overflow:ellipsis;
   width:100%;
 }
 .osui-accordion-item__title--is-left{
@@ -5965,7 +5942,6 @@ span.flatpickr-weekday{
       -ms-flex-pack:center;
           justify-content:center;
   -webkit-transition:all 300ms ease-in-out;
-  -o-transition:all 300ms ease-in-out;
   transition:all 300ms ease-in-out;
   width:16px;
 }
@@ -5978,7 +5954,6 @@ span.flatpickr-weekday{
   height:100%;
   -webkit-transition:-webkit-transform 300ms ease-in-out;
   transition:-webkit-transform 300ms ease-in-out;
-  -o-transition:transform 300ms ease-in-out;
   transition:transform 300ms ease-in-out;
   transition:transform 300ms ease-in-out, -webkit-transform 300ms ease-in-out;
   width:2px;
@@ -6017,7 +5992,6 @@ span.flatpickr-weekday{
 }
 .osui-accordion-item__content--is-animating{
   -webkit-transition:all 300ms ease-in-out;
-  -o-transition:all 300ms ease-in-out;
   transition:all 300ms ease-in-out;
 }
 .osui-accordion-item__content [data-block*=AnimatedLabel]:first-child .animated-label{
@@ -6202,7 +6176,6 @@ span.flatpickr-weekday{
 }
 .card-background-color:after{
   background:-webkit-gradient(linear, left top, left bottom, from(rgba(0, 0, 0, 0)), to(rgb(0, 0, 0)));
-  background:-o-linear-gradient(top, rgba(0, 0, 0, 0) 0%, rgb(0, 0, 0) 100%);
   background:linear-gradient(180deg, rgba(0, 0, 0, 0) 0%, rgb(0, 0, 0) 100%);
   content:"";
   height:100%;
@@ -6251,8 +6224,7 @@ span.flatpickr-weekday{
 .card-detail-text{
   color:var(--color-neutral-7);
   overflow:hidden;
-  -o-text-overflow:ellipsis;
-     text-overflow:ellipsis;
+  text-overflow:ellipsis;
 }
 .is-rtl .card-detail-left{
   padding-left:var(--space-base);
@@ -6446,7 +6418,6 @@ span.flatpickr-weekday{
   -webkit-transform-style:preserve-3d;
           transform-style:preserve-3d;
   -webkit-transition:all 630ms cubic-bezier(0.03, 0.01, 0.67, 1.97);
-  -o-transition:all 630ms cubic-bezier(0.03, 0.01, 0.67, 1.97);
   transition:all 630ms cubic-bezier(0.03, 0.01, 0.67, 1.97);
 }
 .osui-flip-content__container--flip-self{
@@ -6704,8 +6675,7 @@ span.flatpickr-weekday{
 }
 .list-item-content-title, .list-item-content-text{
   overflow:hidden;
-  -o-text-overflow:ellipsis;
-     text-overflow:ellipsis;
+  text-overflow:ellipsis;
   white-space:nowrap;
 }
 .list-item-content-title{
@@ -6879,7 +6849,6 @@ span.flatpickr-weekday{
   width:-moz-fit-content;
   width:fit-content;
   -webkit-transition:opacity 250ms;
-  -o-transition:opacity 250ms;
   transition:opacity 250ms;
 }
 .osui-tooltip__balloon-wrapper__balloon{
@@ -7201,32 +7170,26 @@ span.flatpickr-weekday{
 }
 .osui-tooltip__balloon-wrapper--is-opening.left{
   -webkit-transition:left 250ms;
-  -o-transition:left 250ms;
   transition:left 250ms;
 }
 .osui-tooltip__balloon-wrapper--is-opening.right{
   -webkit-transition:right 250ms;
-  -o-transition:right 250ms;
   transition:right 250ms;
 }
 .osui-tooltip__balloon-wrapper--is-opening.center{
   -webkit-transition:top 250ms;
-  -o-transition:top 250ms;
   transition:top 250ms;
 }
 .osui-tooltip__balloon-wrapper--is-opening.top, .osui-tooltip__balloon-wrapper--is-opening.top-left, .osui-tooltip__balloon-wrapper--is-opening.top-right{
   -webkit-transition:top 250ms;
-  -o-transition:top 250ms;
   transition:top 250ms;
 }
 .osui-tooltip__balloon-wrapper--is-opening.bottom, .osui-tooltip__balloon-wrapper--is-opening.bottom-left, .osui-tooltip__balloon-wrapper--is-opening.bottom-right{
   -webkit-transition:top 250ms;
-  -o-transition:top 250ms;
   transition:top 250ms;
 }
 .osui-tooltip__balloon-wrapper--is-opening .osui-tooltip__balloon-wrapper__balloon{
   -webkit-transition:opacity 250ms;
-  -o-transition:opacity 250ms;
   transition:opacity 250ms;
 }
 .osui-tooltip__balloon-wrapper--is-open{
@@ -7455,7 +7418,6 @@ span.flatpickr-weekday{
   position:absolute;
   top:0;
   -webkit-transition:opacity 0.3s cubic-bezier(0, 0, 0.3, 1);
-  -o-transition:opacity 0.3s cubic-bezier(0, 0, 0.3, 1);
   transition:opacity 0.3s cubic-bezier(0, 0, 0.3, 1);
   width:100%;
   will-change:opacity;
@@ -7476,12 +7438,10 @@ span.flatpickr-weekday{
 }
 .action-sheet-container--visible.action-sheet-container--animatable .action-sheet{
   -webkit-transition:all 330ms ease-out;
-  -o-transition:all 330ms ease-out;
   transition:all 330ms ease-out;
 }
 .action-sheet-container--animatable .action-sheet{
   -webkit-transition:all 130ms ease-in;
-  -o-transition:all 130ms ease-in;
   transition:all 130ms ease-in;
 }
 .action-sheet-buttons{
@@ -7531,7 +7491,6 @@ span.flatpickr-weekday{
           animation-fill-mode:both;
   display:inline-block;
   -webkit-transition-timing-function:ease-out;
-       -o-transition-timing-function:ease-out;
           transition-timing-function:ease-out;
   visibility:hidden;
   width:100%;
@@ -7624,7 +7583,6 @@ span.flatpickr-weekday{
   position:absolute;
   top:8px;
   -webkit-transition:all 300ms ease;
-  -o-transition:all 300ms ease;
   transition:all 300ms ease;
   z-index:var(--layer-global-screen);
 }
@@ -7645,7 +7603,6 @@ span.flatpickr-weekday{
   border-radius:var(--border-radius-none);
   padding:var(--space-none);
   -webkit-transition:all 100ms ease-in-out;
-  -o-transition:all 100ms ease-in-out;
   transition:all 100ms ease-in-out;
 }
 .animated-label-input .form-control[data-input]:focus, .animated-label-input .form-control[data-textarea]:focus{
@@ -7727,7 +7684,6 @@ span.flatpickr-weekday{
   text-align:center;
   -webkit-transition:-webkit-transform 350ms var(--osui-bottom-sheet-transition-function);
   transition:-webkit-transform 350ms var(--osui-bottom-sheet-transition-function);
-  -o-transition:transform 350ms var(--osui-bottom-sheet-transition-function);
   transition:transform 350ms var(--osui-bottom-sheet-transition-function);
   transition:transform 350ms var(--osui-bottom-sheet-transition-function), -webkit-transform 350ms var(--osui-bottom-sheet-transition-function);
   -webkit-transform:translateY(100%);
@@ -7790,13 +7746,11 @@ span.flatpickr-weekday{
 .osui-bottom-sheet:not(.osui-bottom-sheet--is-open){
   -webkit-transition:-webkit-transform 200ms ease-out;
   transition:-webkit-transform 200ms ease-out;
-  -o-transition:transform 200ms ease-out;
   transition:transform 200ms ease-out;
   transition:transform 200ms ease-out, -webkit-transform 200ms ease-out;
 }
 .osui-bottom-sheet:not(.osui-bottom-sheet--is-open) + .osui-bottom-sheet-overlay{
   -webkit-transition:opacity 200ms ease-out;
-  -o-transition:opacity 200ms ease-out;
   transition:opacity 200ms ease-out;
 }
 .osui-bottom-sheet-overlay{
@@ -7808,7 +7762,6 @@ span.flatpickr-weekday{
   position:fixed;
   top:0;
   -webkit-transition:opacity 350ms ease-in;
-  -o-transition:opacity 350ms ease-in;
   transition:opacity 350ms ease-in;
   width:100vw;
   z-index:calc(var(--layer-below) + var(--osui-bottom-sheet-layer));
@@ -7843,7 +7796,6 @@ span.flatpickr-weekday{
           transform:translateY(-2px);
   -webkit-transition:opacity 200ms ease, -webkit-transform 200ms var(--osui-bottom-sheet-transition-function);
   transition:opacity 200ms ease, -webkit-transform 200ms var(--osui-bottom-sheet-transition-function);
-  -o-transition:opacity 200ms ease, transform 200ms var(--osui-bottom-sheet-transition-function);
   transition:opacity 200ms ease, transform 200ms var(--osui-bottom-sheet-transition-function);
   transition:opacity 200ms ease, transform 200ms var(--osui-bottom-sheet-transition-function), -webkit-transform 200ms var(--osui-bottom-sheet-transition-function);
   top:0;
@@ -7891,7 +7843,6 @@ span.flatpickr-weekday{
   height:40px;
   opacity:1;
   -webkit-transition:opacity 150ms linear;
-  -o-transition:opacity 150ms linear;
   transition:opacity 150ms linear;
   width:40px;
   will-change:opacity;
@@ -8346,7 +8297,6 @@ span.flatpickr-weekday{
 .safari input.flatpickr-input,
 .safari input.flatpickr-input + input{
   -webkit-transition:none;
-  -o-transition:none;
   transition:none;
 }
 .phone .flatpickr-current-month .flatpickr-monthDropdown-months,
@@ -8709,7 +8659,6 @@ html[data-uieditorversion^="1"] .osui-datepicker-calendar-ss-preview.has-today-b
   margin-right:var(--space-s);
   overflow:visible;
   -webkit-transition:background-color 0.25s ease;
-  -o-transition:background-color 0.25s ease;
   transition:background-color 0.25s ease;
   width:16px;
 }
@@ -8720,7 +8669,6 @@ html[data-uieditorversion^="1"] .osui-datepicker-calendar-ss-preview.has-today-b
   height:85%;
   opacity:0;
   -webkit-transition:opacity 0.25s ease;
-  -o-transition:opacity 0.25s ease;
   transition:opacity 0.25s ease;
   width:40%;
 }
@@ -8757,7 +8705,6 @@ html[data-uieditorversion^="1"] .osui-datepicker-calendar-ss-preview.has-today-b
   padding:var(--space-xs) var(--space-xl) var(--space-xs) var(--space-base);
   position:relative;
   -webkit-transition:height, border-color 0.25s ease;
-  -o-transition:height, border-color 0.25s ease;
   transition:height, border-color 0.25s ease;
   vertical-align:middle;
   width:100%;
@@ -8776,7 +8723,6 @@ html[data-uieditorversion^="1"] .osui-datepicker-calendar-ss-preview.has-today-b
       -ms-transform-origin:center;
           transform-origin:center;
   -webkit-transition:all 0.25s ease;
-  -o-transition:all 0.25s ease;
   transition:all 0.25s ease;
 }
 .vscomp-toggle-button:hover{
@@ -8886,7 +8832,6 @@ html[data-uieditorversion^="1"] .osui-datepicker-calendar-ss-preview.has-today-b
       align-content:center;
   background-color:var(--color-neutral-0);
   -webkit-transition:background-color 0.25s ease;
-  -o-transition:background-color 0.25s ease;
   transition:background-color 0.25s ease;
 }
 .vscomp-option.focused, .vscomp-option.selected{
@@ -9102,10 +9047,8 @@ body.vscomp-popup-active .vscomp-wrapper{
   -webkit-transform:translateY(0px) translateZ(0) scale(1);
           transform:translateY(0px) translateZ(0) scale(1);
   -webkit-transition:all 180ms ease-out;
-  -o-transition:all 180ms ease-out;
   transition:all 180ms ease-out;
   -webkit-transition-delay:calc(var(--delay) * 40ms);
-       -o-transition-delay:calc(var(--delay) * 40ms);
           transition-delay:calc(var(--delay) * 40ms);
 }
 .floating-actions-wrapper.is--open .floating-actions-item-button{
@@ -9160,7 +9103,6 @@ body.vscomp-popup-active .vscomp-wrapper{
   -webkit-transform:translateY(--space-base) translateZ(0);
           transform:translateY(--space-base) translateZ(0);
   -webkit-transition:all 100ms ease-in;
-  -o-transition:all 100ms ease-in;
   transition:all 100ms ease-in;
 }
 .floating-actions-item{
@@ -9190,11 +9132,9 @@ body.vscomp-popup-active .vscomp-wrapper{
           transform:translateZ(0) scale(0.3);
   -webkit-transition:-webkit-transform 180ms ease-out;
   transition:-webkit-transform 180ms ease-out;
-  -o-transition:transform 180ms ease-out;
   transition:transform 180ms ease-out;
   transition:transform 180ms ease-out, -webkit-transform 180ms ease-out;
   -webkit-transition-delay:calc(var(--delay) * 40ms);
-       -o-transition-delay:calc(var(--delay) * 40ms);
           transition-delay:calc(var(--delay) * 40ms);
   width:40px;
 }
@@ -9230,7 +9170,6 @@ body.vscomp-popup-active .vscomp-wrapper{
       -ms-transform-origin:center center;
           transform-origin:center center;
   -webkit-transition:all 180ms linear;
-  -o-transition:all 180ms linear;
   transition:all 180ms linear;
   width:56px;
 }
@@ -9248,7 +9187,6 @@ body.vscomp-popup-active .vscomp-wrapper{
   right:0;
   top:0;
   -webkit-transition:opacity 180ms ease-out;
-  -o-transition:opacity 180ms ease-out;
   transition:opacity 180ms ease-out;
   width:100vw;
   z-index:var(--osui-floating-actions-layer);
@@ -9542,7 +9480,6 @@ body.vscomp-popup-active .vscomp-wrapper{
   position:fixed;
   -webkit-transition:opacity 300ms ease-out, -webkit-transform 300ms ease-out;
   transition:opacity 300ms ease-out, -webkit-transform 300ms ease-out;
-  -o-transition:transform 300ms ease-out, opacity 300ms ease-out;
   transition:transform 300ms ease-out, opacity 300ms ease-out;
   transition:transform 300ms ease-out, opacity 300ms ease-out, -webkit-transform 300ms ease-out;
   -webkit-user-select:none;
@@ -9729,7 +9666,6 @@ body.vscomp-popup-active .vscomp-wrapper{
   height:var(--range-slider-handle-size);
   -webkit-transition:-webkit-transform 150ms ease-out;
   transition:-webkit-transform 150ms ease-out;
-  -o-transition:transform 150ms ease-out;
   transition:transform 150ms ease-out;
   transition:transform 150ms ease-out, -webkit-transform 150ms ease-out;
   width:var(--range-slider-handle-size);
@@ -10058,7 +9994,6 @@ body.vscomp-popup-active .vscomp-wrapper{
   right:13px;
   top:50%;
   -webkit-transition:all 300ms ease;
-  -o-transition:all 300ms ease;
   transition:all 300ms ease;
   width:16px;
 }
@@ -10073,7 +10008,6 @@ body.vscomp-popup-active .vscomp-wrapper{
       -ms-transform:rotate(-45deg);
           transform:rotate(-45deg);
   -webkit-transition:all 300ms ease;
-  -o-transition:all 300ms ease;
   transition:all 300ms ease;
   width:3px;
 }
@@ -10086,14 +10020,12 @@ body.vscomp-popup-active .vscomp-wrapper{
       -ms-transform:translate(0, calc(-100% - var(--os-safe-area-top)));
           transform:translate(0, calc(-100% - var(--os-safe-area-top)));
   -webkit-transition:all 300ms ease;
-  -o-transition:all 300ms ease;
   transition:all 300ms ease;
 }
 .layout-native .header-right .search-input input[data-input], .layout-native .header-right .search-input input[data-input]:empty{
   height:34px;
   padding-left:var(--space-xl);
   -webkit-transition:none;
-  -o-transition:none;
   transition:none;
 }
 .layout-native .header-right .search-input input[data-input]:focus{
@@ -10136,7 +10068,6 @@ body.vscomp-popup-active .vscomp-wrapper{
   position:fixed;
   top:0;
   -webkit-transition:all 130ms ease-in;
-  -o-transition:all 130ms ease-in;
   transition:all 130ms ease-in;
   width:var(--sidebar-width);
   will-change:transform;
@@ -10214,7 +10145,6 @@ body.vscomp-popup-active .vscomp-wrapper{
   position:fixed;
   top:0;
   -webkit-transition:opacity 130ms ease-in;
-  -o-transition:opacity 130ms ease-in;
   transition:opacity 130ms ease-in;
   width:200vw;
   will-change:opacity;
@@ -10237,7 +10167,6 @@ body.vscomp-popup-active .vscomp-wrapper{
           transform:none;
   -webkit-transition:-webkit-transform 330ms ease-out;
   transition:-webkit-transform 330ms ease-out;
-  -o-transition:transform 330ms ease-out;
   transition:transform 330ms ease-out;
   transition:transform 330ms ease-out, -webkit-transform 330ms ease-out;
   will-change:transform;
@@ -10340,7 +10269,6 @@ body.vscomp-popup-active .vscomp-wrapper{
 }
 .stackedcards--animatable{
   -webkit-transition:all 400ms ease;
-  -o-transition:all 400ms ease;
   transition:all 400ms ease;
 }
 .stackedcards .init{
@@ -10649,8 +10577,7 @@ html[data-uieditorversion^="1"] .osui-timepicker__dropdown-ss-preview.time12h, h
 .bottom-bar-item-text{
   font-size:10px;
   overflow:hidden;
-  -o-text-overflow:ellipsis;
-     text-overflow:ellipsis;
+  text-overflow:ellipsis;
   white-space:nowrap;
   word-wrap:break-word;
 }
@@ -10988,7 +10915,6 @@ html[data-uieditorversion^="1"] .osui-timepicker__dropdown-ss-preview.time12h, h
   display:flex;
   padding:var(--space-none) var(--space-s);
   -webkit-transition:all 150ms linear;
-  -o-transition:all 150ms linear;
   transition:all 150ms linear;
 }
 .osui-submenu__header__icon{
@@ -11000,7 +10926,6 @@ html[data-uieditorversion^="1"] .osui-timepicker__dropdown-ss-preview.time12h, h
       -ms-transform:rotate(-45deg);
           transform:rotate(-45deg);
   -webkit-transition:all 150ms linear;
-  -o-transition:all 150ms linear;
   transition:all 150ms linear;
 }
 .osui-submenu__header__icon:before{
@@ -11012,7 +10937,6 @@ html[data-uieditorversion^="1"] .osui-timepicker__dropdown-ss-preview.time12h, h
   content:"";
   height:6px;
   -webkit-transition:all 150ms linear;
-  -o-transition:all 150ms linear;
   transition:all 150ms linear;
   width:6px;
 }
@@ -11027,7 +10951,6 @@ html[data-uieditorversion^="1"] .osui-timepicker__dropdown-ss-preview.time12h, h
   height:100%;
   position:relative;
   -webkit-transition:all 150ms linear;
-  -o-transition:all 150ms linear;
   transition:all 150ms linear;
   -servicestudio-min-width:100px;
   -servicestudio-margin-left:calc(var(--space-s) * -1);
@@ -11069,7 +10992,6 @@ html[data-uieditorversion^="1"] .osui-timepicker__dropdown-ss-preview.time12h, h
       -ms-transform:translateY(-8px);
           transform:translateY(-8px);
   -webkit-transition:all 130ms ease-out;
-  -o-transition:all 130ms ease-out;
   transition:all 130ms ease-out;
   z-index:var(--layer-global-elevated);
 }
@@ -11415,7 +11337,6 @@ html[data-uieditorversion^="1"] .osui-timepicker__dropdown-ss-preview.time12h, h
   position:absolute;
   -webkit-transition:-webkit-transform 200ms linear;
   transition:-webkit-transform 200ms linear;
-  -o-transition:transform 200ms linear;
   transition:transform 200ms linear;
   transition:transform 200ms linear, -webkit-transform 200ms linear;
   -webkit-transform-origin:0 0;
@@ -11975,12 +11896,10 @@ html[data-uieditorversion^="1"] .wizard-wrapper-item{
 }
 .osui-progress-bar__container.animate-entrance .osui-progress-bar__value:before{
   -webkit-transition-delay:0.5s;
-       -o-transition-delay:0.5s;
           transition-delay:0.5s;
 }
 .osui-progress-bar__container.animate-entrance .osui-progress-bar__value:before, .osui-progress-bar__container.animate-progress-change .osui-progress-bar__value:before{
   -webkit-transition-duration:0.35s;
-       -o-transition-duration:0.35s;
           transition-duration:0.35s;
 }
 .osui-progress-bar__value{
@@ -12089,17 +12008,14 @@ html[data-uieditorversion^="1"] .wizard-wrapper-item{
   stroke-dashoffset:var(--stroke-dashoffset);
   stroke-linecap:var(--shape);
   -webkit-transition:stroke-dashoffset 0;
-  -o-transition:stroke-dashoffset 0;
   transition:stroke-dashoffset 0;
 }
 .osui-progress-circle__container__progress-path.animate-entrance, .osui-progress-circle__container__progress-path.animate-progress-change{
   -webkit-transition-duration:0.35s;
-       -o-transition-duration:0.35s;
           transition-duration:0.35s;
 }
 .osui-progress-circle__container__progress-path.animate-entrance{
   -webkit-transition-delay:0.5s;
-       -o-transition-delay:0.5s;
           transition-delay:0.5s;
 }
 .osui-progress-circle__container__trail-path{
@@ -12179,7 +12095,6 @@ html[data-uieditorversion^="1"] .wizard-wrapper-item{
   position:absolute;
   top:0;
   -webkit-transition:opacity linear 150ms;
-  -o-transition:opacity linear 150ms;
   transition:opacity linear 150ms;
 }
 .rating-item-filled, .rating-item-half, .rating-item-empty{
@@ -12319,7 +12234,6 @@ html[data-uieditorversion^="1"] .wizard-wrapper-item{
   display:-ms-inline-flexbox;
   display:inline-flex;
   -webkit-transition:none;
-  -o-transition:none;
   transition:none;
   vertical-align:middle;
   white-space:nowrap;
@@ -12452,14 +12366,12 @@ html[data-uieditorversion^="1"] .wizard-wrapper-item{
 }
 .pull-to-refresh .genericon{
   -webkit-transition:all 0.25s ease;
-  -o-transition:all 0.25s ease;
   transition:all 0.25s ease;
 }
 .ptr-loading .content,
 .ptr-loading .pull-to-refresh, .ptr-reset .content,
 .ptr-reset .pull-to-refresh{
   -webkit-transition:all 0.25s ease;
-  -o-transition:all 0.25s ease;
   transition:all 0.25s ease;
 }
 .ptr-loading .pull-to-refresh .genericon, .ptr-reset .pull-to-refresh .genericon{
@@ -12559,7 +12471,6 @@ html[data-uieditorversion^="1"] .wizard-wrapper-item{
   top:0;
   -webkit-transition:-webkit-transform 200ms ease-in-out;
   transition:-webkit-transform 200ms ease-in-out;
-  -o-transition:transform 200ms ease-in-out;
   transition:transform 200ms ease-in-out;
   transition:transform 200ms ease-in-out, -webkit-transform 200ms ease-in-out;
 }
@@ -12571,8 +12482,7 @@ html[data-uieditorversion^="1"] .wizard-wrapper-item{
 }
 .osui-dropdown-serverside__selected-values > *:first-child{
   overflow:hidden;
-  -o-text-overflow:ellipsis;
-     text-overflow:ellipsis;
+  text-overflow:ellipsis;
   white-space:nowrap;
   width:100%;
 }
@@ -12593,7 +12503,6 @@ html[data-uieditorversion^="1"] .wizard-wrapper-item{
   padding:var(--space-none) var(--space-base);
   position:relative;
   -webkit-transition:border 250ms ease-in-out;
-  -o-transition:border 250ms ease-in-out;
   transition:border 250ms ease-in-out;
   width:100%;
 }
@@ -12619,7 +12528,6 @@ html[data-uieditorversion^="1"] .wizard-wrapper-item{
   overflow:hidden;
   position:absolute;
   -webkit-transition:opacity 300ms ease;
-  -o-transition:opacity 300ms ease;
   transition:opacity 300ms ease;
   width:100%;
   z-index:var(--layer-global-elevated);
@@ -12650,7 +12558,6 @@ html[data-uieditorversion^="1"] .wizard-wrapper-item{
           transform:translateY(calc(-1 * var(--osui-dropdown-ss-thresholdanimateval)));
   -webkit-transition:opacity 250ms ease, -webkit-transform 300ms ease-in-out;
   transition:opacity 250ms ease, -webkit-transform 300ms ease-in-out;
-  -o-transition:opacity 250ms ease, transform 300ms ease-in-out;
   transition:opacity 250ms ease, transform 300ms ease-in-out;
   transition:opacity 250ms ease, transform 300ms ease-in-out, -webkit-transform 300ms ease-in-out;
 }
@@ -12750,7 +12657,6 @@ html[data-uieditorversion^="1"] .wizard-wrapper-item{
       -ms-transform:translateY(0);
           transform:translateY(0);
   -webkit-transition:opacity 250ms ease;
-  -o-transition:opacity 250ms ease;
   transition:opacity 250ms ease;
 }
 .osui-dropdown-serverside__balloon--is-top .osui-dropdown-serverside__balloon-content{
@@ -12887,7 +12793,6 @@ body:has(.popup-dialog):has(.osui-dropdown-serverside--is-opened) .osui-dropdown
   overflow:hidden;
   top:0;
   -webkit-transition:opacity 250ms ease;
-  -o-transition:opacity 250ms ease;
   transition:opacity 250ms ease;
 }
 .phone .osui-dropdown-serverside__balloon-wrapper{
@@ -12937,7 +12842,6 @@ body:has(.popup-dialog):has(.osui-dropdown-serverside--is-opened) .osui-dropdown
   padding:var(--space-s) var(--space-base);
   position:relative;
   -webkit-transition:background 250ms ease;
-  -o-transition:background 250ms ease;
   transition:background 250ms ease;
   width:100%;
   z-index:0;
@@ -12965,8 +12869,7 @@ body:has(.popup-dialog):has(.osui-dropdown-serverside--is-opened) .osui-dropdown
 }
 .osui-dropdown-serverside-item__content > *:first-child{
   overflow:hidden;
-  -o-text-overflow:ellipsis;
-     text-overflow:ellipsis;
+  text-overflow:ellipsis;
   white-space:nowrap;
   width:100%;
 }
@@ -13035,7 +12938,6 @@ body:has(.popup-dialog):has(.osui-dropdown-serverside--is-opened) .osui-dropdown
   font-size:24px;
   font-weight:400;
   -webkit-transition:all 300ms ease-in-out;
-  -o-transition:all 300ms ease-in-out;
   transition:all 300ms ease-in-out;
 }
 .section-expandable .section-expandable-icon:after{
@@ -13061,7 +12963,6 @@ body:has(.popup-dialog):has(.osui-dropdown-serverside--is-opened) .osui-dropdown
 }
 .section-expandable .section-expandable-content-animating, .section-expandable .section-expandable-content.is--animating{
   -webkit-transition:all 300ms ease-in-out;
-  -o-transition:all 300ms ease-in-out;
   transition:all 300ms ease-in-out;
 }
 .section-expandable .section-expandable-content.no-padding{
@@ -13163,7 +13064,6 @@ button.OSFillParent{
   overflow:hidden;
   position:relative;
   -webkit-transition:all 400ms ease;
-  -o-transition:all 400ms ease;
   transition:all 400ms ease;
   will-change:transform;
 }
@@ -13207,7 +13107,6 @@ button.OSFillParent{
 }
 .carousel--animatable{
   -webkit-transition:all 250ms linear;
-  -o-transition:all 250ms linear;
   transition:all 250ms linear;
   will-change:transform;
 }
@@ -13293,7 +13192,6 @@ button.OSFillParent{
       -ms-transform:translateY(-25px);
           transform:translateY(-25px);
   -webkit-transition:opacity 150ms linear;
-  -o-transition:opacity 150ms linear;
   transition:opacity 150ms linear;
   width:40px;
   will-change:opacity;
@@ -13334,7 +13232,6 @@ button.OSFillParent{
 .carousel-is-moving .hide-on-drag{
   opacity:0;
   -webkit-transition:opacity 250ms ease;
-  -o-transition:opacity 250ms ease;
   transition:opacity 250ms ease;
 }
 .carousel .list.list-group{
@@ -13847,7 +13744,6 @@ input.OSFillParent.calendar-input{
   line-height:calc(var(--font-size-base) * 2);
   padding-left:var(--space-base);
   -webkit-transition:all 180ms linear;
-  -o-transition:all 180ms linear;
   transition:all 180ms linear;
   vertical-align:top;
   width:100%;
@@ -14011,7 +13907,6 @@ input.OSFillParent.calendar-input{
   height:40px;
   padding:var(--space-none) var(--space-base);
   -webkit-transition:all 180ms linear;
-  -o-transition:all 180ms linear;
   transition:all 180ms linear;
 }
 .section-expandable-content .choices__list--dropdown.is-active{
@@ -14096,7 +13991,6 @@ input.OSFillParent.calendar-input{
       -ms-transform-origin:center;
           transform-origin:center;
   -webkit-transition:all 300ms ease;
-  -o-transition:all 300ms ease;
   transition:all 300ms ease;
 }
 .choices[data-type*=select-one].is-open:after{
@@ -14138,8 +14032,7 @@ input.OSFillParent.calendar-input{
   color:var(--color-neutral-10);
   overflow:hidden;
   padding-right:var(--space-base);
-  -o-text-overflow:ellipsis;
-     text-overflow:ellipsis;
+  text-overflow:ellipsis;
   white-space:nowrap;
   width:99%;
 }
@@ -14299,7 +14192,6 @@ input.OSFillParent.calendar-input{
 .flip-content-container{
   position:relative;
   -webkit-transition:all 630ms cubic-bezier(0.03, 0.01, 0.67, 1.97);
-  -o-transition:all 630ms cubic-bezier(0.03, 0.01, 0.67, 1.97);
   transition:all 630ms cubic-bezier(0.03, 0.01, 0.67, 1.97);
   -webkit-transform-style:preserve-3d;
   transform-style:preserve-3d;
@@ -14449,12 +14341,10 @@ input.OSFillParent.calendar-input{
 }
 .notification--visible.notification--animatable{
   -webkit-transition:all 330ms ease-out;
-  -o-transition:all 330ms ease-out;
   transition:all 330ms ease-out;
 }
 .notification--animatable{
   -webkit-transition:all 130ms ease-in;
-  -o-transition:all 130ms ease-in;
   transition:all 130ms ease-in;
 }
 .layout-native .notification{
@@ -14513,7 +14403,6 @@ input.OSFillParent.calendar-input{
       -ms-transform-origin:left;
           transform-origin:left;
   -webkit-transition:all 750ms ease-out;
-  -o-transition:all 750ms ease-out;
   transition:all 750ms ease-out;
   will-change:width;
 }
@@ -14657,7 +14546,6 @@ input.OSFillParent.calendar-input{
       -ms-transform:translateX(102%);
           transform:translateX(102%);
   -webkit-transition:all 130ms ease-in;
-  -o-transition:all 130ms ease-in;
   transition:all 130ms ease-in;
   width:500px;
   will-change:transform;
@@ -14694,7 +14582,6 @@ input.OSFillParent.calendar-input{
       -ms-transform:none;
           transform:none;
   -webkit-transition:all 330ms ease-out;
-  -o-transition:all 330ms ease-out;
   transition:all 330ms ease-out;
   will-change:transform;
 }
@@ -14791,7 +14678,6 @@ input.OSFillParent.calendar-input{
   display:flex;
   padding:var(--space-none) var(--space-s);
   -webkit-transition:all 150ms linear;
-  -o-transition:all 150ms linear;
   transition:all 150ms linear;
 }
 .submenu-icon{
@@ -14803,7 +14689,6 @@ input.OSFillParent.calendar-input{
       -ms-transform:rotate(-45deg);
           transform:rotate(-45deg);
   -webkit-transition:all 150ms linear;
-  -o-transition:all 150ms linear;
   transition:all 150ms linear;
 }
 .submenu-icon:before{
@@ -14815,7 +14700,6 @@ input.OSFillParent.calendar-input{
   content:"";
   height:6px;
   -webkit-transition:all 150ms linear;
-  -o-transition:all 150ms linear;
   transition:all 150ms linear;
   width:6px;
 }
@@ -14830,7 +14714,6 @@ input.OSFillParent.calendar-input{
   height:100%;
   position:relative;
   -webkit-transition:all 150ms linear;
-  -o-transition:all 150ms linear;
   transition:all 150ms linear;
 }
 .submenu-item a{
@@ -14867,7 +14750,6 @@ input.OSFillParent.calendar-input{
       -ms-transform:translateY(-8px);
           transform:translateY(-8px);
   -webkit-transition:all 130ms ease-out;
-  -o-transition:all 130ms ease-out;
   transition:all 130ms ease-out;
   z-index:var(--layer-global-elevated);
 }
@@ -15143,7 +15025,6 @@ input.OSFillParent.calendar-input{
   margin-left:var(--space-l);
   padding:var(--space-base) var(--space-xs);
   -webkit-transition:border 150ms linear;
-  -o-transition:border 150ms linear;
   transition:border 150ms linear;
   white-space:nowrap;
 }
@@ -15200,7 +15081,6 @@ input.OSFillParent.calendar-input{
 .layout-native .tabs-content-wrapper{
   -webkit-transition:-webkit-transform 230ms ease-in-out;
   transition:-webkit-transform 230ms ease-in-out;
-  -o-transition:transform 230ms ease-in-out;
   transition:transform 230ms ease-in-out;
   transition:transform 230ms ease-in-out, -webkit-transform 230ms ease-in-out;
 }
@@ -16270,8 +16150,7 @@ input.OSFillParent.calendar-input{
 }
 .text-ellipsis{
   overflow:hidden;
-  -o-text-overflow:ellipsis;
-     text-overflow:ellipsis;
+  text-overflow:ellipsis;
   white-space:nowrap;
 }
 /*! 7.9. Border Size */
@@ -17454,7 +17333,6 @@ img.thumbnail{
 /*! 7.24. Miscellaneous */
 .no-transition{
   -webkit-transition:none !important;
-  -o-transition:none !important;
   transition:none !important;
 }
 .no-transform{
@@ -17512,7 +17390,6 @@ img.thumbnail{
 .fade-leave.fade-leave-active{
   -webkit-transition:opacity 400ms ease-in-out, -webkit-transform 400ms ease-in-out;
   transition:opacity 400ms ease-in-out, -webkit-transform 400ms ease-in-out;
-  -o-transition:transform 400ms ease-in-out, opacity 400ms ease-in-out;
   transition:transform 400ms ease-in-out, opacity 400ms ease-in-out;
   transition:transform 400ms ease-in-out, opacity 400ms ease-in-out, -webkit-transform 400ms ease-in-out;
 }
@@ -17528,7 +17405,6 @@ img.thumbnail{
 .fade-leave.fade-leave-active .content{
   -webkit-transition:opacity 400ms ease-in-out, -webkit-transform 400ms ease-in-out;
   transition:opacity 400ms ease-in-out, -webkit-transform 400ms ease-in-out;
-  -o-transition:transform 400ms ease-in-out, opacity 400ms ease-in-out;
   transition:transform 400ms ease-in-out, opacity 400ms ease-in-out;
   transition:transform 400ms ease-in-out, opacity 400ms ease-in-out, -webkit-transform 400ms ease-in-out;
 }
@@ -17605,7 +17481,6 @@ img.thumbnail{
 .fade-enter.fade-enter-active .header{
   -webkit-transition:opacity 400ms ease-in-out, -webkit-transform 400ms ease-in-out;
   transition:opacity 400ms ease-in-out, -webkit-transform 400ms ease-in-out;
-  -o-transition:transform 400ms ease-in-out, opacity 400ms ease-in-out;
   transition:transform 400ms ease-in-out, opacity 400ms ease-in-out;
   transition:transform 400ms ease-in-out, opacity 400ms ease-in-out, -webkit-transform 400ms ease-in-out;
 }
@@ -17616,7 +17491,6 @@ img.thumbnail{
 .fade-leave.fade-leave-active{
   opacity:0;
   -webkit-transition:all 400ms ease-in-out;
-  -o-transition:all 400ms ease-in-out;
   transition:all 400ms ease-in-out;
 }
 .fade-leave.fade-leave-active .header{
@@ -17624,7 +17498,6 @@ img.thumbnail{
   -webkit-transform:translateY(-200px) translateZ(0);
           transform:translateY(-200px) translateZ(0);
   -webkit-transition:none;
-  -o-transition:none;
   transition:none;
 }
 .fade-leave.screen-container{

--- a/dist/OutSystemsUI.d.ts
+++ b/dist/OutSystemsUI.d.ts
@@ -5016,7 +5016,7 @@ declare namespace Providers.OSUI.Dropdown.VirtualSelect {
 declare namespace Providers.OSUI.Dropdown.VirtualSelect.Enum {
     enum ProviderInfo {
         Name = "VirtualSelect",
-        Version = "1.0.37"
+        Version = "1.0.39"
     }
     enum CssClass {
         ErrorMessage = "osui-dropdown-error-message",

--- a/dist/OutSystemsUI.js
+++ b/dist/OutSystemsUI.js
@@ -17729,7 +17729,7 @@ var Providers;
                     let ProviderInfo;
                     (function (ProviderInfo) {
                         ProviderInfo["Name"] = "VirtualSelect";
-                        ProviderInfo["Version"] = "1.0.37";
+                        ProviderInfo["Version"] = "1.0.39";
                     })(ProviderInfo = Enum.ProviderInfo || (Enum.ProviderInfo = {}));
                     let CssClass;
                     (function (CssClass) {

--- a/dist/OutSystemsUI.js
+++ b/dist/OutSystemsUI.js
@@ -17676,6 +17676,7 @@ var Providers;
                             options: this._getOptionsList(),
                             placeholder: this.Prompt,
                             search: true,
+                            searchNormalize: true,
                             searchPlaceholderText: this.SearchPrompt,
                             selectAllOnlyVisible: true,
                             selectedValue: this.getSelectedValues(),

--- a/package.json
+++ b/package.json
@@ -64,6 +64,6 @@
 		"typedoc-plugin-merge-modules": "^4.0.1",
 		"typedoc-umlclass": "^0.7.0",
 		"typescript": "^4.5.0",
-		"virtual-select-plugin": "^1.0.37"
+		"virtual-select-plugin": "1.0.39"
 	}
 }

--- a/src/scripts/Providers/OSUI/Dropdown/VirtualSelect/AbstractVirtualSelectConfig.ts
+++ b/src/scripts/Providers/OSUI/Dropdown/VirtualSelect/AbstractVirtualSelectConfig.ts
@@ -190,6 +190,7 @@ namespace Providers.OSUI.Dropdown.VirtualSelect {
 				options: this._getOptionsList() as [],
 				placeholder: this.Prompt,
 				search: true,
+				searchNormalize: true,
 				searchPlaceholderText: this.SearchPrompt,
 				selectAllOnlyVisible: true,
 				selectedValue: this.getSelectedValues() as [],

--- a/src/scripts/Providers/OSUI/Dropdown/VirtualSelect/AbstractVirtualSelectEnum.ts
+++ b/src/scripts/Providers/OSUI/Dropdown/VirtualSelect/AbstractVirtualSelectEnum.ts
@@ -5,7 +5,7 @@ namespace Providers.OSUI.Dropdown.VirtualSelect.Enum {
 	 */
 	export enum ProviderInfo {
 		Name = 'VirtualSelect',
-		Version = '1.0.37',
+		Version = '1.0.39',
 	}
 
 	/**

--- a/src/scripts/Providers/OSUI/Dropdown/VirtualSelect/README.md
+++ b/src/scripts/Providers/OSUI/Dropdown/VirtualSelect/README.md
@@ -1,3 +1,3 @@
-# VirtualSelect · ![virtualselect version](https://img.shields.io/badge/version-v1.0.37-informational)
+# VirtualSelect · ![virtualselect version](https://img.shields.io/badge/version-v1.0.39-informational)
 
 All info about this Provider <a href="https://sa-si-dev.github.io/virtual-select/#/">here</a>.

--- a/src/scripts/Providers/OSUI/Dropdown/VirtualSelect/VirtualSelect.d.ts
+++ b/src/scripts/Providers/OSUI/Dropdown/VirtualSelect/VirtualSelect.d.ts
@@ -95,6 +95,7 @@ namespace Providers.OSUI.Dropdown.VirtualSelect {
 		popupDropboxBreakpoint?: string;
 		position?: string;
 		search?: boolean;
+		searchNormalize?: boolean;
 		searchPlaceholderText?: string;
 		selectAllOnlyVisible?: boolean;
 		selectAllText?: string;

--- a/src/scripts/Providers/OSUI/Dropdown/VirtualSelect/scss/_virtualselect_lib.scss
+++ b/src/scripts/Providers/OSUI/Dropdown/VirtualSelect/scss/_virtualselect_lib.scss
@@ -1,5 +1,5 @@
 /*!
- * Virtual Select v1.0.37
+ * Virtual Select v1.0.39
  * https://sa-si-dev.github.io/virtual-select
  * Licensed under MIT (https://github.com/sa-si-dev/virtual-select/blob/master/LICENSE)
  */
@@ -241,6 +241,18 @@
 	height: 40px;
 	padding: 0 5px 0 15px;
 	position: relative;
+}
+.vscomp-search-label,
+.vscomp-live-region {
+	border: 0;
+	clip: rect(0 0 0 0);
+	height: 1px;
+	margin: -1px;
+	overflow: hidden;
+	padding: 0;
+	position: absolute;
+	white-space: nowrap;
+	width: 1px;
 }
 .vscomp-search-input {
 	background-color: rgba(0, 0, 0, 0);


### PR DESCRIPTION
This PR is to update Virtual Select v1.0.39 and add the ability to allow a normalized search (ignoring diacritics).

### What was done

- Now, Dropdown Search and Dropdown Tags will be using the latest version of their library provider (VirtualSelect v1.0.39).
This version also brings new extensibility configurations that were added to the VirtualSelectConfigs structure that contains the properties available on the SetVirtualSelectConfigs client action - _ariaLabelText, emptyValue, search, searchFormLabel, searchGroup, searchNormalize, showDropboxAsPopup, textDirection_.
- Now, Dropdown Search and Dropdown Tags components will allow a normalized search (ignoring diacritics).

### Test Steps

**Test Case 1 - Regression and Normalized Search:**

1. Go to ests_DropdownSearch
2. Run regression tests
3. Search by `Gonc` and check that we can get `Gonçalo`
4. Repeated the same tests on Tests_DropdownTags 


**Test Case 2 - Extensibility:**

1. Go to Tests_DropdownSearch
2. Go to the Manual SetProviderConfigs section
3. Tested the following options:
    - ariaLabelText
    - emptyValue
    - search
    - searchFormLabel
    - searchGroup
    - searchNormalize
    - showDropboxAsPopup 
    - textDirection
4. Repeated the same tests on Tests_DropdownTags 



### Checklist

-   [X] tested locally
-   [X] documented the code
-   [X] clean all warnings and errors of eslint
-   [X] requires changes in OutSystems
-   [ ] requires new sample page in OutSystems (if so, provide a module with changes)
