### PR TITLE
ROU-3280: Add client actions for Video

### DIFF
--- a/dist/OutSystemsUI.d.ts
+++ b/dist/OutSystemsUI.d.ts
@@ -3679,6 +3679,9 @@ declare namespace OSFramework.OSUI.Patterns.Video.Enum {
 }
 declare namespace OSFramework.OSUI.Patterns.Video {
     interface IVideo extends Interface.IPattern {
+        getVideoState(): void;
+        setVideoPause(): void;
+        setVideoPlay(): void;
     }
 }
 declare namespace OSFramework.OSUI.Patterns.Video {
@@ -3686,6 +3689,7 @@ declare namespace OSFramework.OSUI.Patterns.Video {
         private _platformEventOnStateChanged;
         private _videoElement;
         private _videoSourceElement;
+        private _videoState;
         constructor(uniqueId: string, configs: JSON);
         private _setAutoplay;
         private _setControls;
@@ -3706,7 +3710,10 @@ declare namespace OSFramework.OSUI.Patterns.Video {
         build(): void;
         changeProperty(propertyName: string, propertyValue: unknown): void;
         dispose(): void;
+        getVideoState(): string;
         registerCallback(eventName: string, callback: GlobalCallbacks.OSGeneric): void;
+        setVideoPause(): void;
+        setVideoPlay(): void;
     }
 }
 declare namespace OSFramework.OSUI.Patterns.Video {
@@ -4052,9 +4059,11 @@ declare namespace OutSystems.OSUI.ErrorCodes {
     };
     const Video: {
         FailChangeProperty: string;
-        FailClose: string;
         FailDispose: string;
         FailRegisterCallback: string;
+        FailGetState: string;
+        FailPause: string;
+        FailPlay: string;
     };
     const Legacy: {
         FailAddFavicon_Legacy: string;
@@ -4441,6 +4450,9 @@ declare namespace OutSystems.OSUI.Patterns.VideoAPI {
     function GetVideoById(videoId: string): OSFramework.OSUI.Patterns.Video.IVideo;
     function Initialize(videoId: string): OSFramework.OSUI.Patterns.Video.IVideo;
     function RegisterCallback(videoId: string, eventName: string, callback: OSFramework.OSUI.GlobalCallbacks.OSGeneric): string;
+    function VideoPause(videoId: string): string;
+    function VideoPlay(videoId: string): string;
+    function VideoGetState(videoId: string): string;
 }
 declare namespace OutSystems.OSUI.Utils.Accessibility {
     function SetAccessibilityRole(widgetId: string, role: string): string;

--- a/dist/OutSystemsUI.d.ts
+++ b/dist/OutSystemsUI.d.ts
@@ -4451,9 +4451,9 @@ declare namespace OutSystems.OSUI.Patterns.VideoAPI {
     function GetVideoById(videoId: string): OSFramework.OSUI.Patterns.Video.IVideo;
     function Initialize(videoId: string): OSFramework.OSUI.Patterns.Video.IVideo;
     function RegisterCallback(videoId: string, eventName: string, callback: OSFramework.OSUI.GlobalCallbacks.OSGeneric): string;
-    function VideoGetState(videoId: string): string;
-    function VideoPause(videoId: string): string;
-    function VideoPlay(videoId: string): string;
+    function GetState(videoId: string): string;
+    function Pause(videoId: string): string;
+    function Play(videoId: string): string;
 }
 declare namespace OutSystems.OSUI.Utils.Accessibility {
     function SetAccessibilityRole(widgetId: string, role: string): string;

--- a/dist/OutSystemsUI.d.ts
+++ b/dist/OutSystemsUI.d.ts
@@ -3679,7 +3679,7 @@ declare namespace OSFramework.OSUI.Patterns.Video.Enum {
 }
 declare namespace OSFramework.OSUI.Patterns.Video {
     interface IVideo extends Interface.IPattern {
-        getVideoState(): void;
+        getVideoState: string;
         setVideoPause(): void;
         setVideoPlay(): void;
     }
@@ -3710,7 +3710,7 @@ declare namespace OSFramework.OSUI.Patterns.Video {
         build(): void;
         changeProperty(propertyName: string, propertyValue: unknown): void;
         dispose(): void;
-        getVideoState(): string;
+        get getVideoState(): string;
         registerCallback(eventName: string, callback: GlobalCallbacks.OSGeneric): void;
         setVideoPause(): void;
         setVideoPlay(): void;
@@ -4450,9 +4450,9 @@ declare namespace OutSystems.OSUI.Patterns.VideoAPI {
     function GetVideoById(videoId: string): OSFramework.OSUI.Patterns.Video.IVideo;
     function Initialize(videoId: string): OSFramework.OSUI.Patterns.Video.IVideo;
     function RegisterCallback(videoId: string, eventName: string, callback: OSFramework.OSUI.GlobalCallbacks.OSGeneric): string;
+    function VideoGetState(videoId: string): string;
     function VideoPause(videoId: string): string;
     function VideoPlay(videoId: string): string;
-    function VideoGetState(videoId: string): string;
 }
 declare namespace OutSystems.OSUI.Utils.Accessibility {
     function SetAccessibilityRole(widgetId: string, role: string): string;

--- a/dist/OutSystemsUI.js
+++ b/dist/OutSystemsUI.js
@@ -15304,7 +15304,7 @@ var OutSystems;
                     return result;
                 }
                 VideoAPI.RegisterCallback = RegisterCallback;
-                function VideoGetState(videoId) {
+                function GetState(videoId) {
                     const result = OutSystems.OSUI.Utils.CreateApiResponse({
                         errorCode: OSUI.ErrorCodes.Video.FailGetState,
                         hasValue: true,
@@ -15315,8 +15315,8 @@ var OutSystems;
                     });
                     return result;
                 }
-                VideoAPI.VideoGetState = VideoGetState;
-                function VideoPause(videoId) {
+                VideoAPI.GetState = GetState;
+                function Pause(videoId) {
                     const result = OutSystems.OSUI.Utils.CreateApiResponse({
                         errorCode: OSUI.ErrorCodes.Video.FailPause,
                         callback: () => {
@@ -15326,8 +15326,8 @@ var OutSystems;
                     });
                     return result;
                 }
-                VideoAPI.VideoPause = VideoPause;
-                function VideoPlay(videoId) {
+                VideoAPI.Pause = Pause;
+                function Play(videoId) {
                     const result = OutSystems.OSUI.Utils.CreateApiResponse({
                         errorCode: OSUI.ErrorCodes.Video.FailPlay,
                         callback: () => {
@@ -15337,7 +15337,7 @@ var OutSystems;
                     });
                     return result;
                 }
-                VideoAPI.VideoPlay = VideoPlay;
+                VideoAPI.Play = Play;
             })(VideoAPI = Patterns.VideoAPI || (Patterns.VideoAPI = {}));
         })(Patterns = OSUI.Patterns || (OSUI.Patterns = {}));
     })(OSUI = OutSystems.OSUI || (OutSystems.OSUI = {}));

--- a/dist/OutSystemsUI.js
+++ b/dist/OutSystemsUI.js
@@ -11614,8 +11614,7 @@ var OSFramework;
                         this.unsetHtmlElements();
                         super.dispose();
                     }
-                    getVideoState() {
-                        console.log(this._videoState);
+                    get getVideoState() {
                         return this._videoState;
                     }
                     registerCallback(eventName, callback) {
@@ -15289,6 +15288,18 @@ var OutSystems;
                     return result;
                 }
                 VideoAPI.RegisterCallback = RegisterCallback;
+                function VideoGetState(videoId) {
+                    const result = OutSystems.OSUI.Utils.CreateApiResponse({
+                        errorCode: OSUI.ErrorCodes.Video.FailGetState,
+                        hasValue: true,
+                        callback: () => {
+                            const video = GetVideoById(videoId);
+                            return video.getVideoState;
+                        },
+                    });
+                    return result;
+                }
+                VideoAPI.VideoGetState = VideoGetState;
                 function VideoPause(videoId) {
                     const result = OutSystems.OSUI.Utils.CreateApiResponse({
                         errorCode: OSUI.ErrorCodes.Video.FailPause,
@@ -15311,17 +15322,6 @@ var OutSystems;
                     return result;
                 }
                 VideoAPI.VideoPlay = VideoPlay;
-                function VideoGetState(videoId) {
-                    const result = OutSystems.OSUI.Utils.CreateApiResponse({
-                        errorCode: OSUI.ErrorCodes.Video.FailGetState,
-                        callback: () => {
-                            const video = GetVideoById(videoId);
-                            video.getVideoState();
-                        },
-                    });
-                    return result;
-                }
-                VideoAPI.VideoGetState = VideoGetState;
             })(VideoAPI = Patterns.VideoAPI || (Patterns.VideoAPI = {}));
         })(Patterns = OSUI.Patterns || (OSUI.Patterns = {}));
     })(OSUI = OutSystems.OSUI || (OutSystems.OSUI = {}));

--- a/dist/OutSystemsUI.js
+++ b/dist/OutSystemsUI.js
@@ -11542,6 +11542,7 @@ var OSFramework;
                         else {
                             this.triggerPlatformEventCallback(this._platformEventOnStateChanged.bind(this), stateChanged);
                         }
+                        this._videoState = stateChanged;
                     }
                     setA11YProperties() {
                         console.log(OSUI.GlobalEnum.WarningMessages.MethodNotImplemented);
@@ -11613,6 +11614,10 @@ var OSFramework;
                         this.unsetHtmlElements();
                         super.dispose();
                     }
+                    getVideoState() {
+                        console.log(this._videoState);
+                        return this._videoState;
+                    }
                     registerCallback(eventName, callback) {
                         switch (eventName) {
                             case Patterns.Video.Enum.Events.OnStateChanged:
@@ -11626,6 +11631,12 @@ var OSFramework;
                             default:
                                 super.registerCallback(eventName, callback);
                         }
+                    }
+                    setVideoPause() {
+                        this._videoElement.pause();
+                    }
+                    setVideoPlay() {
+                        this._videoElement.play();
                     }
                 }
                 Video_1.Video = Video;
@@ -12042,9 +12053,11 @@ var OutSystems;
             };
             ErrorCodes.Video = {
                 FailChangeProperty: 'OSUI-API-31001',
-                FailClose: 'OSUI-API-31002',
-                FailDispose: 'OSUI-API-31003',
-                FailRegisterCallback: 'OSUI-API-31004',
+                FailDispose: 'OSUI-API-31002',
+                FailRegisterCallback: 'OSUI-API-31003',
+                FailGetState: 'OSUI-API-31004',
+                FailPause: 'OSUI-API-31005',
+                FailPlay: 'OSUI-API-31006',
             };
             ErrorCodes.Legacy = {
                 FailAddFavicon_Legacy: 'OSUI-LEG-000001',
@@ -15276,6 +15289,39 @@ var OutSystems;
                     return result;
                 }
                 VideoAPI.RegisterCallback = RegisterCallback;
+                function VideoPause(videoId) {
+                    const result = OutSystems.OSUI.Utils.CreateApiResponse({
+                        errorCode: OSUI.ErrorCodes.Video.FailPause,
+                        callback: () => {
+                            const video = GetVideoById(videoId);
+                            video.setVideoPause();
+                        },
+                    });
+                    return result;
+                }
+                VideoAPI.VideoPause = VideoPause;
+                function VideoPlay(videoId) {
+                    const result = OutSystems.OSUI.Utils.CreateApiResponse({
+                        errorCode: OSUI.ErrorCodes.Video.FailPlay,
+                        callback: () => {
+                            const video = GetVideoById(videoId);
+                            video.setVideoPlay();
+                        },
+                    });
+                    return result;
+                }
+                VideoAPI.VideoPlay = VideoPlay;
+                function VideoGetState(videoId) {
+                    const result = OutSystems.OSUI.Utils.CreateApiResponse({
+                        errorCode: OSUI.ErrorCodes.Video.FailGetState,
+                        callback: () => {
+                            const video = GetVideoById(videoId);
+                            video.getVideoState();
+                        },
+                    });
+                    return result;
+                }
+                VideoAPI.VideoGetState = VideoGetState;
             })(VideoAPI = Patterns.VideoAPI || (Patterns.VideoAPI = {}));
         })(Patterns = OSUI.Patterns || (OSUI.Patterns = {}));
     })(OSUI = OutSystems.OSUI || (OutSystems.OSUI = {}));

--- a/src/scripts/OSFramework/OSUI/Pattern/Video/IVideo.ts
+++ b/src/scripts/OSFramework/OSUI/Pattern/Video/IVideo.ts
@@ -8,8 +8,26 @@ namespace OSFramework.OSUI.Patterns.Video {
 	 * @extends {Interface.IPattern}
 	 */
 	export interface IVideo extends Interface.IPattern {
-		getVideoState(): void;
+		/**
+		 * Getter the value of video state
+		 *
+		 * @type {string}
+		 * @memberof IVideo
+		 */
+		getVideoState: string;
+
+		/**
+		 * Function that will trigger the pause video method
+		 *
+		 * @memberof IVideo
+		 */
 		setVideoPause(): void;
+
+		/**
+		 * Function that will trigger the play video method
+		 *
+		 * @memberof IVideo
+		 */
 		setVideoPlay(): void;
 	}
 }

--- a/src/scripts/OSFramework/OSUI/Pattern/Video/IVideo.ts
+++ b/src/scripts/OSFramework/OSUI/Pattern/Video/IVideo.ts
@@ -6,7 +6,10 @@ namespace OSFramework.OSUI.Patterns.Video {
 	 * @export
 	 * @interface IVideo
 	 * @extends {Interface.IPattern}
-	 * @extends {Interface.ICallback}
 	 */
-	export interface IVideo extends Interface.IPattern {}
+	export interface IVideo extends Interface.IPattern {
+		getVideoState(): void;
+		setVideoPause(): void;
+		setVideoPlay(): void;
+	}
 }

--- a/src/scripts/OSFramework/OSUI/Pattern/Video/Video.ts
+++ b/src/scripts/OSFramework/OSUI/Pattern/Video/Video.ts
@@ -28,7 +28,12 @@ namespace OSFramework.OSUI.Patterns.Video {
 			super(uniqueId, new VideoConfig(configs));
 		}
 
-		// Method that will set the Autoplay attribute
+		/**
+		 * Method that will set the Autoplay attribute
+		 *
+		 * @private
+		 * @memberof Video
+		 */
 		private _setAutoplay(): void {
 			this._videoElement.autoplay = this.configs.Autoplay;
 
@@ -39,12 +44,22 @@ namespace OSFramework.OSUI.Patterns.Video {
 			}
 		}
 
-		// Method that will set the controls attribute
+		/**
+		 * Method that will set the controls attribute
+		 *
+		 * @private
+		 * @memberof Video
+		 */
 		private _setControls(): void {
 			this._videoElement.controls = this.configs.Controls;
 		}
 
-		// Method that will set the Height attribute
+		/**
+		 * Method that will set the Height attribute
+		 *
+		 * @private
+		 * @memberof Video
+		 */
 		private _setHeight(): void {
 			if (this.configs.Height !== Constants.EmptyString) {
 				OSUI.Helper.Dom.Attribute.Set(
@@ -57,17 +72,32 @@ namespace OSFramework.OSUI.Patterns.Video {
 			}
 		}
 
-		// Method that will set the loop attribute
+		/**
+		 * Method that will set the loop attribute
+		 *
+		 * @private
+		 * @memberof Video
+		 */
 		private _setLoop(): void {
 			this._videoElement.loop = this.configs.Loop;
 		}
 
-		// Method that will set the muted attribute
+		/**
+		 * Method that will set the muted attribute
+		 *
+		 * @private
+		 * @memberof Video
+		 */
 		private _setMuted(): void {
 			this._videoElement.muted = this.configs.Muted;
 		}
 
-		// Method that will set the poster image on video
+		/**
+		 * Method that will set the poster image on video
+		 *
+		 * @private
+		 * @memberof Video
+		 */
 		private _setPosterUrl(): void {
 			if (this.configs.PosterURL !== Constants.EmptyString) {
 				this._videoElement.poster = this.configs.PosterURL;
@@ -76,7 +106,12 @@ namespace OSFramework.OSUI.Patterns.Video {
 			}
 		}
 
-		// Method to apply all initial video configs
+		/**
+		 * Method to apply all initial video configs
+		 *
+		 * @private
+		 * @memberof Video
+		 */
 		private _setVideoConfigs(): void {
 			this._setAutoplay();
 
@@ -98,7 +133,12 @@ namespace OSFramework.OSUI.Patterns.Video {
 			}
 		}
 
-		// Method to create the source element
+		/**
+		 * Method to create the source element
+		 *
+		 * @private
+		 * @memberof Video
+		 */
 		private _setVideoSource(): void {
 			// Get the file extension from URL
 			const _urlFileExtension = this.configs.URL.split('.').pop();
@@ -111,7 +151,12 @@ namespace OSFramework.OSUI.Patterns.Video {
 			this._videoSourceElement.type = Patterns.Video.Enum.VideoAttributes.TypePath + _urlFileExtension;
 		}
 
-		// Method create the track element
+		/**
+		 * Method create the track element
+		 *
+		 * @private
+		 * @memberof Video
+		 */
 		private _setVideoTrack(): void {
 			// Check if contains tracks to be added
 			// If true, create the element with all the attributes
@@ -136,7 +181,12 @@ namespace OSFramework.OSUI.Patterns.Video {
 			}
 		}
 
-		// Method that will set the Width attribute
+		/**
+		 * Method that will set the Width attribute
+		 *
+		 * @private
+		 * @memberof Video
+		 */
 		private _setWidth(): void {
 			if (this.configs.Width !== Constants.EmptyString) {
 				OSUI.Helper.Dom.Attribute.Set(
@@ -149,7 +199,13 @@ namespace OSFramework.OSUI.Patterns.Video {
 			}
 		}
 
-		// Method that triggers the OnStateChanged event
+		/**
+		 * Method that triggers the OnStateChanged event
+		 *
+		 * @private
+		 * @param {string} stateChanged value of video state
+		 * @memberof Video
+		 */
 		private _triggerOnStateChangedEvent(stateChanged: string): void {
 			if (stateChanged === Patterns.Video.Enum.VideoStates.Unstarted) {
 				if (this._videoElement.currentTime === 0) {
@@ -323,9 +379,7 @@ namespace OSFramework.OSUI.Patterns.Video {
 		 *
 		 * @memberof OSFramework.Patterns.Video.Video
 		 */
-		public getVideoState(): string {
-			// code goes here
-			console.log(this._videoState);
+		public get getVideoState(): string {
 			return this._videoState;
 		}
 

--- a/src/scripts/OSFramework/OSUI/Pattern/Video/Video.ts
+++ b/src/scripts/OSFramework/OSUI/Pattern/Video/Video.ts
@@ -15,6 +15,8 @@ namespace OSFramework.OSUI.Patterns.Video {
 		private _videoElement: HTMLVideoElement;
 		// Store the source element
 		private _videoSourceElement: HTMLSourceElement;
+		// Store the current video state
+		private _videoState: string;
 
 		/**
 		 * Creates an instance of Video.
@@ -156,6 +158,9 @@ namespace OSFramework.OSUI.Patterns.Video {
 			} else {
 				this.triggerPlatformEventCallback(this._platformEventOnStateChanged.bind(this), stateChanged);
 			}
+
+			// Update video state value
+			this._videoState = stateChanged;
 		}
 
 		/**
@@ -314,6 +319,17 @@ namespace OSFramework.OSUI.Patterns.Video {
 		}
 
 		/**
+		 * Method to get video state
+		 *
+		 * @memberof OSFramework.Patterns.Video.Video
+		 */
+		public getVideoState(): string {
+			// code goes here
+			console.log(this._videoState);
+			return this._videoState;
+		}
+
+		/**
 		 * Set callbacks for the pattern
 		 *
 		 * @param {string} eventName
@@ -333,6 +349,24 @@ namespace OSFramework.OSUI.Patterns.Video {
 				default:
 					super.registerCallback(eventName, callback);
 			}
+		}
+
+		/**
+		 * Method to pause video
+		 *
+		 * @memberof OSFramework.Patterns.Video.Video
+		 */
+		public setVideoPause(): void {
+			this._videoElement.pause();
+		}
+
+		/**
+		 * Method to play video
+		 *
+		 * @memberof OSFramework.Patterns.Video.Video
+		 */
+		public setVideoPlay(): void {
+			this._videoElement.play();
 		}
 	}
 }

--- a/src/scripts/OutSystems/OSUI/ErrorCodes.ts
+++ b/src/scripts/OutSystems/OSUI/ErrorCodes.ts
@@ -321,9 +321,11 @@ namespace OutSystems.OSUI.ErrorCodes {
 
 	export const Video = {
 		FailChangeProperty: 'OSUI-API-31001',
-		FailClose: 'OSUI-API-31002',
-		FailDispose: 'OSUI-API-31003',
-		FailRegisterCallback: 'OSUI-API-31004',
+		FailDispose: 'OSUI-API-31002',
+		FailRegisterCallback: 'OSUI-API-31003',
+		FailGetState: 'OSUI-API-31004',
+		FailPause: 'OSUI-API-31005',
+		FailPlay: 'OSUI-API-31006',
 	};
 
 	// Error Codes used in Legacy Client Action

--- a/src/scripts/OutSystems/OSUI/Patterns/VideoAPI.ts
+++ b/src/scripts/OutSystems/OSUI/Patterns/VideoAPI.ts
@@ -130,8 +130,29 @@ namespace OutSystems.OSUI.Patterns.VideoAPI {
 	}
 
 	/**
+	 * Function that returns the state of a given video
 	 *
-	 * Function that play video on a given video
+	 * @export
+	 * @param {string} videoId
+	 * @return {*}  {string}
+	 */
+	export function VideoGetState(videoId: string): string {
+		const result = OutSystems.OSUI.Utils.CreateApiResponse({
+			errorCode: ErrorCodes.Video.FailGetState,
+			hasValue: true,
+			callback: () => {
+				const video = GetVideoById(videoId);
+
+				return video.getVideoState;
+			},
+		});
+
+		return result;
+	}
+
+	/**
+	 *
+	 * Function that pause video on a given video
 	 * @export
 	 * @param {string} videoId
 	 * @return {*}  {string}
@@ -163,26 +184,6 @@ namespace OutSystems.OSUI.Patterns.VideoAPI {
 				const video = GetVideoById(videoId);
 
 				video.setVideoPlay();
-			},
-		});
-
-		return result;
-	}
-
-	/**
-	 *
-	 * Function that play video on a given video
-	 * @export
-	 * @param {string} videoId
-	 * @return {*}  {string}
-	 */
-	export function VideoGetState(videoId: string): string {
-		const result = OutSystems.OSUI.Utils.CreateApiResponse({
-			errorCode: ErrorCodes.Video.FailGetState,
-			callback: () => {
-				const video = GetVideoById(videoId);
-
-				video.getVideoState();
 			},
 		});
 

--- a/src/scripts/OutSystems/OSUI/Patterns/VideoAPI.ts
+++ b/src/scripts/OutSystems/OSUI/Patterns/VideoAPI.ts
@@ -128,4 +128,64 @@ namespace OutSystems.OSUI.Patterns.VideoAPI {
 
 		return result;
 	}
+
+	/**
+	 *
+	 * Function that play video on a given video
+	 * @export
+	 * @param {string} videoId
+	 * @return {*}  {string}
+	 */
+	export function VideoPause(videoId: string): string {
+		const result = OutSystems.OSUI.Utils.CreateApiResponse({
+			errorCode: ErrorCodes.Video.FailPause,
+			callback: () => {
+				const video = GetVideoById(videoId);
+
+				video.setVideoPause();
+			},
+		});
+
+		return result;
+	}
+
+	/**
+	 *
+	 * Function that play video on a given video
+	 * @export
+	 * @param {string} videoId
+	 * @return {*}  {string}
+	 */
+	export function VideoPlay(videoId: string): string {
+		const result = OutSystems.OSUI.Utils.CreateApiResponse({
+			errorCode: ErrorCodes.Video.FailPlay,
+			callback: () => {
+				const video = GetVideoById(videoId);
+
+				video.setVideoPlay();
+			},
+		});
+
+		return result;
+	}
+
+	/**
+	 *
+	 * Function that play video on a given video
+	 * @export
+	 * @param {string} videoId
+	 * @return {*}  {string}
+	 */
+	export function VideoGetState(videoId: string): string {
+		const result = OutSystems.OSUI.Utils.CreateApiResponse({
+			errorCode: ErrorCodes.Video.FailGetState,
+			callback: () => {
+				const video = GetVideoById(videoId);
+
+				video.getVideoState();
+			},
+		});
+
+		return result;
+	}
 }

--- a/src/scripts/OutSystems/OSUI/Patterns/VideoAPI.ts
+++ b/src/scripts/OutSystems/OSUI/Patterns/VideoAPI.ts
@@ -136,7 +136,7 @@ namespace OutSystems.OSUI.Patterns.VideoAPI {
 	 * @param {string} videoId
 	 * @return {*}  {string}
 	 */
-	export function VideoGetState(videoId: string): string {
+	export function GetState(videoId: string): string {
 		const result = OutSystems.OSUI.Utils.CreateApiResponse({
 			errorCode: ErrorCodes.Video.FailGetState,
 			hasValue: true,
@@ -157,7 +157,7 @@ namespace OutSystems.OSUI.Patterns.VideoAPI {
 	 * @param {string} videoId
 	 * @return {*}  {string}
 	 */
-	export function VideoPause(videoId: string): string {
+	export function Pause(videoId: string): string {
 		const result = OutSystems.OSUI.Utils.CreateApiResponse({
 			errorCode: ErrorCodes.Video.FailPause,
 			callback: () => {
@@ -177,7 +177,7 @@ namespace OutSystems.OSUI.Patterns.VideoAPI {
 	 * @param {string} videoId
 	 * @return {*}  {string}
 	 */
-	export function VideoPlay(videoId: string): string {
+	export function Play(videoId: string): string {
 		const result = OutSystems.OSUI.Utils.CreateApiResponse({
 			errorCode: ErrorCodes.Video.FailPlay,
 			callback: () => {


### PR DESCRIPTION
This PR is for adding the new client actions for video:
- VideoGetState: Returns the reproduction state of the video.
- VideoPause: Pause a Video with a given identifier.
- VideoPlay:Play a Video with a given identifier.

![image](https://github.com/OutSystems/outsystems-ui/assets/25321845/20d21687-f034-4220-a7cb-61539e8f331c)

### What was happening
- Now it's possible to Play and Pause a video using actions and based on conditions

### What was done
- Create client actions: **VideoGetState** (Returns the reproduction state of the video), **VideoPause** (Pause a Video with a given identifier) and **VideoPlay** (Play a Video with a given identifier)

### Test Steps
1. Open the sample page
2. Click on Play Video and / or Pause Video
3. Expected: The video will react to each client action

### Checklist
-   [X] tested locally
-   [X] documented the code
-   [X] clean all warnings and errors of eslint
-   [ ] requires changes in OutSystems (if so, provide a module with changes)
-   [ ] requires new sample page in OutSystems (if so, provide a module with changes)
