### PR TITLE
ROU-4327: Improve event management on remove handler

### DIFF
--- a/dist/OutSystemsUI.css
+++ b/dist/OutSystemsUI.css
@@ -506,6 +506,7 @@ a{
 a, a:visited{
   color:var(--color-primary);
   -webkit-transition:all 180ms linear;
+  -o-transition:all 180ms linear;
   transition:all 180ms linear;
 }
 a:hover, a:focus{
@@ -1103,6 +1104,7 @@ body,
   position:fixed;
   top:0;
   -webkit-transition:opacity 130ms ease-in;
+  -o-transition:opacity 130ms ease-in;
   transition:opacity 130ms ease-in;
   width:100vw;
   will-change:opacity;
@@ -1115,6 +1117,7 @@ body,
   opacity:1;
   pointer-events:auto;
   -webkit-transition:opacity 330ms ease-out;
+  -o-transition:opacity 330ms ease-out;
   transition:opacity 330ms ease-out;
 }
 .layout .app-menu-content{
@@ -1172,6 +1175,7 @@ body,
           transform:translateX(0) translateZ(0);
   -webkit-transition:-webkit-transform 130ms ease-in;
   transition:-webkit-transform 130ms ease-in;
+  -o-transition:transform 130ms ease-in;
   transition:transform 130ms ease-in;
   transition:transform 130ms ease-in, -webkit-transform 130ms ease-in;
   width:var(--side-menu-size);
@@ -1184,6 +1188,7 @@ body,
           transform:translateX(var(--side-menu-size)) translateZ(0);
   -webkit-transition:-webkit-transform 330ms ease-out;
   transition:-webkit-transform 330ms ease-out;
+  -o-transition:transform 330ms ease-out;
   transition:transform 330ms ease-out;
   transition:transform 330ms ease-out, -webkit-transform 330ms ease-out;
 }
@@ -1224,6 +1229,7 @@ body,
   -webkit-transform:translateX(0) translateZ(0);
           transform:translateX(0) translateZ(0);
   -webkit-transition:all 330ms ease-out;
+  -o-transition:all 330ms ease-out;
   transition:all 330ms ease-out;
 }
 /*! 3.6. Layout Native - Menu */
@@ -1306,6 +1312,7 @@ body,
           transform:translateX(0) translateZ(0);
   -webkit-transition:-webkit-transform 130ms ease-in;
   transition:-webkit-transform 130ms ease-in;
+  -o-transition:transform 130ms ease-in;
   transition:transform 130ms ease-in;
   transition:transform 130ms ease-in, -webkit-transform 130ms ease-in;
   width:var(--side-menu-size);
@@ -1317,6 +1324,7 @@ body,
           transform:translateX(var(--side-menu-size)) translateZ(0);
   -webkit-transition:-webkit-transform 330ms ease-out;
   transition:-webkit-transform 330ms ease-out;
+  -o-transition:transform 330ms ease-out;
   transition:transform 330ms ease-out;
   transition:transform 330ms ease-out, -webkit-transform 330ms ease-out;
 }
@@ -1347,6 +1355,7 @@ body,
       -ms-transform:none;
           transform:none;
   -webkit-transition:none;
+  -o-transition:none;
   transition:none;
 }
 .is-rtl.desktop .aside-expandable.menu-visible .main{
@@ -1356,6 +1365,7 @@ body,
 .is-rtl.tablet .app-menu-content, .is-rtl.phone .app-menu-content{
   right:calc(-1 * var(--side-menu-size));
   -webkit-transition:all 330ms ease-out;
+  -o-transition:all 330ms ease-out;
   transition:all 330ms ease-out;
 }
 .is-rtl:not(.portrait) .layout-side.layout-native.aside-visible .app-menu-content{
@@ -1369,6 +1379,7 @@ body,
   -webkit-transform:translateX(0) translateZ(0);
           transform:translateX(0) translateZ(0);
   -webkit-transition:all 330ms ease-out;
+  -o-transition:all 330ms ease-out;
   transition:all 330ms ease-out;
 }
 /*! 3.8. Menu - Header Logo */
@@ -1791,6 +1802,7 @@ body .app-menu-content .app-menu-links{
   color:var(--color-neutral-9);
   font-size:var(--font-size-s);
   -webkit-transition:all 180ms linear;
+  -o-transition:all 180ms linear;
   transition:all 180ms linear;
 }
 .form-control[data-input]:hover, .form-control[data-textarea]:hover{
@@ -1890,6 +1902,7 @@ body .app-menu-content .app-menu-links{
   height:30px;
   opacity:1;
   -webkit-transition:all 180ms linear;
+  -o-transition:all 180ms linear;
   transition:all 180ms linear;
   width:48px;
 }
@@ -1905,6 +1918,7 @@ body .app-menu-content .app-menu-links{
   -webkit-transform:translateX(4px) translateZ(0);
           transform:translateX(4px) translateZ(0);
   -webkit-transition:all 180ms linear;
+  -o-transition:all 180ms linear;
   transition:all 180ms linear;
   width:24px;
 }
@@ -1962,6 +1976,7 @@ body .app-menu-content .app-menu-links{
   height:22px;
   opacity:1;
   -webkit-transition:all 180ms linear;
+  -o-transition:all 180ms linear;
   transition:all 180ms linear;
   width:22px;
 }
@@ -2045,6 +2060,7 @@ body .app-menu-content .app-menu-links{
       -ms-transform:rotate(-45deg) translateY(0) translateX(0);
           transform:rotate(-45deg) translateY(0) translateX(0);
   -webkit-transition:all 300ms ease-in-out;
+  -o-transition:all 300ms ease-in-out;
   transition:all 300ms ease-in-out;
   width:8px;
 }
@@ -2111,7 +2127,8 @@ body .app-menu-content .app-menu-links{
 }
 .dropdown-container .dropdown-popup-row span{
   overflow:hidden;
-  text-overflow:ellipsis;
+  -o-text-overflow:ellipsis;
+     text-overflow:ellipsis;
   white-space:nowrap;
 }
 .dropdown-container .scrollable-list-with-scroll{
@@ -2225,6 +2242,7 @@ select.dropdown-display[disabled]{
   margin:0;
   padding:var(--space-none) var(--space-base);
   -webkit-transition:all 100ms linear;
+  -o-transition:all 100ms linear;
   transition:all 100ms linear;
 }
 .btn:hover:active{
@@ -3012,6 +3030,7 @@ div.feedback-message-warning{
   height:24px;
   position:relative;
   -webkit-transition:all 180ms linear;
+  -o-transition:all 180ms linear;
   transition:all 180ms linear;
   width:24px;
 }
@@ -3029,6 +3048,7 @@ div.feedback-message-warning{
   display:flex;
   height:100%;
   -webkit-transition:all 180ms linear;
+  -o-transition:all 180ms linear;
   transition:all 180ms linear;
   width:100%;
 }
@@ -3356,6 +3376,7 @@ div.feedback-message-warning{
 .flatpickr-months .flatpickr-prev-month svg path,
 .flatpickr-months .flatpickr-next-month svg path{
   -webkit-transition:fill 0.1s;
+  -o-transition:fill 0.1s;
   transition:fill 0.1s;
   fill:inherit;
 }
@@ -4078,6 +4099,7 @@ span.flatpickr-weekday{
   -webkit-transition:transform 0.3s;
   -webkit-transition:-webkit-transform 0.3s;
   transition:-webkit-transform 0.3s;
+  -o-transition:transform 0.3s;
   transition:transform 0.3s;
   transition:transform 0.3s, -webkit-transform 0.3s;
 }
@@ -4517,6 +4539,7 @@ span.flatpickr-weekday{
   position:relative;
   -webkit-transition:-webkit-transform 0.2s linear;
   transition:-webkit-transform 0.2s linear;
+  -o-transition:transform 0.2s linear;
   transition:transform 0.2s linear;
   transition:transform 0.2s linear, -webkit-transform 0.2s linear;
   width:8px;
@@ -4717,7 +4740,8 @@ span.flatpickr-weekday{
   line-height:20px;
   max-width:100%;
   overflow:hidden;
-  text-overflow:ellipsis;
+  -o-text-overflow:ellipsis;
+     text-overflow:ellipsis;
   white-space:nowrap;
 }
 .vscomp-arrow{
@@ -4912,7 +4936,8 @@ span.flatpickr-weekday{
 }
 .vscomp-option-text{
   overflow:hidden;
-  text-overflow:ellipsis;
+  -o-text-overflow:ellipsis;
+     text-overflow:ellipsis;
   white-space:nowrap;
   -webkit-user-select:none;
   -moz-user-select:none;
@@ -4922,7 +4947,8 @@ span.flatpickr-weekday{
 }
 .vscomp-option-description{
   overflow:hidden;
-  text-overflow:ellipsis;
+  -o-text-overflow:ellipsis;
+     text-overflow:ellipsis;
   white-space:nowrap;
   color:#666;
   font-size:13px;
@@ -5039,6 +5065,7 @@ span.flatpickr-weekday{
 }
 .vscomp-wrapper .checkbox-icon::after{
   -webkit-transition-duration:0.2s;
+       -o-transition-duration:0.2s;
           transition-duration:0.2s;
   border:2px solid #888;
   content:"";
@@ -5190,6 +5217,7 @@ span.flatpickr-weekday{
 }
 .vscomp-wrapper.keep-always-open .vscomp-dropbox{
   -webkit-transition-duration:0s;
+       -o-transition-duration:0s;
           transition-duration:0s;
   border:1px solid #ddd;
   -webkit-box-shadow:none;
@@ -5222,12 +5250,14 @@ span.flatpickr-weekday{
   height:auto;
   min-height:28px;
   overflow:auto;
-  text-overflow:unset;
+  -o-text-overflow:unset;
+     text-overflow:unset;
   white-space:normal;
 }
 .vscomp-wrapper.show-value-as-tags .vscomp-value-tag{
   overflow:hidden;
-  text-overflow:ellipsis;
+  -o-text-overflow:ellipsis;
+     text-overflow:ellipsis;
   white-space:nowrap;
   -webkit-box-align:center;
       -ms-flex-align:center;
@@ -5248,7 +5278,8 @@ span.flatpickr-weekday{
 }
 .vscomp-wrapper.show-value-as-tags .vscomp-value-tag-content{
   overflow:hidden;
-  text-overflow:ellipsis;
+  -o-text-overflow:ellipsis;
+     text-overflow:ellipsis;
   white-space:nowrap;
   width:calc(100% - 20px);
 }
@@ -5755,6 +5786,7 @@ span.flatpickr-weekday{
   -webkit-transform:translateX(100%) translateZ(0);
           transform:translateX(100%) translateZ(0);
   -webkit-transition:all 190ms ease-in;
+  -o-transition:all 190ms ease-in;
   transition:all 190ms ease-in;
   width:100%;
   will-change:transform;
@@ -5764,6 +5796,7 @@ span.flatpickr-weekday{
   -webkit-transform:translateX(0) translateZ(0);
           transform:translateX(0) translateZ(0);
   -webkit-transition:all 330ms ease-out;
+  -o-transition:all 330ms ease-out;
   transition:all 330ms ease-out;
 }
 .phone .split-screen-wrapper .split-right{
@@ -5889,6 +5922,7 @@ span.flatpickr-weekday{
   border-color:var(--color-primary);
   opacity:1;
   -webkit-transition:opacity 300ms ease-in;
+  -o-transition:opacity 300ms ease-in;
   transition:opacity 300ms ease-in;
 }
 .osui-accordion-item--is-disabled{
@@ -5916,7 +5950,8 @@ span.flatpickr-weekday{
   width:100%;
 }
 .osui-accordion-item__title__placeholder{
-  text-overflow:ellipsis;
+  -o-text-overflow:ellipsis;
+     text-overflow:ellipsis;
   width:100%;
 }
 .osui-accordion-item__title--is-left{
@@ -5944,6 +5979,7 @@ span.flatpickr-weekday{
       -ms-flex-pack:center;
           justify-content:center;
   -webkit-transition:all 300ms ease-in-out;
+  -o-transition:all 300ms ease-in-out;
   transition:all 300ms ease-in-out;
   width:16px;
 }
@@ -5956,6 +5992,7 @@ span.flatpickr-weekday{
   height:100%;
   -webkit-transition:-webkit-transform 300ms ease-in-out;
   transition:-webkit-transform 300ms ease-in-out;
+  -o-transition:transform 300ms ease-in-out;
   transition:transform 300ms ease-in-out;
   transition:transform 300ms ease-in-out, -webkit-transform 300ms ease-in-out;
   width:2px;
@@ -5994,6 +6031,7 @@ span.flatpickr-weekday{
 }
 .osui-accordion-item__content--is-animating{
   -webkit-transition:all 300ms ease-in-out;
+  -o-transition:all 300ms ease-in-out;
   transition:all 300ms ease-in-out;
 }
 .osui-accordion-item__content [data-block*=AnimatedLabel]:first-child .animated-label{
@@ -6178,6 +6216,7 @@ span.flatpickr-weekday{
 }
 .card-background-color:after{
   background:-webkit-gradient(linear, left top, left bottom, from(rgba(0, 0, 0, 0)), to(rgb(0, 0, 0)));
+  background:-o-linear-gradient(top, rgba(0, 0, 0, 0) 0%, rgb(0, 0, 0) 100%);
   background:linear-gradient(180deg, rgba(0, 0, 0, 0) 0%, rgb(0, 0, 0) 100%);
   content:"";
   height:100%;
@@ -6226,7 +6265,8 @@ span.flatpickr-weekday{
 .card-detail-text{
   color:var(--color-neutral-7);
   overflow:hidden;
-  text-overflow:ellipsis;
+  -o-text-overflow:ellipsis;
+     text-overflow:ellipsis;
 }
 .is-rtl .card-detail-left{
   padding-left:var(--space-base);
@@ -6420,6 +6460,7 @@ span.flatpickr-weekday{
   -webkit-transform-style:preserve-3d;
           transform-style:preserve-3d;
   -webkit-transition:all 630ms cubic-bezier(0.03, 0.01, 0.67, 1.97);
+  -o-transition:all 630ms cubic-bezier(0.03, 0.01, 0.67, 1.97);
   transition:all 630ms cubic-bezier(0.03, 0.01, 0.67, 1.97);
 }
 .osui-flip-content__container--flip-self{
@@ -6677,7 +6718,8 @@ span.flatpickr-weekday{
 }
 .list-item-content-title, .list-item-content-text{
   overflow:hidden;
-  text-overflow:ellipsis;
+  -o-text-overflow:ellipsis;
+     text-overflow:ellipsis;
   white-space:nowrap;
 }
 .list-item-content-title{
@@ -6851,6 +6893,7 @@ span.flatpickr-weekday{
   width:-moz-fit-content;
   width:fit-content;
   -webkit-transition:opacity 250ms;
+  -o-transition:opacity 250ms;
   transition:opacity 250ms;
 }
 .osui-tooltip__balloon-wrapper__balloon{
@@ -7172,26 +7215,32 @@ span.flatpickr-weekday{
 }
 .osui-tooltip__balloon-wrapper--is-opening.left{
   -webkit-transition:left 250ms;
+  -o-transition:left 250ms;
   transition:left 250ms;
 }
 .osui-tooltip__balloon-wrapper--is-opening.right{
   -webkit-transition:right 250ms;
+  -o-transition:right 250ms;
   transition:right 250ms;
 }
 .osui-tooltip__balloon-wrapper--is-opening.center{
   -webkit-transition:top 250ms;
+  -o-transition:top 250ms;
   transition:top 250ms;
 }
 .osui-tooltip__balloon-wrapper--is-opening.top, .osui-tooltip__balloon-wrapper--is-opening.top-left, .osui-tooltip__balloon-wrapper--is-opening.top-right{
   -webkit-transition:top 250ms;
+  -o-transition:top 250ms;
   transition:top 250ms;
 }
 .osui-tooltip__balloon-wrapper--is-opening.bottom, .osui-tooltip__balloon-wrapper--is-opening.bottom-left, .osui-tooltip__balloon-wrapper--is-opening.bottom-right{
   -webkit-transition:top 250ms;
+  -o-transition:top 250ms;
   transition:top 250ms;
 }
 .osui-tooltip__balloon-wrapper--is-opening .osui-tooltip__balloon-wrapper__balloon{
   -webkit-transition:opacity 250ms;
+  -o-transition:opacity 250ms;
   transition:opacity 250ms;
 }
 .osui-tooltip__balloon-wrapper--is-open{
@@ -7420,6 +7469,7 @@ span.flatpickr-weekday{
   position:absolute;
   top:0;
   -webkit-transition:opacity 0.3s cubic-bezier(0, 0, 0.3, 1);
+  -o-transition:opacity 0.3s cubic-bezier(0, 0, 0.3, 1);
   transition:opacity 0.3s cubic-bezier(0, 0, 0.3, 1);
   width:100%;
   will-change:opacity;
@@ -7440,10 +7490,12 @@ span.flatpickr-weekday{
 }
 .action-sheet-container--visible.action-sheet-container--animatable .action-sheet{
   -webkit-transition:all 330ms ease-out;
+  -o-transition:all 330ms ease-out;
   transition:all 330ms ease-out;
 }
 .action-sheet-container--animatable .action-sheet{
   -webkit-transition:all 130ms ease-in;
+  -o-transition:all 130ms ease-in;
   transition:all 130ms ease-in;
 }
 .action-sheet-buttons{
@@ -7493,6 +7545,7 @@ span.flatpickr-weekday{
           animation-fill-mode:both;
   display:inline-block;
   -webkit-transition-timing-function:ease-out;
+       -o-transition-timing-function:ease-out;
           transition-timing-function:ease-out;
   visibility:hidden;
   width:100%;
@@ -7585,6 +7638,7 @@ span.flatpickr-weekday{
   position:absolute;
   top:8px;
   -webkit-transition:all 300ms ease;
+  -o-transition:all 300ms ease;
   transition:all 300ms ease;
   z-index:var(--layer-global-screen);
 }
@@ -7605,6 +7659,7 @@ span.flatpickr-weekday{
   border-radius:var(--border-radius-none);
   padding:var(--space-none);
   -webkit-transition:all 100ms ease-in-out;
+  -o-transition:all 100ms ease-in-out;
   transition:all 100ms ease-in-out;
 }
 .animated-label-input .form-control[data-input]:focus, .animated-label-input .form-control[data-textarea]:focus{
@@ -7692,6 +7747,7 @@ span.flatpickr-weekday{
   opacity:1;
   pointer-events:all;
   -webkit-transition:opacity 300ms ease-in;
+  -o-transition:opacity 300ms ease-in;
   transition:opacity 300ms ease-in;
 }
 .osui-balloon:not(.osui-balloon--is-open) *{
@@ -7784,6 +7840,7 @@ span.flatpickr-weekday{
   text-align:center;
   -webkit-transition:-webkit-transform 350ms var(--osui-bottom-sheet-transition-function);
   transition:-webkit-transform 350ms var(--osui-bottom-sheet-transition-function);
+  -o-transition:transform 350ms var(--osui-bottom-sheet-transition-function);
   transition:transform 350ms var(--osui-bottom-sheet-transition-function);
   transition:transform 350ms var(--osui-bottom-sheet-transition-function), -webkit-transform 350ms var(--osui-bottom-sheet-transition-function);
   -webkit-transform:translateY(100%);
@@ -7846,11 +7903,13 @@ span.flatpickr-weekday{
 .osui-bottom-sheet:not(.osui-bottom-sheet--is-open){
   -webkit-transition:-webkit-transform 200ms ease-out;
   transition:-webkit-transform 200ms ease-out;
+  -o-transition:transform 200ms ease-out;
   transition:transform 200ms ease-out;
   transition:transform 200ms ease-out, -webkit-transform 200ms ease-out;
 }
 .osui-bottom-sheet:not(.osui-bottom-sheet--is-open) + .osui-bottom-sheet-overlay{
   -webkit-transition:opacity 200ms ease-out;
+  -o-transition:opacity 200ms ease-out;
   transition:opacity 200ms ease-out;
 }
 .osui-bottom-sheet-overlay{
@@ -7862,6 +7921,7 @@ span.flatpickr-weekday{
   position:fixed;
   top:0;
   -webkit-transition:opacity 350ms ease-in;
+  -o-transition:opacity 350ms ease-in;
   transition:opacity 350ms ease-in;
   width:100vw;
   z-index:calc(var(--layer-below) + var(--osui-bottom-sheet-layer));
@@ -7896,6 +7956,7 @@ span.flatpickr-weekday{
           transform:translateY(-2px);
   -webkit-transition:opacity 200ms ease, -webkit-transform 200ms var(--osui-bottom-sheet-transition-function);
   transition:opacity 200ms ease, -webkit-transform 200ms var(--osui-bottom-sheet-transition-function);
+  -o-transition:opacity 200ms ease, transform 200ms var(--osui-bottom-sheet-transition-function);
   transition:opacity 200ms ease, transform 200ms var(--osui-bottom-sheet-transition-function);
   transition:opacity 200ms ease, transform 200ms var(--osui-bottom-sheet-transition-function), -webkit-transform 200ms var(--osui-bottom-sheet-transition-function);
   top:0;
@@ -7943,6 +8004,7 @@ span.flatpickr-weekday{
   height:40px;
   opacity:1;
   -webkit-transition:opacity 150ms linear;
+  -o-transition:opacity 150ms linear;
   transition:opacity 150ms linear;
   width:40px;
   will-change:opacity;
@@ -8397,6 +8459,7 @@ span.flatpickr-weekday{
 .safari input.flatpickr-input,
 .safari input.flatpickr-input + input{
   -webkit-transition:none;
+  -o-transition:none;
   transition:none;
 }
 .phone .flatpickr-current-month .flatpickr-monthDropdown-months,
@@ -8759,6 +8822,7 @@ html[data-uieditorversion^="1"] .osui-datepicker-calendar-ss-preview.has-today-b
   margin-right:var(--space-s);
   overflow:visible;
   -webkit-transition:background-color 0.25s ease;
+  -o-transition:background-color 0.25s ease;
   transition:background-color 0.25s ease;
   width:16px;
 }
@@ -8769,6 +8833,7 @@ html[data-uieditorversion^="1"] .osui-datepicker-calendar-ss-preview.has-today-b
   height:85%;
   opacity:0;
   -webkit-transition:opacity 0.25s ease;
+  -o-transition:opacity 0.25s ease;
   transition:opacity 0.25s ease;
   width:40%;
 }
@@ -8805,6 +8870,7 @@ html[data-uieditorversion^="1"] .osui-datepicker-calendar-ss-preview.has-today-b
   padding:var(--space-xs) var(--space-xl) var(--space-xs) var(--space-base);
   position:relative;
   -webkit-transition:height, border-color 0.25s ease;
+  -o-transition:height, border-color 0.25s ease;
   transition:height, border-color 0.25s ease;
   vertical-align:middle;
   width:100%;
@@ -8823,6 +8889,7 @@ html[data-uieditorversion^="1"] .osui-datepicker-calendar-ss-preview.has-today-b
       -ms-transform-origin:center;
           transform-origin:center;
   -webkit-transition:all 0.25s ease;
+  -o-transition:all 0.25s ease;
   transition:all 0.25s ease;
 }
 .vscomp-toggle-button:hover{
@@ -8932,6 +8999,7 @@ html[data-uieditorversion^="1"] .osui-datepicker-calendar-ss-preview.has-today-b
       align-content:center;
   background-color:var(--color-neutral-0);
   -webkit-transition:background-color 0.25s ease;
+  -o-transition:background-color 0.25s ease;
   transition:background-color 0.25s ease;
 }
 .vscomp-option.focused, .vscomp-option.selected{
@@ -9147,8 +9215,10 @@ body.vscomp-popup-active .vscomp-wrapper{
   -webkit-transform:translateY(0px) translateZ(0) scale(1);
           transform:translateY(0px) translateZ(0) scale(1);
   -webkit-transition:all 180ms ease-out;
+  -o-transition:all 180ms ease-out;
   transition:all 180ms ease-out;
   -webkit-transition-delay:calc(var(--delay) * 40ms);
+       -o-transition-delay:calc(var(--delay) * 40ms);
           transition-delay:calc(var(--delay) * 40ms);
 }
 .floating-actions-wrapper.is--open .floating-actions-item-button{
@@ -9203,6 +9273,7 @@ body.vscomp-popup-active .vscomp-wrapper{
   -webkit-transform:translateY(--space-base) translateZ(0);
           transform:translateY(--space-base) translateZ(0);
   -webkit-transition:all 100ms ease-in;
+  -o-transition:all 100ms ease-in;
   transition:all 100ms ease-in;
 }
 .floating-actions-item{
@@ -9232,9 +9303,11 @@ body.vscomp-popup-active .vscomp-wrapper{
           transform:translateZ(0) scale(0.3);
   -webkit-transition:-webkit-transform 180ms ease-out;
   transition:-webkit-transform 180ms ease-out;
+  -o-transition:transform 180ms ease-out;
   transition:transform 180ms ease-out;
   transition:transform 180ms ease-out, -webkit-transform 180ms ease-out;
   -webkit-transition-delay:calc(var(--delay) * 40ms);
+       -o-transition-delay:calc(var(--delay) * 40ms);
           transition-delay:calc(var(--delay) * 40ms);
   width:40px;
 }
@@ -9270,6 +9343,7 @@ body.vscomp-popup-active .vscomp-wrapper{
       -ms-transform-origin:center center;
           transform-origin:center center;
   -webkit-transition:all 180ms linear;
+  -o-transition:all 180ms linear;
   transition:all 180ms linear;
   width:56px;
 }
@@ -9287,6 +9361,7 @@ body.vscomp-popup-active .vscomp-wrapper{
   right:0;
   top:0;
   -webkit-transition:opacity 180ms ease-out;
+  -o-transition:opacity 180ms ease-out;
   transition:opacity 180ms ease-out;
   width:100vw;
   z-index:var(--osui-floating-actions-layer);
@@ -9580,6 +9655,7 @@ body.vscomp-popup-active .vscomp-wrapper{
   position:fixed;
   -webkit-transition:opacity 300ms ease-out, -webkit-transform 300ms ease-out;
   transition:opacity 300ms ease-out, -webkit-transform 300ms ease-out;
+  -o-transition:transform 300ms ease-out, opacity 300ms ease-out;
   transition:transform 300ms ease-out, opacity 300ms ease-out;
   transition:transform 300ms ease-out, opacity 300ms ease-out, -webkit-transform 300ms ease-out;
   -webkit-user-select:none;
@@ -9766,6 +9842,7 @@ body.vscomp-popup-active .vscomp-wrapper{
   height:var(--range-slider-handle-size);
   -webkit-transition:-webkit-transform 150ms ease-out;
   transition:-webkit-transform 150ms ease-out;
+  -o-transition:transform 150ms ease-out;
   transition:transform 150ms ease-out;
   transition:transform 150ms ease-out, -webkit-transform 150ms ease-out;
   width:var(--range-slider-handle-size);
@@ -10094,6 +10171,7 @@ body.vscomp-popup-active .vscomp-wrapper{
   right:13px;
   top:50%;
   -webkit-transition:all 300ms ease;
+  -o-transition:all 300ms ease;
   transition:all 300ms ease;
   width:16px;
 }
@@ -10108,6 +10186,7 @@ body.vscomp-popup-active .vscomp-wrapper{
       -ms-transform:rotate(-45deg);
           transform:rotate(-45deg);
   -webkit-transition:all 300ms ease;
+  -o-transition:all 300ms ease;
   transition:all 300ms ease;
   width:3px;
 }
@@ -10120,12 +10199,14 @@ body.vscomp-popup-active .vscomp-wrapper{
       -ms-transform:translate(0, calc(-100% - var(--os-safe-area-top)));
           transform:translate(0, calc(-100% - var(--os-safe-area-top)));
   -webkit-transition:all 300ms ease;
+  -o-transition:all 300ms ease;
   transition:all 300ms ease;
 }
 .layout-native .header-right .search-input input[data-input], .layout-native .header-right .search-input input[data-input]:empty{
   height:34px;
   padding-left:var(--space-xl);
   -webkit-transition:none;
+  -o-transition:none;
   transition:none;
 }
 .layout-native .header-right .search-input input[data-input]:focus{
@@ -10168,6 +10249,7 @@ body.vscomp-popup-active .vscomp-wrapper{
   position:fixed;
   top:0;
   -webkit-transition:all 130ms ease-in;
+  -o-transition:all 130ms ease-in;
   transition:all 130ms ease-in;
   width:var(--sidebar-width);
   will-change:transform;
@@ -10245,6 +10327,7 @@ body.vscomp-popup-active .vscomp-wrapper{
   position:fixed;
   top:0;
   -webkit-transition:opacity 130ms ease-in;
+  -o-transition:opacity 130ms ease-in;
   transition:opacity 130ms ease-in;
   width:200vw;
   will-change:opacity;
@@ -10267,6 +10350,7 @@ body.vscomp-popup-active .vscomp-wrapper{
           transform:none;
   -webkit-transition:-webkit-transform 330ms ease-out;
   transition:-webkit-transform 330ms ease-out;
+  -o-transition:transform 330ms ease-out;
   transition:transform 330ms ease-out;
   transition:transform 330ms ease-out, -webkit-transform 330ms ease-out;
   will-change:transform;
@@ -10369,6 +10453,7 @@ body.vscomp-popup-active .vscomp-wrapper{
 }
 .stackedcards--animatable{
   -webkit-transition:all 400ms ease;
+  -o-transition:all 400ms ease;
   transition:all 400ms ease;
 }
 .stackedcards .init{
@@ -10675,7 +10760,8 @@ html[data-uieditorversion^="1"] .osui-timepicker__dropdown-ss-preview.time12h, h
 .bottom-bar-item-text{
   font-size:10px;
   overflow:hidden;
-  text-overflow:ellipsis;
+  -o-text-overflow:ellipsis;
+     text-overflow:ellipsis;
   white-space:nowrap;
   word-wrap:break-word;
 }
@@ -11059,6 +11145,7 @@ html[data-uieditorversion^="1"] .osui-timepicker__dropdown-ss-preview.time12h, h
   display:flex;
   padding:var(--space-none) var(--space-s);
   -webkit-transition:all 150ms linear;
+  -o-transition:all 150ms linear;
   transition:all 150ms linear;
 }
 .osui-submenu__header__icon{
@@ -11070,6 +11157,7 @@ html[data-uieditorversion^="1"] .osui-timepicker__dropdown-ss-preview.time12h, h
       -ms-transform:rotate(-45deg);
           transform:rotate(-45deg);
   -webkit-transition:all 150ms linear;
+  -o-transition:all 150ms linear;
   transition:all 150ms linear;
 }
 .osui-submenu__header__icon:before{
@@ -11081,6 +11169,7 @@ html[data-uieditorversion^="1"] .osui-timepicker__dropdown-ss-preview.time12h, h
   content:"";
   height:6px;
   -webkit-transition:all 150ms linear;
+  -o-transition:all 150ms linear;
   transition:all 150ms linear;
   width:6px;
 }
@@ -11095,6 +11184,7 @@ html[data-uieditorversion^="1"] .osui-timepicker__dropdown-ss-preview.time12h, h
   height:100%;
   position:relative;
   -webkit-transition:all 150ms linear;
+  -o-transition:all 150ms linear;
   transition:all 150ms linear;
   -servicestudio-min-width:100px;
   -servicestudio-margin-left:calc(var(--space-s) * -1);
@@ -11136,6 +11226,7 @@ html[data-uieditorversion^="1"] .osui-timepicker__dropdown-ss-preview.time12h, h
       -ms-transform:translateY(-8px);
           transform:translateY(-8px);
   -webkit-transition:all 130ms ease-out;
+  -o-transition:all 130ms ease-out;
   transition:all 130ms ease-out;
   z-index:var(--layer-global-elevated);
 }
@@ -11481,6 +11572,7 @@ html[data-uieditorversion^="1"] .osui-timepicker__dropdown-ss-preview.time12h, h
   position:absolute;
   -webkit-transition:-webkit-transform 200ms linear;
   transition:-webkit-transform 200ms linear;
+  -o-transition:transform 200ms linear;
   transition:transform 200ms linear;
   transition:transform 200ms linear, -webkit-transform 200ms linear;
   -webkit-transform-origin:0 0;
@@ -12040,10 +12132,12 @@ html[data-uieditorversion^="1"] .wizard-wrapper-item{
 }
 .osui-progress-bar__container.animate-entrance .osui-progress-bar__value:before{
   -webkit-transition-delay:0.5s;
+       -o-transition-delay:0.5s;
           transition-delay:0.5s;
 }
 .osui-progress-bar__container.animate-entrance .osui-progress-bar__value:before, .osui-progress-bar__container.animate-progress-change .osui-progress-bar__value:before{
   -webkit-transition-duration:0.35s;
+       -o-transition-duration:0.35s;
           transition-duration:0.35s;
 }
 .osui-progress-bar__value{
@@ -12152,14 +12246,17 @@ html[data-uieditorversion^="1"] .wizard-wrapper-item{
   stroke-dashoffset:var(--stroke-dashoffset);
   stroke-linecap:var(--shape);
   -webkit-transition:stroke-dashoffset 0;
+  -o-transition:stroke-dashoffset 0;
   transition:stroke-dashoffset 0;
 }
 .osui-progress-circle__container__progress-path.animate-entrance, .osui-progress-circle__container__progress-path.animate-progress-change{
   -webkit-transition-duration:0.35s;
+       -o-transition-duration:0.35s;
           transition-duration:0.35s;
 }
 .osui-progress-circle__container__progress-path.animate-entrance{
   -webkit-transition-delay:0.5s;
+       -o-transition-delay:0.5s;
           transition-delay:0.5s;
 }
 .osui-progress-circle__container__trail-path{
@@ -12239,6 +12336,7 @@ html[data-uieditorversion^="1"] .wizard-wrapper-item{
   position:absolute;
   top:0;
   -webkit-transition:opacity linear 150ms;
+  -o-transition:opacity linear 150ms;
   transition:opacity linear 150ms;
 }
 .rating-item-filled, .rating-item-half, .rating-item-empty{
@@ -12378,6 +12476,7 @@ html[data-uieditorversion^="1"] .wizard-wrapper-item{
   display:-ms-inline-flexbox;
   display:inline-flex;
   -webkit-transition:none;
+  -o-transition:none;
   transition:none;
   vertical-align:middle;
   white-space:nowrap;
@@ -12510,12 +12609,14 @@ html[data-uieditorversion^="1"] .wizard-wrapper-item{
 }
 .pull-to-refresh .genericon{
   -webkit-transition:all 0.25s ease;
+  -o-transition:all 0.25s ease;
   transition:all 0.25s ease;
 }
 .ptr-loading .content,
 .ptr-loading .pull-to-refresh, .ptr-reset .content,
 .ptr-reset .pull-to-refresh{
   -webkit-transition:all 0.25s ease;
+  -o-transition:all 0.25s ease;
   transition:all 0.25s ease;
 }
 .ptr-loading .pull-to-refresh .genericon, .ptr-reset .pull-to-refresh .genericon{
@@ -12615,6 +12716,7 @@ html[data-uieditorversion^="1"] .wizard-wrapper-item{
   top:0;
   -webkit-transition:-webkit-transform 200ms ease-in-out;
   transition:-webkit-transform 200ms ease-in-out;
+  -o-transition:transform 200ms ease-in-out;
   transition:transform 200ms ease-in-out;
   transition:transform 200ms ease-in-out, -webkit-transform 200ms ease-in-out;
 }
@@ -12626,7 +12728,8 @@ html[data-uieditorversion^="1"] .wizard-wrapper-item{
 }
 .osui-dropdown-serverside__selected-values > *:first-child{
   overflow:hidden;
-  text-overflow:ellipsis;
+  -o-text-overflow:ellipsis;
+     text-overflow:ellipsis;
   white-space:nowrap;
   width:100%;
 }
@@ -12647,6 +12750,7 @@ html[data-uieditorversion^="1"] .wizard-wrapper-item{
   padding:var(--space-none) var(--space-base);
   position:relative;
   -webkit-transition:border 250ms ease-in-out;
+  -o-transition:border 250ms ease-in-out;
   transition:border 250ms ease-in-out;
   width:100%;
 }
@@ -12672,6 +12776,7 @@ html[data-uieditorversion^="1"] .wizard-wrapper-item{
   overflow:hidden;
   position:absolute;
   -webkit-transition:opacity 300ms ease;
+  -o-transition:opacity 300ms ease;
   transition:opacity 300ms ease;
   width:100%;
   z-index:var(--layer-global-elevated);
@@ -12702,6 +12807,7 @@ html[data-uieditorversion^="1"] .wizard-wrapper-item{
           transform:translateY(calc(-1 * var(--osui-dropdown-ss-thresholdanimateval)));
   -webkit-transition:opacity 250ms ease, -webkit-transform 300ms ease-in-out;
   transition:opacity 250ms ease, -webkit-transform 300ms ease-in-out;
+  -o-transition:opacity 250ms ease, transform 300ms ease-in-out;
   transition:opacity 250ms ease, transform 300ms ease-in-out;
   transition:opacity 250ms ease, transform 300ms ease-in-out, -webkit-transform 300ms ease-in-out;
 }
@@ -12801,6 +12907,7 @@ html[data-uieditorversion^="1"] .wizard-wrapper-item{
       -ms-transform:translateY(0);
           transform:translateY(0);
   -webkit-transition:opacity 250ms ease;
+  -o-transition:opacity 250ms ease;
   transition:opacity 250ms ease;
 }
 .osui-dropdown-serverside__balloon--is-top .osui-dropdown-serverside__balloon-content{
@@ -12937,6 +13044,7 @@ body:has(.popup-dialog):has(.osui-dropdown-serverside--is-opened) .osui-dropdown
   overflow:hidden;
   top:0;
   -webkit-transition:opacity 250ms ease;
+  -o-transition:opacity 250ms ease;
   transition:opacity 250ms ease;
   z-index:var(--layer-global-instant-interaction);
 }
@@ -12987,6 +13095,7 @@ body:has(.popup-dialog):has(.osui-dropdown-serverside--is-opened) .osui-dropdown
   padding:var(--space-s) var(--space-base);
   position:relative;
   -webkit-transition:background 250ms ease;
+  -o-transition:background 250ms ease;
   transition:background 250ms ease;
   width:100%;
   z-index:var(--layer-global-screen);
@@ -13014,7 +13123,8 @@ body:has(.popup-dialog):has(.osui-dropdown-serverside--is-opened) .osui-dropdown
 }
 .osui-dropdown-serverside-item__content > *:first-child{
   overflow:hidden;
-  text-overflow:ellipsis;
+  -o-text-overflow:ellipsis;
+     text-overflow:ellipsis;
   white-space:nowrap;
   width:100%;
 }
@@ -13083,6 +13193,7 @@ body:has(.popup-dialog):has(.osui-dropdown-serverside--is-opened) .osui-dropdown
   font-size:24px;
   font-weight:400;
   -webkit-transition:all 300ms ease-in-out;
+  -o-transition:all 300ms ease-in-out;
   transition:all 300ms ease-in-out;
 }
 .section-expandable .section-expandable-icon:after{
@@ -13108,6 +13219,7 @@ body:has(.popup-dialog):has(.osui-dropdown-serverside--is-opened) .osui-dropdown
 }
 .section-expandable .section-expandable-content-animating, .section-expandable .section-expandable-content.is--animating{
   -webkit-transition:all 300ms ease-in-out;
+  -o-transition:all 300ms ease-in-out;
   transition:all 300ms ease-in-out;
 }
 .section-expandable .section-expandable-content.no-padding{
@@ -13209,6 +13321,7 @@ button.OSFillParent{
   overflow:hidden;
   position:relative;
   -webkit-transition:all 400ms ease;
+  -o-transition:all 400ms ease;
   transition:all 400ms ease;
   will-change:transform;
 }
@@ -13252,6 +13365,7 @@ button.OSFillParent{
 }
 .carousel--animatable{
   -webkit-transition:all 250ms linear;
+  -o-transition:all 250ms linear;
   transition:all 250ms linear;
   will-change:transform;
 }
@@ -13337,6 +13451,7 @@ button.OSFillParent{
       -ms-transform:translateY(-25px);
           transform:translateY(-25px);
   -webkit-transition:opacity 150ms linear;
+  -o-transition:opacity 150ms linear;
   transition:opacity 150ms linear;
   width:40px;
   will-change:opacity;
@@ -13377,6 +13492,7 @@ button.OSFillParent{
 .carousel-is-moving .hide-on-drag{
   opacity:0;
   -webkit-transition:opacity 250ms ease;
+  -o-transition:opacity 250ms ease;
   transition:opacity 250ms ease;
 }
 .carousel .list.list-group{
@@ -13889,6 +14005,7 @@ input.OSFillParent.calendar-input{
   line-height:calc(var(--font-size-base) * 2);
   padding-left:var(--space-base);
   -webkit-transition:all 180ms linear;
+  -o-transition:all 180ms linear;
   transition:all 180ms linear;
   vertical-align:top;
   width:100%;
@@ -14052,6 +14169,7 @@ input.OSFillParent.calendar-input{
   height:40px;
   padding:var(--space-none) var(--space-base);
   -webkit-transition:all 180ms linear;
+  -o-transition:all 180ms linear;
   transition:all 180ms linear;
 }
 .section-expandable-content .choices__list--dropdown.is-active{
@@ -14136,6 +14254,7 @@ input.OSFillParent.calendar-input{
       -ms-transform-origin:center;
           transform-origin:center;
   -webkit-transition:all 300ms ease;
+  -o-transition:all 300ms ease;
   transition:all 300ms ease;
 }
 .choices[data-type*=select-one].is-open:after{
@@ -14177,7 +14296,8 @@ input.OSFillParent.calendar-input{
   color:var(--color-neutral-10);
   overflow:hidden;
   padding-right:var(--space-base);
-  text-overflow:ellipsis;
+  -o-text-overflow:ellipsis;
+     text-overflow:ellipsis;
   white-space:nowrap;
   width:99%;
 }
@@ -14337,6 +14457,7 @@ input.OSFillParent.calendar-input{
 .flip-content-container{
   position:relative;
   -webkit-transition:all 630ms cubic-bezier(0.03, 0.01, 0.67, 1.97);
+  -o-transition:all 630ms cubic-bezier(0.03, 0.01, 0.67, 1.97);
   transition:all 630ms cubic-bezier(0.03, 0.01, 0.67, 1.97);
   -webkit-transform-style:preserve-3d;
   transform-style:preserve-3d;
@@ -14486,10 +14607,12 @@ input.OSFillParent.calendar-input{
 }
 .notification--visible.notification--animatable{
   -webkit-transition:all 330ms ease-out;
+  -o-transition:all 330ms ease-out;
   transition:all 330ms ease-out;
 }
 .notification--animatable{
   -webkit-transition:all 130ms ease-in;
+  -o-transition:all 130ms ease-in;
   transition:all 130ms ease-in;
 }
 .layout-native .notification{
@@ -14548,6 +14671,7 @@ input.OSFillParent.calendar-input{
       -ms-transform-origin:left;
           transform-origin:left;
   -webkit-transition:all 750ms ease-out;
+  -o-transition:all 750ms ease-out;
   transition:all 750ms ease-out;
   will-change:width;
 }
@@ -14691,6 +14815,7 @@ input.OSFillParent.calendar-input{
       -ms-transform:translateX(102%);
           transform:translateX(102%);
   -webkit-transition:all 130ms ease-in;
+  -o-transition:all 130ms ease-in;
   transition:all 130ms ease-in;
   width:500px;
   will-change:transform;
@@ -14727,6 +14852,7 @@ input.OSFillParent.calendar-input{
       -ms-transform:none;
           transform:none;
   -webkit-transition:all 330ms ease-out;
+  -o-transition:all 330ms ease-out;
   transition:all 330ms ease-out;
   will-change:transform;
 }
@@ -14823,6 +14949,7 @@ input.OSFillParent.calendar-input{
   display:flex;
   padding:var(--space-none) var(--space-s);
   -webkit-transition:all 150ms linear;
+  -o-transition:all 150ms linear;
   transition:all 150ms linear;
 }
 .submenu-icon{
@@ -14834,6 +14961,7 @@ input.OSFillParent.calendar-input{
       -ms-transform:rotate(-45deg);
           transform:rotate(-45deg);
   -webkit-transition:all 150ms linear;
+  -o-transition:all 150ms linear;
   transition:all 150ms linear;
 }
 .submenu-icon:before{
@@ -14845,6 +14973,7 @@ input.OSFillParent.calendar-input{
   content:"";
   height:6px;
   -webkit-transition:all 150ms linear;
+  -o-transition:all 150ms linear;
   transition:all 150ms linear;
   width:6px;
 }
@@ -14859,6 +14988,7 @@ input.OSFillParent.calendar-input{
   height:100%;
   position:relative;
   -webkit-transition:all 150ms linear;
+  -o-transition:all 150ms linear;
   transition:all 150ms linear;
 }
 .submenu-item a{
@@ -14895,6 +15025,7 @@ input.OSFillParent.calendar-input{
       -ms-transform:translateY(-8px);
           transform:translateY(-8px);
   -webkit-transition:all 130ms ease-out;
+  -o-transition:all 130ms ease-out;
   transition:all 130ms ease-out;
   z-index:var(--layer-global-elevated);
 }
@@ -15170,6 +15301,7 @@ input.OSFillParent.calendar-input{
   margin-left:var(--space-l);
   padding:var(--space-base) var(--space-xs);
   -webkit-transition:border 150ms linear;
+  -o-transition:border 150ms linear;
   transition:border 150ms linear;
   white-space:nowrap;
 }
@@ -15226,6 +15358,7 @@ input.OSFillParent.calendar-input{
 .layout-native .tabs-content-wrapper{
   -webkit-transition:-webkit-transform 230ms ease-in-out;
   transition:-webkit-transform 230ms ease-in-out;
+  -o-transition:transform 230ms ease-in-out;
   transition:transform 230ms ease-in-out;
   transition:transform 230ms ease-in-out, -webkit-transform 230ms ease-in-out;
 }
@@ -16305,7 +16438,8 @@ input.OSFillParent.calendar-input{
 }
 .text-ellipsis{
   overflow:hidden;
-  text-overflow:ellipsis;
+  -o-text-overflow:ellipsis;
+     text-overflow:ellipsis;
   white-space:nowrap;
 }
 /*! 7.9. Border Size */
@@ -17488,6 +17622,7 @@ img.thumbnail{
 /*! 7.24. Miscellaneous */
 .no-transition{
   -webkit-transition:none !important;
+  -o-transition:none !important;
   transition:none !important;
 }
 .no-transform{
@@ -17545,6 +17680,7 @@ img.thumbnail{
 .fade-leave.fade-leave-active{
   -webkit-transition:opacity 400ms ease-in-out, -webkit-transform 400ms ease-in-out;
   transition:opacity 400ms ease-in-out, -webkit-transform 400ms ease-in-out;
+  -o-transition:transform 400ms ease-in-out, opacity 400ms ease-in-out;
   transition:transform 400ms ease-in-out, opacity 400ms ease-in-out;
   transition:transform 400ms ease-in-out, opacity 400ms ease-in-out, -webkit-transform 400ms ease-in-out;
 }
@@ -17560,6 +17696,7 @@ img.thumbnail{
 .fade-leave.fade-leave-active .content{
   -webkit-transition:opacity 400ms ease-in-out, -webkit-transform 400ms ease-in-out;
   transition:opacity 400ms ease-in-out, -webkit-transform 400ms ease-in-out;
+  -o-transition:transform 400ms ease-in-out, opacity 400ms ease-in-out;
   transition:transform 400ms ease-in-out, opacity 400ms ease-in-out;
   transition:transform 400ms ease-in-out, opacity 400ms ease-in-out, -webkit-transform 400ms ease-in-out;
 }
@@ -17636,6 +17773,7 @@ img.thumbnail{
 .fade-enter.fade-enter-active .header{
   -webkit-transition:opacity 400ms ease-in-out, -webkit-transform 400ms ease-in-out;
   transition:opacity 400ms ease-in-out, -webkit-transform 400ms ease-in-out;
+  -o-transition:transform 400ms ease-in-out, opacity 400ms ease-in-out;
   transition:transform 400ms ease-in-out, opacity 400ms ease-in-out;
   transition:transform 400ms ease-in-out, opacity 400ms ease-in-out, -webkit-transform 400ms ease-in-out;
 }
@@ -17646,6 +17784,7 @@ img.thumbnail{
 .fade-leave.fade-leave-active{
   opacity:0;
   -webkit-transition:all 400ms ease-in-out;
+  -o-transition:all 400ms ease-in-out;
   transition:all 400ms ease-in-out;
 }
 .fade-leave.fade-leave-active .header{
@@ -17653,6 +17792,7 @@ img.thumbnail{
   -webkit-transform:translateY(-200px) translateZ(0);
           transform:translateY(-200px) translateZ(0);
   -webkit-transition:none;
+  -o-transition:none;
   transition:none;
 }
 .fade-leave.screen-container{

--- a/dist/OutSystemsUI.d.ts
+++ b/dist/OutSystemsUI.d.ts
@@ -559,7 +559,7 @@ declare namespace OSFramework.OSUI.Behaviors {
 declare namespace OSFramework.OSUI.Event.DOMEvents {
     abstract class AbstractEvent<T> implements IEvent<T> {
         private _handlers;
-        protected get handlers(): GlobalCallbacks.OSGeneric[];
+        get handlers(): GlobalCallbacks.OSGeneric[];
         addHandler(handler: GlobalCallbacks.OSGeneric): void;
         hasHandlers(): boolean;
         removeHandler(handler: GlobalCallbacks.OSGeneric): void;
@@ -582,6 +582,7 @@ declare namespace OSFramework.OSUI.Event.DOMEvents {
 }
 declare namespace OSFramework.OSUI.Event.DOMEvents {
     interface IEvent<D> {
+        handlers: GlobalCallbacks.OSGeneric[];
         addEvent(): void;
         addHandler(handler: GlobalCallbacks.OSGeneric, ...args: any[]): void;
         hasHandlers(): boolean;

--- a/dist/OutSystemsUI.js
+++ b/dist/OutSystemsUI.js
@@ -1023,6 +1023,9 @@ var OSFramework;
                         if (this._events.has(eventType)) {
                             const event = this._events.get(eventType);
                             event.removeHandler(handler);
+                            if (event.handlers.length === 0) {
+                                this._events.delete(eventType);
+                            }
                         }
                     }
                     trigger(eventType, data, ...args) {
@@ -3996,6 +3999,7 @@ var OSFramework;
                         this._accordionItemContentElem = undefined;
                         this._accordionItemIconElem = undefined;
                         this._accordionItemPlaceholder = undefined;
+                        this._accordionTitleFocusableChildren = [];
                     }
                     get isDisabled() {
                         return this.configs.IsDisabled;

--- a/src/scripts/OSFramework/OSUI/Event/DOMEvents/AbstractEvent.ts
+++ b/src/scripts/OSFramework/OSUI/Event/DOMEvents/AbstractEvent.ts
@@ -17,7 +17,7 @@ namespace OSFramework.OSUI.Event.DOMEvents {
 		 * Getter for handlers
 		 *
 		 * @readonly
-		 * @protected
+		 * @public
 		 * @type {GlobalCallbacks.OSGeneric[]}
 		 * @memberof AbstractEvent
 		 */

--- a/src/scripts/OSFramework/OSUI/Event/DOMEvents/AbstractEvent.ts
+++ b/src/scripts/OSFramework/OSUI/Event/DOMEvents/AbstractEvent.ts
@@ -21,7 +21,7 @@ namespace OSFramework.OSUI.Event.DOMEvents {
 		 * @type {GlobalCallbacks.OSGeneric[]}
 		 * @memberof AbstractEvent
 		 */
-		protected get handlers(): GlobalCallbacks.OSGeneric[] {
+		public get handlers(): GlobalCallbacks.OSGeneric[] {
 			return this._handlers;
 		}
 

--- a/src/scripts/OSFramework/OSUI/Event/DOMEvents/AbstractEventsManager.ts
+++ b/src/scripts/OSFramework/OSUI/Event/DOMEvents/AbstractEventsManager.ts
@@ -63,6 +63,11 @@ namespace OSFramework.OSUI.Event.DOMEvents {
 			if (this._events.has(eventType)) {
 				const event = this._events.get(eventType);
 				event.removeHandler(handler);
+
+				// If this was the last handler, then remove this eventType
+				if (event.handlers.length === 0) {
+					this._events.delete(eventType);
+				}
 			}
 		}
 

--- a/src/scripts/OSFramework/OSUI/Event/DOMEvents/IEvent.ts
+++ b/src/scripts/OSFramework/OSUI/Event/DOMEvents/IEvent.ts
@@ -8,6 +8,7 @@ namespace OSFramework.OSUI.Event.DOMEvents {
 	 * @template D this will the type of Data to be passed, by default to the handlers.
 	 */
 	export interface IEvent<D> {
+		handlers: GlobalCallbacks.OSGeneric[];
 		addEvent(): void;
 		addHandler(handler: GlobalCallbacks.OSGeneric, ...args): void;
 		hasHandlers(): boolean;


### PR DESCRIPTION
This PR is for improving the management of the events. This was found when improving the lifecycle of the orientationChange event (OutSystems code), that was not being added again in runtime, as the _events map wasn't correctly removing the eventType, when the last handler was removed.

### Checklist

-   [x] tested locally
-   [x] documented the code
-   [x] clean all warnings and errors of eslint
-   [x] requires changes in OutSystems (if so, provide a module with changes)
-   [ ] requires new sample page in OutSystems (if so, provide a module with changes)
