### PR TITLE
Fix sidebar on keypress

### DIFF
--- a/dist/OutSystemsUI.js
+++ b/dist/OutSystemsUI.js
@@ -9018,6 +9018,7 @@ var OSFramework;
                         if (isEscapedPressed) {
                             this.close();
                         }
+                        e.stopPropagation();
                     }
                     _toggle() {
                         if (this._isOpen) {

--- a/src/scripts/OSFramework/OSUI/Pattern/Sidebar/Sidebar.ts
+++ b/src/scripts/OSFramework/OSUI/Pattern/Sidebar/Sidebar.ts
@@ -255,6 +255,8 @@ namespace OSFramework.OSUI.Patterns.Sidebar {
 			if (isEscapedPressed) {
 				this.close();
 			}
+
+			e.stopPropagation();
 		}
 
 		// Method to toggle the Sidebar


### PR DESCRIPTION
This PR is for fixing the closing of a nested Sidebar, when pressing Esc, that was closing all Sidebars at once.

### Checklist

-   [ ] tested locally
-   [ ] documented the code
-   [ ] clean all warnings and errors of eslint
-   [ ] requires changes in OutSystems (if so, provide a module with changes)
-   [ ] requires new sample page in OutSystems (if so, provide a module with changes)
