### PR TITLE
ROU-4405: Minor fixes on OverflowMenu 

### DIFF
--- a/dist/OutSystemsUI.css
+++ b/dist/OutSystemsUI.css
@@ -10832,6 +10832,7 @@ html[data-uieditorversion^="1"] .osui-timepicker__dropdown-ss-preview.time12h, h
 }
 .osui-overflow-menu__balloon{
   min-width:var(--osui-overflow-menu-min-width);
+  overflow:hidden;
 }
 .osui-overflow-menu__balloon a{
   color:var(--color-neutral-9);
@@ -10848,6 +10849,10 @@ html[data-uieditorversion^="1"] .osui-timepicker__dropdown-ss-preview.time12h, h
 }
 .osui-overflow-menu__balloon a:not([class^=padding-]){
   padding:var(--space-s) var(--space-base);
+}
+.tablet .osui-overflow-menu,
+.phone .osui-overflow-menu{
+  --border-radius-rounded:100%;
 }
 .tablet .osui-overflow-menu .osui-overflow-menu__trigger.btn,
 .phone .osui-overflow-menu .osui-overflow-menu__trigger.btn{

--- a/dist/OutSystemsUI.d.ts
+++ b/dist/OutSystemsUI.d.ts
@@ -2462,6 +2462,7 @@ declare namespace OSFramework.OSUI.Patterns.OverflowMenu {
         Position: GlobalEnum.FloatingPosition;
         Shape: GlobalEnum.ShapeTypes;
         constructor(config: JSON);
+        validateDefault(key: string, value: unknown): unknown;
     }
 }
 declare namespace OSFramework.OSUI.Patterns.Progress {

--- a/dist/OutSystemsUI.js
+++ b/dist/OutSystemsUI.js
@@ -1812,6 +1812,7 @@ var OSFramework;
                         if (isEscapedPressed && this.isOpen) {
                             this.close();
                         }
+                        e.stopPropagation();
                     }
                     _removeEventListeners() {
                         this.featureElem.removeEventListener(OSUI.GlobalEnum.HTMLEvent.keyDown, this._eventOnKeypress);
@@ -7303,6 +7304,21 @@ var OSFramework;
                 class OverflowMenuConfig extends Patterns.AbstractConfiguration {
                     constructor(config) {
                         super(config);
+                    }
+                    validateDefault(key, value) {
+                        let validatedValue = undefined;
+                        switch (key) {
+                            case OverflowMenu.Enum.Properties.Shape:
+                                validatedValue = this.validateInRange(value, OSUI.GlobalEnum.ShapeTypes.SoftRounded, OSUI.GlobalEnum.ShapeTypes.Sharp, OSUI.GlobalEnum.ShapeTypes.Rounded);
+                                break;
+                            case OverflowMenu.Enum.Properties.Position:
+                                validatedValue = this.validateString(value, OSUI.GlobalEnum.FloatingPosition.Auto);
+                                break;
+                            default:
+                                validatedValue = super.validateDefault(key, value);
+                                break;
+                        }
+                        return validatedValue;
                     }
                 }
                 OverflowMenu.OverflowMenuConfig = OverflowMenuConfig;

--- a/dist/OutSystemsUI.js
+++ b/dist/OutSystemsUI.js
@@ -7312,7 +7312,7 @@ var OSFramework;
                                 validatedValue = this.validateInRange(value, OSUI.GlobalEnum.ShapeTypes.SoftRounded, OSUI.GlobalEnum.ShapeTypes.Sharp, OSUI.GlobalEnum.ShapeTypes.Rounded);
                                 break;
                             case OverflowMenu.Enum.Properties.Position:
-                                validatedValue = this.validateString(value, OSUI.GlobalEnum.FloatingPosition.Auto);
+                                validatedValue = this.validateInRange(value, OSUI.GlobalEnum.FloatingPosition.Auto, OSUI.GlobalEnum.FloatingPosition.Bottom, OSUI.GlobalEnum.FloatingPosition.BottomEnd, OSUI.GlobalEnum.FloatingPosition.BottomStart, OSUI.GlobalEnum.FloatingPosition.Center, OSUI.GlobalEnum.FloatingPosition.Left, OSUI.GlobalEnum.FloatingPosition.LeftEnd, OSUI.GlobalEnum.FloatingPosition.LeftStart, OSUI.GlobalEnum.FloatingPosition.Right, OSUI.GlobalEnum.FloatingPosition.RightEnd, OSUI.GlobalEnum.FloatingPosition.RightStart, OSUI.GlobalEnum.FloatingPosition.Top, OSUI.GlobalEnum.FloatingPosition.TopEnd, OSUI.GlobalEnum.FloatingPosition.TopStart);
                                 break;
                             default:
                                 validatedValue = super.validateDefault(key, value);

--- a/src/scripts/OSFramework/OSUI/Feature/Balloon/Balloon.ts
+++ b/src/scripts/OSFramework/OSUI/Feature/Balloon/Balloon.ts
@@ -69,6 +69,8 @@ namespace OSFramework.OSUI.Feature.Balloon {
 			if (isEscapedPressed && this.isOpen) {
 				this.close();
 			}
+
+			e.stopPropagation();
 		}
 
 		// Method to remove the event listeners

--- a/src/scripts/OSFramework/OSUI/Pattern/OverflowMenu/OverflowMenuConfig.ts
+++ b/src/scripts/OSFramework/OSUI/Pattern/OverflowMenu/OverflowMenuConfig.ts
@@ -35,7 +35,23 @@ namespace OSFramework.OSUI.Patterns.OverflowMenu {
 					);
 					break;
 				case Enum.Properties.Position:
-					validatedValue = this.validateString(value as string, GlobalEnum.FloatingPosition.Auto);
+					validatedValue = this.validateInRange(
+						value,
+						GlobalEnum.FloatingPosition.Auto,
+						GlobalEnum.FloatingPosition.Bottom,
+						GlobalEnum.FloatingPosition.BottomEnd,
+						GlobalEnum.FloatingPosition.BottomStart,
+						GlobalEnum.FloatingPosition.Center,
+						GlobalEnum.FloatingPosition.Left,
+						GlobalEnum.FloatingPosition.LeftEnd,
+						GlobalEnum.FloatingPosition.LeftStart,
+						GlobalEnum.FloatingPosition.Right,
+						GlobalEnum.FloatingPosition.RightEnd,
+						GlobalEnum.FloatingPosition.RightStart,
+						GlobalEnum.FloatingPosition.Top,
+						GlobalEnum.FloatingPosition.TopEnd,
+						GlobalEnum.FloatingPosition.TopStart
+					);
 					break;
 				default:
 					validatedValue = super.validateDefault(key, value);

--- a/src/scripts/OSFramework/OSUI/Pattern/OverflowMenu/OverflowMenuConfig.ts
+++ b/src/scripts/OSFramework/OSUI/Pattern/OverflowMenu/OverflowMenuConfig.ts
@@ -14,5 +14,35 @@ namespace OSFramework.OSUI.Patterns.OverflowMenu {
 		constructor(config: JSON) {
 			super(config);
 		}
+
+		/**
+		 * Override, Validate configs key values
+		 *
+		 * @param {string} key
+		 * @param {unknown} value
+		 * @return {*}  {unknown}
+		 * @memberof OverflowMenuConfig
+		 */
+		public validateDefault(key: string, value: unknown): unknown {
+			let validatedValue = undefined;
+			switch (key) {
+				case Enum.Properties.Shape:
+					validatedValue = this.validateInRange(
+						value,
+						GlobalEnum.ShapeTypes.SoftRounded,
+						GlobalEnum.ShapeTypes.Sharp,
+						GlobalEnum.ShapeTypes.Rounded
+					);
+					break;
+				case Enum.Properties.Position:
+					validatedValue = this.validateString(value as string, GlobalEnum.FloatingPosition.Auto);
+					break;
+				default:
+					validatedValue = super.validateDefault(key, value);
+					break;
+			}
+
+			return validatedValue;
+		}
 	}
 }

--- a/src/scripts/OSFramework/OSUI/Pattern/OverflowMenu/scss/_overflowmenu.scss
+++ b/src/scripts/OSFramework/OSUI/Pattern/OverflowMenu/scss/_overflowmenu.scss
@@ -28,6 +28,7 @@
     
     &__balloon {
         min-width: var(--osui-overflow-menu-min-width);
+        overflow: hidden;
 
         a {
             color: var(--color-neutral-9);
@@ -56,6 +57,8 @@
 .tablet,
 .phone {
     .osui-overflow-menu {
+        --border-radius-rounded: 100%;
+
         .osui-overflow-menu__trigger {
             &.btn {
                 // Longer specificity to be able to always override default responsive styles for buttons


### PR DESCRIPTION
This PR is for adding the following fixes to the OverflowMenu:

- Fix shape rounded style in mobile;
- Fix hover style when shape is not Sharp and a link is the first child inside the Balloon.
- Fixed Esc behaviour inside Sidebar. Now when pressing Esc, the Sidebar is not closed, only the OverflowMenu.
- Added missing configs validations.

### Checklist

-   [x] tested locally
-   [x] documented the code
-   [x] clean all warnings and errors of eslint
-   [x] requires changes in OutSystems (if so, provide a module with changes)
-   [ ] requires new sample page in OutSystems (if so, provide a module with changes)
