### PR TITLE
Fix OverflowMenu feature dispose

### DIFF
--- a/dist/OutSystemsUI.js
+++ b/dist/OutSystemsUI.js
@@ -1897,7 +1897,8 @@ var OSFramework;
                         }
                     }
                     dispose() {
-                        this._floatingInstance.dispose();
+                        var _a;
+                        (_a = this._floatingInstance) === null || _a === void 0 ? void 0 : _a.dispose();
                         this._unsetCallbacks();
                         super.dispose();
                     }
@@ -7233,7 +7234,8 @@ var OSFramework;
                         }
                     }
                     dispose() {
-                        this._balloonFeature.dispose();
+                        var _a;
+                        (_a = this._balloonFeature) === null || _a === void 0 ? void 0 : _a.dispose();
                         this.removeEventListeners();
                         this.unsetCallbacks();
                         this.unsetHtmlElements();

--- a/src/scripts/OSFramework/OSUI/Feature/Balloon/Balloon.ts
+++ b/src/scripts/OSFramework/OSUI/Feature/Balloon/Balloon.ts
@@ -224,7 +224,7 @@ namespace OSFramework.OSUI.Feature.Balloon {
 		 * @memberof Balloon
 		 */
 		public dispose(): void {
-			this._floatingInstance.dispose();
+			this._floatingInstance?.dispose();
 			this._unsetCallbacks();
 			super.dispose();
 		}

--- a/src/scripts/OSFramework/OSUI/Pattern/OverflowMenu/OverflowMenu.ts
+++ b/src/scripts/OSFramework/OSUI/Pattern/OverflowMenu/OverflowMenu.ts
@@ -244,7 +244,7 @@ namespace OSFramework.OSUI.Patterns.OverflowMenu {
 		 * @memberof OverflowMenu
 		 */
 		public dispose(): void {
-			this._balloonFeature.dispose();
+			this._balloonFeature?.dispose();
 			this.removeEventListeners();
 			this.unsetCallbacks();
 			this.unsetHtmlElements();


### PR DESCRIPTION
This PR is for fixing the OverflowMenu dispose when the pattern is destroyed, without first never being opened, and so the Balloon feature never creates the FloatingPosition util instance

### Test Steps

1. Go to OverflowMenu Screen
2. Navigate to another screen
3. Use back navigation
Expected: No errors triggered


### Checklist

-   [ ] tested locally
-   [ ] documented the code
-   [ ] clean all warnings and errors of eslint
-   [ ] requires changes in OutSystems (if so, provide a module with changes)
-   [ ] requires new sample page in OutSystems (if so, provide a module with changes)
