### PR TITLE
ROU-4391: OverflowMenu - Client Actions to enable/disable the overflow menu

### DIFF
--- a/dist/OutSystemsUI.d.ts
+++ b/dist/OutSystemsUI.d.ts
@@ -2422,6 +2422,8 @@ declare namespace OSFramework.OSUI.Patterns.OverflowMenu.Enum {
 }
 declare namespace OSFramework.OSUI.Patterns.OverflowMenu {
     interface IOverflowMenu extends Interface.IPattern, Interface.IOpenable {
+        disable(): void;
+        enable(): void;
     }
 }
 declare namespace OSFramework.OSUI.Patterns.OverflowMenu {
@@ -2431,6 +2433,7 @@ declare namespace OSFramework.OSUI.Patterns.OverflowMenu {
         private _balloonFeature;
         private _eventBalloonOnToggle;
         private _eventOnClick;
+        private _isDisabled;
         private _isOpenedByApi;
         private _platformEventOnToggle;
         private _triggerElem;
@@ -2453,7 +2456,9 @@ declare namespace OSFramework.OSUI.Patterns.OverflowMenu {
         build(): void;
         changeProperty(propertyName: string, propertyValue: unknown): void;
         close(): void;
+        disable(): void;
         dispose(): void;
+        enable(): void;
         open(isOpenedByApi: boolean): void;
         registerCallback(eventName: string, callback: GlobalCallbacks.OSGeneric): void;
         setBalloonOptions(balloonOptions?: Feature.Balloon.BalloonOptions): void;
@@ -4060,6 +4065,8 @@ declare namespace OutSystems.OSUI.ErrorCodes {
         FailRegisterCallback: string;
         FailOpen: string;
         FailClose: string;
+        FailEnable: string;
+        FailDisable: string;
     };
     const Video: {
         FailChangeProperty: string;
@@ -4273,7 +4280,9 @@ declare namespace OutSystems.OSUI.Patterns.NotificationAPI {
 declare namespace OutSystems.OSUI.Patterns.OverflowMenuAPI {
     function ChangeProperty(overflowMenuId: string, propertyName: string, propertyValue: unknown): string;
     function Create(overflowMenuId: string, configs: string): OSFramework.OSUI.Patterns.OverflowMenu.IOverflowMenu;
+    function Disable(overflowMenuId: string): string;
     function Dispose(overflowMenuId: string): string;
+    function Enable(overflowMenuId: string): string;
     function GetAllOverflowMenus(): Array<string>;
     function GetOverflowMenuById(overflowMenuId: string): OSFramework.OSUI.Patterns.OverflowMenu.IOverflowMenu;
     function Initialize(overflowMenuId: string): OSFramework.OSUI.Patterns.OverflowMenu.IOverflowMenu;

--- a/dist/OutSystemsUI.js
+++ b/dist/OutSystemsUI.js
@@ -3996,6 +3996,7 @@ var OSFramework;
                         this._accordionItemContentElem = undefined;
                         this._accordionItemIconElem = undefined;
                         this._accordionItemPlaceholder = undefined;
+                        this._accordionTitleFocusableChildren = [];
                     }
                     get isDisabled() {
                         return this.configs.IsDisabled;
@@ -7155,6 +7156,7 @@ var OSFramework;
                 class OverflowMenu extends Patterns.AbstractPattern {
                     constructor(uniqueId, configs) {
                         super(uniqueId, new OverflowMenu_1.OverflowMenuConfig(configs));
+                        this._isDisabled = false;
                         this._isOpenedByApi = false;
                         this.isOpen = false;
                     }
@@ -7259,6 +7261,11 @@ var OSFramework;
                             this._balloonFeature.close();
                         }
                     }
+                    disable() {
+                        this._isDisabled = true;
+                        this.close();
+                        OSUI.Helper.Dom.Attribute.Set(this._triggerElem, OSUI.GlobalEnum.HTMLAttributes.Disabled, '');
+                    }
                     dispose() {
                         var _a;
                         (_a = this._balloonFeature) === null || _a === void 0 ? void 0 : _a.dispose();
@@ -7267,8 +7274,12 @@ var OSFramework;
                         this.unsetHtmlElements();
                         super.dispose();
                     }
+                    enable() {
+                        this._isDisabled = false;
+                        OSUI.Helper.Dom.Attribute.Remove(this._triggerElem, OSUI.GlobalEnum.HTMLAttributes.Disabled);
+                    }
                     open(isOpenedByApi) {
-                        if (this._balloonFeature.isOpen === false) {
+                        if (this._balloonFeature.isOpen === false && this._isDisabled === false) {
                             this._isOpenedByApi = isOpenedByApi;
                             this._balloonFeature.open(this._isOpenedByApi);
                         }
@@ -12090,6 +12101,8 @@ var OutSystems;
                 FailRegisterCallback: 'OSUI-API-30003',
                 FailOpen: 'OSUI-API-30004',
                 FailClose: 'OSUI-API-30005',
+                FailEnable: 'OSUI-API-30006',
+                FailDisable: 'OSUI-API-30007',
             };
             ErrorCodes.Video = {
                 FailChangeProperty: 'OSUI-API-31001',
@@ -13821,6 +13834,17 @@ var OutSystems;
                     return _overflowMenuItem;
                 }
                 OverflowMenuAPI.Create = Create;
+                function Disable(overflowMenuId) {
+                    const result = OutSystems.OSUI.Utils.CreateApiResponse({
+                        errorCode: OSUI.ErrorCodes.OverflowMenu.FailDisable,
+                        callback: () => {
+                            const _overflowMenu = GetOverflowMenuById(overflowMenuId);
+                            _overflowMenu.disable();
+                        },
+                    });
+                    return result;
+                }
+                OverflowMenuAPI.Disable = Disable;
                 function Dispose(overflowMenuId) {
                     const result = OutSystems.OSUI.Utils.CreateApiResponse({
                         errorCode: OSUI.ErrorCodes.OverflowMenu.FailDispose,
@@ -13833,6 +13857,17 @@ var OutSystems;
                     return result;
                 }
                 OverflowMenuAPI.Dispose = Dispose;
+                function Enable(overflowMenuId) {
+                    const result = OutSystems.OSUI.Utils.CreateApiResponse({
+                        errorCode: OSUI.ErrorCodes.OverflowMenu.FailEnable,
+                        callback: () => {
+                            const _overflowMenu = GetOverflowMenuById(overflowMenuId);
+                            _overflowMenu.enable();
+                        },
+                    });
+                    return result;
+                }
+                OverflowMenuAPI.Enable = Enable;
                 function GetAllOverflowMenus() {
                     return OSFramework.OSUI.Helper.MapOperation.ExportKeys(_overflowMenuMap);
                 }

--- a/src/scripts/OSFramework/OSUI/Pattern/OverflowMenu/IOverflowMenu.ts
+++ b/src/scripts/OSFramework/OSUI/Pattern/OverflowMenu/IOverflowMenu.ts
@@ -3,5 +3,8 @@ namespace OSFramework.OSUI.Patterns.OverflowMenu {
 	/**
 	 * Defines the interface for OutSystemsUI OverflowMenu Pattern
 	 */
-	export interface IOverflowMenu extends Interface.IPattern, Interface.IOpenable {}
+	export interface IOverflowMenu extends Interface.IPattern, Interface.IOpenable {
+		disable(): void;
+		enable(): void;
+	}
 }

--- a/src/scripts/OSFramework/OSUI/Pattern/OverflowMenu/OverflowMenu.ts
+++ b/src/scripts/OSFramework/OSUI/Pattern/OverflowMenu/OverflowMenu.ts
@@ -18,6 +18,8 @@ namespace OSFramework.OSUI.Patterns.OverflowMenu {
 		// Store the Event Callbacks
 		private _eventBalloonOnToggle: GlobalCallbacks.Generic;
 		private _eventOnClick: GlobalCallbacks.Generic;
+		// Flag used to set the enable/disable state
+		private _isDisabled = false;
 		// Flag used to deal with onBodyClick and open api concurrency methods!
 		private _isOpenedByApi = false;
 		// Store the platform events
@@ -27,7 +29,7 @@ namespace OSFramework.OSUI.Patterns.OverflowMenu {
 
 		// Store the Balloon options to pass to the Balloon Class
 		public balloonOptions: Feature.Balloon.BalloonOptions;
-		// Store the isOpen ststus
+		// Store the isOpen status
 		public isOpen = false;
 
 		constructor(uniqueId: string, configs: JSON) {
@@ -239,6 +241,17 @@ namespace OSFramework.OSUI.Patterns.OverflowMenu {
 		}
 
 		/**
+		 * Method to disable the pattern
+		 *
+		 * @memberof OverflowMenu
+		 */
+		public disable(): void {
+			this._isDisabled = true;
+			this.close();
+			Helper.Dom.Attribute.Set(this._triggerElem, GlobalEnum.HTMLAttributes.Disabled, '');
+		}
+
+		/**
 		 * Method to destroy the Pattern
 		 *
 		 * @memberof OverflowMenu
@@ -252,12 +265,22 @@ namespace OSFramework.OSUI.Patterns.OverflowMenu {
 		}
 
 		/**
+		 * Method to enable the pattern
+		 *
+		 * @memberof OverflowMenu
+		 */
+		public enable(): void {
+			this._isDisabled = false;
+			Helper.Dom.Attribute.Remove(this._triggerElem, GlobalEnum.HTMLAttributes.Disabled);
+		}
+
+		/**
 		 * Method to open the Pattern
 		 *
 		 * @memberof OverflowMenu
 		 */
 		public open(isOpenedByApi: boolean): void {
-			if (this._balloonFeature.isOpen === false) {
+			if (this._balloonFeature.isOpen === false && this._isDisabled === false) {
 				this._isOpenedByApi = isOpenedByApi;
 				this._balloonFeature.open(this._isOpenedByApi);
 			}

--- a/src/scripts/OutSystems/OSUI/ErrorCodes.ts
+++ b/src/scripts/OutSystems/OSUI/ErrorCodes.ts
@@ -317,6 +317,8 @@ namespace OutSystems.OSUI.ErrorCodes {
 		FailRegisterCallback: 'OSUI-API-30003',
 		FailOpen: 'OSUI-API-30004',
 		FailClose: 'OSUI-API-30005',
+		FailEnable: 'OSUI-API-30006',
+		FailDisable: 'OSUI-API-30007',
 	};
 
 	export const Video = {

--- a/src/scripts/OutSystems/OSUI/Patterns/OverflowMenuAPI.ts
+++ b/src/scripts/OutSystems/OSUI/Patterns/OverflowMenuAPI.ts
@@ -53,6 +53,25 @@ namespace OutSystems.OSUI.Patterns.OverflowMenuAPI {
 	}
 
 	/**
+	 * Function that will disable the given OverflowMenu
+	 *
+	 * @export
+	 * @param {string} overflowMenuId
+	 */
+	export function Disable(overflowMenuId: string): string {
+		const result = OutSystems.OSUI.Utils.CreateApiResponse({
+			errorCode: ErrorCodes.OverflowMenu.FailDisable,
+			callback: () => {
+				const _overflowMenu = GetOverflowMenuById(overflowMenuId);
+
+				_overflowMenu.disable();
+			},
+		});
+
+		return result;
+	}
+
+	/**
 	 * Function that will dispose the instance of the given OverflowMenu
 	 *
 	 * @export
@@ -67,6 +86,25 @@ namespace OutSystems.OSUI.Patterns.OverflowMenuAPI {
 				_overflowMenu.dispose();
 
 				_overflowMenuMap.delete(_overflowMenu.uniqueId);
+			},
+		});
+
+		return result;
+	}
+
+	/**
+	 * Function that will enable the given OverflowMenu
+	 *
+	 * @export
+	 * @param {string} overflowMenuId
+	 */
+	export function Enable(overflowMenuId: string): string {
+		const result = OutSystems.OSUI.Utils.CreateApiResponse({
+			errorCode: ErrorCodes.OverflowMenu.FailEnable,
+			callback: () => {
+				const _overflowMenu = GetOverflowMenuById(overflowMenuId);
+
+				_overflowMenu.enable();
 			},
 		});
 


### PR DESCRIPTION
This PR is for add the client Actions to enable/disable the overflow menu

### What was done
- Added the enable and disable methods to the OverflowMenu 
- Added a condition to evaluate if the overflow menu is enabled before opening it
- Added the Enable and Disable functions to the OverflowMenuAPI

### Test Steps
1. Go to a test page with a OverflowMenu instance
2. Add buttons to to Enable or disable the OverflowMenu using the OverflowMenuEnable and OverflowMenuDisable
3.  Test each Client Action and check if it works as expected.

### Checklist

-   [x] tested locally
-   [x] documented the code
-   [x] clean all warnings and errors of eslint
-   [x] requires changes in OutSystems (if so, provide a module with changes)
-   [ ] requires new sample page in OutSystems (if so, provide a module with changes)
