### PR TITLE
ROU-4231: Improve Indicator size management

### DIFF
--- a/dist/OutSystemsUI.css
+++ b/dist/OutSystemsUI.css
@@ -11466,8 +11466,8 @@ html[data-uieditorversion^="1"] .osui-timepicker__dropdown-ss-preview.time12h, h
   height:var(--tabs-indicator-size);
   position:absolute;
   top:0;
-  -webkit-transform:translateY(var(--tabs-indicator-transform)) translateX(0) translateZ(0) scaleY(var(--tabs-indicator-scale));
-          transform:translateY(var(--tabs-indicator-transform)) translateX(0) translateZ(0) scaleY(var(--tabs-indicator-scale));
+  -webkit-transform:translateY(var(--tabs-indicator-transform)) translateX(0) translateZ(0);
+          transform:translateY(var(--tabs-indicator-transform)) translateX(0) translateZ(0);
   width:2px;
 }
 .osui-tabs--is-vertical .osui-tabs__content{
@@ -11497,10 +11497,10 @@ html[data-uieditorversion^="1"] .osui-timepicker__dropdown-ss-preview.time12h, h
 }
 .osui-tabs--is-horizontal .osui-tabs__header__indicator{
   bottom:0;
-  min-width:var(--tabs-indicator-size);
   height:2px;
-  -webkit-transform:translateX(var(--tabs-indicator-transform)) translateY(0) translateZ(0) scaleX(var(--tabs-indicator-scale));
-          transform:translateX(var(--tabs-indicator-transform)) translateY(0) translateZ(0) scaleX(var(--tabs-indicator-scale));
+  -webkit-transform:translateX(var(--tabs-indicator-transform)) translateY(0) translateZ(0);
+          transform:translateX(var(--tabs-indicator-transform)) translateY(0) translateZ(0);
+  width:var(--tabs-indicator-size);
 }
 .osui-tabs--is-horizontal .osui-tabs__content{
   border-top:var(--border-size-s) solid var(--color-neutral-5);

--- a/dist/OutSystemsUI.d.ts
+++ b/dist/OutSystemsUI.d.ts
@@ -184,6 +184,7 @@ declare namespace OSFramework.OSUI.GlobalEnum {
         LayoutSide = "layout-side",
         LayoutTop = "layout-top",
         List = "list",
+        LoginPassword = "login-password",
         MainContent = "main-content",
         MenuLinks = "app-menu-links",
         Placeholder = "ph",
@@ -284,7 +285,7 @@ declare namespace OSFramework.OSUI.GlobalEnum {
         Name = "name",
         StatusBar = "data-status-bar-height",
         Style = "style",
-        type = "type"
+        Type = "type"
     }
     enum HTMLElement {
         Body = "body",
@@ -414,6 +415,7 @@ declare namespace OSFramework.OSUI.GlobalEnum {
     enum InputTypeAttr {
         Date = "date",
         DateTime = "date-time-edit",
+        Password = "password",
         Text = "text",
         Time = "time"
     }
@@ -3223,7 +3225,7 @@ declare namespace OSFramework.OSUI.Patterns.Tabs.Enum {
         TabsContentItemOverflow = "--tabs-content-item-overflow",
         TabsHeaderItems = "--tabs-header-items",
         TabsHeight = "--tabs-height",
-        TabsIndicatorScale = "--tabs-indicator-scale",
+        TabsIndicatorSize = "--tabs-indicator-size",
         TabsIndicatorTransform = "--tabs-indicator-transform"
     }
     enum Properties {
@@ -3263,7 +3265,6 @@ declare namespace OSFramework.OSUI.Patterns.Tabs {
         private _hasDragGestures;
         private _hasSingleContent;
         private _headerItemsLength;
-        private _isChromium;
         private _platformEventTabsOnChange;
         private _requestAnimationFrameOnIndicatorResize;
         private _tabsContentElement;
@@ -4617,7 +4618,7 @@ declare namespace OutSystems.OSUI.Utils {
     function MoveElement(ElementId: string, TargetSelector: string, TimeoutVal?: number): string;
     function SetActiveElement(ElementId: string, IsActive: boolean): string;
     function SetSelectedTableRow(TableId: string, RowNumber: number, IsSelected: boolean): string;
-    function ShowPassword(): string;
+    function ShowPassword(WidgetId?: string): string;
 }
 declare namespace Providers.OSUI.ErrorCodes {
     const FloatingUI: {

--- a/dist/OutSystemsUI.js
+++ b/dist/OutSystemsUI.js
@@ -247,6 +247,7 @@ var OSFramework;
                 CssClassElements["LayoutSide"] = "layout-side";
                 CssClassElements["LayoutTop"] = "layout-top";
                 CssClassElements["List"] = "list";
+                CssClassElements["LoginPassword"] = "login-password";
                 CssClassElements["MainContent"] = "main-content";
                 CssClassElements["MenuLinks"] = "app-menu-links";
                 CssClassElements["Placeholder"] = "ph";
@@ -358,7 +359,7 @@ var OSFramework;
                 HTMLAttributes["Name"] = "name";
                 HTMLAttributes["StatusBar"] = "data-status-bar-height";
                 HTMLAttributes["Style"] = "style";
-                HTMLAttributes["type"] = "type";
+                HTMLAttributes["Type"] = "type";
             })(HTMLAttributes = GlobalEnum.HTMLAttributes || (GlobalEnum.HTMLAttributes = {}));
             let HTMLElement;
             (function (HTMLElement) {
@@ -500,6 +501,7 @@ var OSFramework;
             (function (InputTypeAttr) {
                 InputTypeAttr["Date"] = "date";
                 InputTypeAttr["DateTime"] = "date-time-edit";
+                InputTypeAttr["Password"] = "password";
                 InputTypeAttr["Text"] = "text";
                 InputTypeAttr["Time"] = "time";
             })(InputTypeAttr = GlobalEnum.InputTypeAttr || (GlobalEnum.InputTypeAttr = {}));
@@ -7267,7 +7269,7 @@ var OSFramework;
                     disable() {
                         this._isDisabled = true;
                         this.close();
-                        OSUI.Helper.Dom.Attribute.Set(this._triggerElem, OSUI.GlobalEnum.HTMLAttributes.Disabled, '');
+                        OSUI.Helper.Dom.Attribute.Set(this._triggerElem, OSUI.GlobalEnum.HTMLAttributes.Disabled, OSFramework.OSUI.Constants.EmptyString);
                     }
                     dispose() {
                         var _a;
@@ -9799,7 +9801,7 @@ var OSFramework;
                         CssProperty["TabsContentItemOverflow"] = "--tabs-content-item-overflow";
                         CssProperty["TabsHeaderItems"] = "--tabs-header-items";
                         CssProperty["TabsHeight"] = "--tabs-height";
-                        CssProperty["TabsIndicatorScale"] = "--tabs-indicator-scale";
+                        CssProperty["TabsIndicatorSize"] = "--tabs-indicator-size";
                         CssProperty["TabsIndicatorTransform"] = "--tabs-indicator-transform";
                     })(CssProperty = Enum.CssProperty || (Enum.CssProperty = {}));
                     let Properties;
@@ -9842,7 +9844,6 @@ var OSFramework;
                         super(uniqueId, new Tabs_1.TabsConfig(configs));
                         this._hasDragGestures =
                             OSUI.Helper.DeviceInfo.IsNative && this.configs.TabsOrientation === OSUI.GlobalEnum.Orientation.Horizontal;
-                        this._isChromium = OSUI.Helper.DeviceInfo.GetBrowser() === 'chrome' || OSUI.Helper.DeviceInfo.GetBrowser() === 'edge';
                     }
                     _addContentItem(tabsContentChildItem) {
                         if (this.getChild(tabsContentChildItem.uniqueId)) {
@@ -9967,39 +9968,35 @@ var OSFramework;
                             if (!OSUI.Helper.Dom.Attribute.Get(this._activeTabHeaderElement.selfElement, OSUI.GlobalEnum.HTMLAttributes.Disabled)) {
                                 OSUI.Helper.Dom.Attribute.Remove(this._tabsIndicatorElement, OSUI.GlobalEnum.HTMLAttributes.Disabled);
                             }
-                            const isVertical = this.configs.TabsOrientation === OSUI.GlobalEnum.Orientation.Vertical;
-                            const activeElement = this._activeTabHeaderElement.selfElement;
-                            const transformValue = isVertical
-                                ? activeElement.offsetTop
+                            const _isVertical = this.configs.TabsOrientation === OSUI.GlobalEnum.Orientation.Vertical;
+                            const _activeElement = this._activeTabHeaderElement.selfElement;
+                            const transformValue = _isVertical
+                                ? _activeElement.offsetTop
                                 : OutSystems.OSUI.Utils.GetIsRTL()
-                                    ? -(this._tabsHeaderElement.offsetWidth - activeElement.offsetLeft - activeElement.offsetWidth)
-                                    : activeElement.offsetLeft;
-                            const newSize = isVertical ? activeElement.offsetHeight : activeElement.offsetWidth;
-                            let pixelRatio = 1;
-                            if (this._isChromium) {
-                                pixelRatio = window.devicePixelRatio;
-                            }
-                            const newScaleValue = (pixelRatio * newSize) / Math.round(pixelRatio);
+                                    ? -(this._tabsHeaderElement.offsetWidth - _activeElement.offsetLeft - _activeElement.offsetWidth)
+                                    : _activeElement.offsetLeft;
+                            const elementRect = _activeElement.getBoundingClientRect();
+                            const finalScale = _isVertical ? elementRect.height : elementRect.width;
                             function updateIndicatorUI() {
                                 if (this._tabsIndicatorElement) {
                                     OSUI.Helper.Dom.Styles.SetStyleAttribute(this._tabsIndicatorElement, Tabs_1.Enum.CssProperty.TabsIndicatorTransform, transformValue + OSUI.GlobalEnum.Units.Pixel);
-                                    OSUI.Helper.Dom.Styles.SetStyleAttribute(this._tabsIndicatorElement, Tabs_1.Enum.CssProperty.TabsIndicatorScale, Math.floor(newScaleValue));
+                                    OSUI.Helper.Dom.Styles.SetStyleAttribute(this._tabsIndicatorElement, Tabs_1.Enum.CssProperty.TabsIndicatorSize, Math.floor(finalScale) + OSUI.GlobalEnum.Units.Pixel);
                                 }
                                 else {
                                     cancelAnimationFrame(this._requestAnimationFrameOnIndicatorResize);
                                 }
                             }
                             this._requestAnimationFrameOnIndicatorResize = requestAnimationFrame(updateIndicatorUI.bind(this));
-                            if (isNaN(newScaleValue) || newScaleValue === 0) {
+                            if (isNaN(finalScale) || finalScale === 0) {
                                 const resizeObserver = new ResizeObserver((entries) => {
                                     for (const entry of entries) {
                                         if (entry.contentBoxSize) {
                                             this._handleTabIndicator();
-                                            resizeObserver.unobserve(activeElement);
+                                            resizeObserver.unobserve(_activeElement);
                                         }
                                     }
                                 });
-                                resizeObserver.observe(activeElement);
+                                resizeObserver.observe(_activeElement);
                             }
                         }
                     }
@@ -16869,13 +16866,29 @@ var OutSystems;
                 return result;
             }
             Utils.SetSelectedTableRow = SetSelectedTableRow;
-            function ShowPassword() {
+            function ShowPassword(WidgetId) {
                 const result = OutSystems.OSUI.Utils.CreateApiResponse({
                     errorCode: OSUI.ErrorCodes.Utilities.FailShowPassword,
                     callback: () => {
-                        const inputPassword = OSFramework.OSUI.Helper.Dom.ClassSelector(document, 'login-password');
-                        const typeInputPassword = inputPassword.type;
-                        OSFramework.OSUI.Helper.Dom.Attribute.Set(inputPassword, 'type', typeInputPassword === 'password' ? 'text' : 'password');
+                        if (WidgetId) {
+                            const _inputPassword = OSFramework.OSUI.Helper.Dom.GetElementById(WidgetId);
+                            if (_inputPassword.tagName.toLowerCase() !== OSFramework.OSUI.GlobalEnum.HTMLElement.Input ||
+                                (_inputPassword.type !== OSFramework.OSUI.GlobalEnum.InputTypeAttr.Text &&
+                                    _inputPassword.type !== OSFramework.OSUI.GlobalEnum.InputTypeAttr.Password)) {
+                                console.warn(`Object with WidgetId '${WidgetId}' should be an input element.`);
+                            }
+                            const _typeInputPassword = _inputPassword.type === OSFramework.OSUI.GlobalEnum.InputTypeAttr.Password
+                                ? OSFramework.OSUI.GlobalEnum.InputTypeAttr.Text
+                                : OSFramework.OSUI.GlobalEnum.InputTypeAttr.Password;
+                            OSFramework.OSUI.Helper.Dom.Attribute.Set(_inputPassword, OSFramework.OSUI.GlobalEnum.HTMLAttributes.Type, _typeInputPassword);
+                        }
+                        else {
+                            const _inputPassword = OSFramework.OSUI.Helper.Dom.ClassSelector(document, OSFramework.OSUI.GlobalEnum.CssClassElements.LoginPassword);
+                            const _typeInputPassword = _inputPassword.type;
+                            OSFramework.OSUI.Helper.Dom.Attribute.Set(_inputPassword, OSFramework.OSUI.GlobalEnum.HTMLAttributes.Type, _typeInputPassword === OSFramework.OSUI.GlobalEnum.InputTypeAttr.Password
+                                ? OSFramework.OSUI.GlobalEnum.InputTypeAttr.Text
+                                : OSFramework.OSUI.GlobalEnum.InputTypeAttr.Password);
+                        }
                     },
                 });
                 return result;
@@ -17795,7 +17808,7 @@ var Providers;
                             this.jumpIntoToday();
                         }
                         updatePlatformInputAttrs() {
-                            OSFramework.OSUI.Helper.Dom.Attribute.Set(this.datePickerPlatformInputElem, OSFramework.OSUI.GlobalEnum.HTMLAttributes.type, OSFramework.OSUI.GlobalEnum.InputTypeAttr.Text);
+                            OSFramework.OSUI.Helper.Dom.Attribute.Set(this.datePickerPlatformInputElem, OSFramework.OSUI.GlobalEnum.HTMLAttributes.Type, OSFramework.OSUI.GlobalEnum.InputTypeAttr.Text);
                         }
                         build() {
                             super.build();
@@ -17941,7 +17954,7 @@ var Providers;
                             const dateType = this.configs.TimeFormat === OSFramework.OSUI.Patterns.DatePicker.Enum.TimeFormatMode.Disable
                                 ? OSFramework.OSUI.GlobalEnum.InputTypeAttr.Date
                                 : OSFramework.OSUI.GlobalEnum.InputTypeAttr.DateTime;
-                            OSFramework.OSUI.Helper.Dom.Attribute.Set(this.datePickerPlatformInputElem, OSFramework.OSUI.GlobalEnum.HTMLAttributes.type, dateType);
+                            OSFramework.OSUI.Helper.Dom.Attribute.Set(this.datePickerPlatformInputElem, OSFramework.OSUI.GlobalEnum.HTMLAttributes.Type, dateType);
                         }
                         build() {
                             super.build();
@@ -19379,7 +19392,7 @@ var Providers;
                         this.monthPickerPlatformInputElem = undefined;
                     }
                     updatePlatformInputAttrs() {
-                        OSFramework.OSUI.Helper.Dom.Attribute.Set(this.monthPickerPlatformInputElem, OSFramework.OSUI.GlobalEnum.HTMLAttributes.type, OSFramework.OSUI.GlobalEnum.InputTypeAttr.Text);
+                        OSFramework.OSUI.Helper.Dom.Attribute.Set(this.monthPickerPlatformInputElem, OSFramework.OSUI.GlobalEnum.HTMLAttributes.Type, OSFramework.OSUI.GlobalEnum.InputTypeAttr.Text);
                     }
                     build() {
                         super.build();
@@ -20635,7 +20648,7 @@ var Providers;
                         this.timePickerPlatformInputElem = undefined;
                     }
                     updatePlatformInputAttrs() {
-                        OSFramework.OSUI.Helper.Dom.Attribute.Set(this.timePickerPlatformInputElem, OSFramework.OSUI.GlobalEnum.HTMLAttributes.type, OSFramework.OSUI.GlobalEnum.InputTypeAttr.Time);
+                        OSFramework.OSUI.Helper.Dom.Attribute.Set(this.timePickerPlatformInputElem, OSFramework.OSUI.GlobalEnum.HTMLAttributes.Type, OSFramework.OSUI.GlobalEnum.InputTypeAttr.Time);
                     }
                     build() {
                         super.build();

--- a/src/scripts/OSFramework/OSUI/Pattern/Tabs/Enum.ts
+++ b/src/scripts/OSFramework/OSUI/Pattern/Tabs/Enum.ts
@@ -48,7 +48,7 @@ namespace OSFramework.OSUI.Patterns.Tabs.Enum {
 		TabsContentItemOverflow = '--tabs-content-item-overflow',
 		TabsHeaderItems = '--tabs-header-items',
 		TabsHeight = '--tabs-height',
-		TabsIndicatorScale = '--tabs-indicator-scale',
+		TabsIndicatorSize = '--tabs-indicator-size',
 		TabsIndicatorTransform = '--tabs-indicator-transform',
 	}
 

--- a/src/scripts/OSFramework/OSUI/Pattern/Tabs/Tabs.ts
+++ b/src/scripts/OSFramework/OSUI/Pattern/Tabs/Tabs.ts
@@ -32,8 +32,6 @@ namespace OSFramework.OSUI.Patterns.Tabs {
 		private _hasSingleContent: boolean;
 		// Store the number of headerItems to be used to set the css variable
 		private _headerItemsLength: number;
-		// Store if the current browser is Chrome or Edge (Chromium based)
-		private _isChromium: boolean;
 		// Store the onTabsChange platform callback
 		private _platformEventTabsOnChange: Callbacks.OSOnChangeEvent;
 		// Store the id of the requestAnimationFrame called to animate the indicator
@@ -51,7 +49,6 @@ namespace OSFramework.OSUI.Patterns.Tabs {
 			// Check if running on native shell, to enable drag gestures
 			this._hasDragGestures =
 				Helper.DeviceInfo.IsNative && this.configs.TabsOrientation === GlobalEnum.Orientation.Horizontal;
-			this._isChromium = Helper.DeviceInfo.GetBrowser() === 'chrome' || Helper.DeviceInfo.GetBrowser() === 'edge';
 		}
 
 		// Method that it's called whenever a new TabsContentItem is rendered
@@ -266,28 +263,21 @@ namespace OSFramework.OSUI.Patterns.Tabs {
 					Helper.Dom.Attribute.Remove(this._tabsIndicatorElement, GlobalEnum.HTMLAttributes.Disabled);
 				}
 
-				const isVertical = this.configs.TabsOrientation === GlobalEnum.Orientation.Vertical;
-				const activeElement = this._activeTabHeaderElement.selfElement;
+				const _isVertical = this.configs.TabsOrientation === GlobalEnum.Orientation.Vertical;
+				const _activeElement = this._activeTabHeaderElement.selfElement;
 
 				// Get transform value based on orientation and rtl value
-				const transformValue = isVertical
-					? activeElement.offsetTop
+				const _transformValue = _isVertical
+					? _activeElement.offsetTop
 					: OutSystems.OSUI.Utils.GetIsRTL()
-					? -(this._tabsHeaderElement.offsetWidth - activeElement.offsetLeft - activeElement.offsetWidth)
-					: activeElement.offsetLeft;
+					? -(this._tabsHeaderElement.offsetWidth - _activeElement.offsetLeft - _activeElement.offsetWidth)
+					: _activeElement.offsetLeft;
 
-				// Check current active item size
-				const newSize = isVertical ? activeElement.offsetHeight : activeElement.offsetWidth;
+				// Get the actual size of the current tabsHeader
+				const _elementRect = _activeElement.getBoundingClientRect();
 
-				let pixelRatio = 1;
-
-				if (this._isChromium) {
-					// devicePixelRatio used here to account for browser or system zoom
-					pixelRatio = window.devicePixelRatio;
-				}
-
-				// translate pixel sized value to a scale value
-				const newScaleValue = (pixelRatio * newSize) / Math.round(pixelRatio);
+				// Set the final size, based on orientation
+				const _finalSize = _isVertical ? _elementRect.height : _elementRect.width;
 
 				// Update the css variables, that will trigger a transform transition
 				function updateIndicatorUI() {
@@ -296,14 +286,14 @@ namespace OSFramework.OSUI.Patterns.Tabs {
 						Helper.Dom.Styles.SetStyleAttribute(
 							this._tabsIndicatorElement,
 							Enum.CssProperty.TabsIndicatorTransform,
-							transformValue + GlobalEnum.Units.Pixel
+							_transformValue + GlobalEnum.Units.Pixel
 						);
 
-						// Apply transform scale
+						// Set indicator size
 						Helper.Dom.Styles.SetStyleAttribute(
 							this._tabsIndicatorElement,
-							Enum.CssProperty.TabsIndicatorScale,
-							Math.floor(newScaleValue)
+							Enum.CssProperty.TabsIndicatorSize,
+							Math.floor(_finalSize) + GlobalEnum.Units.Pixel
 						);
 					} else {
 						cancelAnimationFrame(this._requestAnimationFrameOnIndicatorResize);
@@ -314,17 +304,17 @@ namespace OSFramework.OSUI.Patterns.Tabs {
 
 				// If at this moment the active item has no size (NaN), set an observer to run this method when its size is changed
 				// This happens, as an example, when there're tabs inside tabs, and inner one has no size when it's built, due to being on a non-active tab
-				if (isNaN(newScaleValue) || newScaleValue === 0) {
+				if (isNaN(_finalSize) || _finalSize === 0) {
 					const resizeObserver = new ResizeObserver((entries) => {
 						for (const entry of entries) {
 							if (entry.contentBoxSize) {
 								this._handleTabIndicator();
 								// We just need this once, so lets remove the observer
-								resizeObserver.unobserve(activeElement);
+								resizeObserver.unobserve(_activeElement);
 							}
 						}
 					});
-					resizeObserver.observe(activeElement);
+					resizeObserver.observe(_activeElement);
 				}
 			}
 		}

--- a/src/scripts/OSFramework/OSUI/Pattern/Tabs/scss/_tabs.scss
+++ b/src/scripts/OSFramework/OSUI/Pattern/Tabs/scss/_tabs.scss
@@ -69,8 +69,7 @@
 				height: var(--tabs-indicator-size);
 				position: absolute;
 				top: 0;
-				transform: translateY(var(--tabs-indicator-transform)) translateX(0) translateZ(0)
-					scaleY(var(--tabs-indicator-scale));
+				transform: translateY(var(--tabs-indicator-transform)) translateX(0) translateZ(0);
 				width: 2px;
 			}
 		}
@@ -103,10 +102,9 @@
 
 		.osui-tabs__header__indicator {
 			bottom: 0;
-			min-width: var(--tabs-indicator-size);
 			height: 2px;
-			transform: translateX(var(--tabs-indicator-transform)) translateY(0) translateZ(0)
-				scaleX(var(--tabs-indicator-scale));
+			transform: translateX(var(--tabs-indicator-transform)) translateY(0) translateZ(0);
+			width: (var(--tabs-indicator-size));
 		}
 
 		.osui-tabs__content {


### PR DESCRIPTION
This PR is for improving the way we manage the size of the Tabs Indicator element. 

Due to recurrent issues related to browser/system zoom, now the indicator size is defined using width/height (based on Tabs orientation) from the current TabsHeaderItem. Before this was using transform: scale(), to allow a transition on size, without affecting performance.

### Checklist

-   [x] tested locally
-   [x] documented the code
-   [x] clean all warnings and errors of eslint
-   [x] requires changes in OutSystems (if so, provide a module with changes)
-   [ ] requires new sample page in OutSystems (if so, provide a module with changes)
