### PR TITLE
ROU-4420: Fix an issue on AnimatedLabel inside lists

### DIFF
--- a/dist/OutSystemsUI.css
+++ b/dist/OutSystemsUI.css
@@ -7695,6 +7695,9 @@ span.flatpickr-weekday{
 .animated-label-input .form-control[data-textarea] + span.validation-message{
   bottom:7px;
 }
+.list.list-group > [data-block*=AnimatedLabel]:first-child .animated-label{
+  margin-top:var(--space-s);
+}
 .form .animated-label-input .form-control[data-textarea] + span.validation-message{
   position:relative;
   bottom:var(--space-m);

--- a/src/scripts/OSFramework/OSUI/Pattern/AnimatedLabel/scss/_animated-label.scss
+++ b/src/scripts/OSFramework/OSUI/Pattern/AnimatedLabel/scss/_animated-label.scss
@@ -105,6 +105,11 @@
 	}
 }
 
+/* Fix for animated labels inside lists */
+.list.list-group > [data-block*='AnimatedLabel']:first-child .animated-label {
+	margin-top: var(--space-s);
+}
+
 ///
 .form {
 	.animated-label {


### PR DESCRIPTION
This PR is for fixing the issue on AnimatedLabels when is used inside lists.

### What was happening
- The AnimatedLabel uses negative margins to place the text and this goes to outside the pattern and when is used inside elements with overflow: hidden, this issue will occur:
<img width="1149" alt="image" src="https://github.com/OutSystems/outsystems-ui/assets/25321845/d6de7b13-f1d9-4528-955e-286a400e34df">

### What was done
- Created a selector that push down the animated label when is the first child of a list:
<img width="1153" alt="image" src="https://github.com/OutSystems/outsystems-ui/assets/25321845/4fdd3156-774a-46fc-9965-39b103d4a043">

### Test Steps
1. Open Test page
2. Check if the AnimatedLabels is correctly displayed;

### Checklist
-   [X] tested locally
-   [X] documented the code
-   [X] clean all warnings and errors of eslint
-   [ ] requires changes in OutSystems (if so, provide a module with changes)
-   [ ] requires new sample page in OutSystems (if so, provide a module with changes)
