### PR TITLE
ROU-4250: Change name from Subtitles to Captions

### DIFF
--- a/dist/OutSystemsUI.d.ts
+++ b/dist/OutSystemsUI.d.ts
@@ -3712,12 +3712,12 @@ declare namespace OSFramework.OSUI.Patterns.Video {
 declare namespace OSFramework.OSUI.Patterns.Video {
     class VideoConfig extends AbstractConfiguration {
         Autoplay: boolean;
+        Captions: string;
         Controls: boolean;
         Height: string;
         Loop: boolean;
         Muted: boolean;
         PosterURL: string;
-        Subtitles: string;
         URL: string;
         Width: string;
         constructor(config: JSON);

--- a/dist/OutSystemsUI.js
+++ b/dist/OutSystemsUI.js
@@ -11512,9 +11512,9 @@ var OSFramework;
                         this._videoSourceElement.type = Patterns.Video.Enum.VideoAttributes.TypePath + _urlFileExtension;
                     }
                     _setVideoTrack() {
-                        const subtitlesList = JSON.parse(this.configs.Subtitles);
-                        if (subtitlesList.length > 0) {
-                            for (const item of subtitlesList) {
+                        const captionsList = JSON.parse(this.configs.Captions);
+                        if (captionsList.length > 0) {
+                            for (const item of captionsList) {
                                 const trackElement = document.createElement(Patterns.Video.Enum.VideoTags.Track);
                                 OSUI.Helper.Dom.Styles.AddClass(trackElement, Patterns.Video.Enum.CssClass.VideoTrack);
                                 trackElement.kind = Patterns.Video.Enum.VideoAttributes.Captions;

--- a/src/scripts/OSFramework/OSUI/Pattern/Video/Video.ts
+++ b/src/scripts/OSFramework/OSUI/Pattern/Video/Video.ts
@@ -113,10 +113,10 @@ namespace OSFramework.OSUI.Patterns.Video {
 		private _setVideoTrack(): void {
 			// Check if contains tracks to be added
 			// If true, create the element with all the attributes
-			const subtitlesList = JSON.parse(this.configs.Subtitles);
+			const captionsList = JSON.parse(this.configs.Captions);
 
-			if (subtitlesList.length > 0) {
-				for (const item of subtitlesList) {
+			if (captionsList.length > 0) {
+				for (const item of captionsList) {
 					const trackElement = document.createElement(Patterns.Video.Enum.VideoTags.Track);
 
 					// Add class to track element created

--- a/src/scripts/OSFramework/OSUI/Pattern/Video/VideoConfig.ts
+++ b/src/scripts/OSFramework/OSUI/Pattern/Video/VideoConfig.ts
@@ -9,12 +9,12 @@ namespace OSFramework.OSUI.Patterns.Video {
 	 */
 	export class VideoConfig extends AbstractConfiguration {
 		public Autoplay: boolean;
+		public Captions: string;
 		public Controls: boolean;
 		public Height: string;
 		public Loop: boolean;
 		public Muted: boolean;
 		public PosterURL: string;
-		public Subtitles: string;
 		public URL: string;
 		public Width: string;
 


### PR DESCRIPTION
This PR is to change the parameter name from Subtitles to Captions and review the method to set tracks.

### What was done
- Change variables names with subtitle prefix to captions
- Change the configs parameters from Subtitles to Captions

### Checklist
-   [X] tested locally
-   [X] documented the code
-   [X] clean all warnings and errors of eslint
-   [ ] requires changes in OutSystems (if so, provide a module with changes)
-   [ ] requires new sample page in OutSystems (if so, provide a module with changes)
