### PR TITLE
ROU-4440: Change ShowPassword with new parameter

### DIFF
--- a/src/scripts/OutSystems/OSUI/Utils/Utilities.ts
+++ b/src/scripts/OutSystems/OSUI/Utils/Utilities.ts
@@ -241,6 +241,13 @@ namespace OutSystems.OSUI.Utils {
 			callback: () => {
 				if (WidgetId) {
 					const inputPassword = OSFramework.OSUI.Helper.Dom.GetElementById(WidgetId) as HTMLInputElement;
+					// If the element with WidgetId is not an input we will log a warning
+					if (
+						inputPassword.tagName.toLowerCase() !== 'input' ||
+						(inputPassword.type !== 'text' && inputPassword.type !== 'password')
+					) {
+						console.warn(`Object with WidgetId '${WidgetId}' should be an input element.`);
+					}
 					const typeInputPassword = inputPassword.type === 'password' ? 'text' : 'password';
 					inputPassword.setAttribute('type', typeInputPassword);
 					OSFramework.OSUI.Helper.Dom.Attribute.Set(inputPassword, 'type', typeInputPassword);

--- a/src/scripts/OutSystems/OSUI/Utils/Utilities.ts
+++ b/src/scripts/OutSystems/OSUI/Utils/Utilities.ts
@@ -230,22 +230,33 @@ namespace OutSystems.OSUI.Utils {
 
 	/**
 	 * Action to be used on the Login screen to enable users to show or hide the password characters.
+	 * If WidgetId exists we will show the password to that input, otherwise it will pick the first one on the screen.
+	 * @export
+	 * @param {string} [WidgetId] Input element to which we will toggle the password visibility.
+	 * @return {*}  {string}
 	 */
-	export function ShowPassword(): string {
+	export function ShowPassword(WidgetId?: string): string {
 		const result = OutSystems.OSUI.Utils.CreateApiResponse({
 			errorCode: ErrorCodes.Utilities.FailShowPassword,
 			callback: () => {
-				const inputPassword = OSFramework.OSUI.Helper.Dom.ClassSelector(
-					document,
-					'login-password'
-				) as HTMLInputElement;
-				const typeInputPassword = inputPassword.type;
+				if (WidgetId) {
+					const inputPassword = OSFramework.OSUI.Helper.Dom.GetElementById(WidgetId) as HTMLInputElement;
+					const typeInputPassword = inputPassword.type === 'password' ? 'text' : 'password';
+					inputPassword.setAttribute('type', typeInputPassword);
+					OSFramework.OSUI.Helper.Dom.Attribute.Set(inputPassword, 'type', typeInputPassword);
+				} else {
+					const inputPassword = OSFramework.OSUI.Helper.Dom.ClassSelector(
+						document,
+						'login-password'
+					) as HTMLInputElement;
+					const typeInputPassword = inputPassword.type;
 
-				OSFramework.OSUI.Helper.Dom.Attribute.Set(
-					inputPassword,
-					'type',
-					typeInputPassword === 'password' ? 'text' : 'password'
-				);
+					OSFramework.OSUI.Helper.Dom.Attribute.Set(
+						inputPassword,
+						'type',
+						typeInputPassword === 'password' ? 'text' : 'password'
+					);
+				}
 			},
 		});
 


### PR DESCRIPTION
This PR is for improving the _ShowPassword_ API so that we can apply it to a specific input element on a screen.

### What was happening

- The first element on a screen was always picked so it wouldn't work in the case of multiple inputs calling _ShowPassword_  

### What was done

- Now, a new optional input parameter called WidgetId will be available so that we can specify the input element to which we will toggle the password visibility.

### Test Steps

**Test Case 1 - Login Screen (regression):**

1. Go to `Login `screen
2. Insert a password
3. Click on the icon to see the password
4. **Expected**: Check that the password is revealed


**Test Case 2 - Multiple inputs:**

1. Go to `ShowPasswordSample`
2. Insert a password
3. Click on the icon to see the password
4. **Expected**: Check that the password is revealed and success is displayed on the panel

**Test Case 3 - Invalid element Id:**

1. Go to `ShowPasswordSample`
2. Click on the button `Invalid WidgetId`
3. **Expected**: Check that the error message '' is displayed on the panel with `Code = OSUI-API-28008 ; Message = Object with Id 'Invalid_Widget_ID' not found`.

**Test Case 4 - Invalid element Type:**

1. Go to `ShowPasswordSample`
2. Click on the button Invalid Element Type
3. Open the Dev Tools Console
4. **Expected**: Check that the password is revealed and success is displayed on the panel (here the responsibility is on the developer) but a warning is shown on the console with `Object with WidgetId 'Switch1' should be an input element`.



### Screenshots
![ShowPassword](https://github.com/OutSystems/outsystems-ui/assets/29493222/f76ff621-2058-44ef-b4c9-8706cb6e7f1f)


### Checklist

-   [X] tested locally
-   [X] documented the code
-   [X] clean all warnings and errors of eslint
-   [X] requires changes in OutSystems
-   [ ] requires new sample page in OutSystems (if so, provide a module with changes)
