### PR TITLE
ROU-4399:  Make the Change properties implementation consistent across components

### DIFF
--- a/dist/OutSystemsUI.d.ts
+++ b/dist/OutSystemsUI.d.ts
@@ -184,6 +184,7 @@ declare namespace OSFramework.OSUI.GlobalEnum {
         LayoutSide = "layout-side",
         LayoutTop = "layout-top",
         List = "list",
+        LoginPassword = "login-password",
         MainContent = "main-content",
         MenuLinks = "app-menu-links",
         Placeholder = "ph",
@@ -284,7 +285,7 @@ declare namespace OSFramework.OSUI.GlobalEnum {
         Name = "name",
         StatusBar = "data-status-bar-height",
         Style = "style",
-        type = "type"
+        Type = "type"
     }
     enum HTMLElement {
         Body = "body",
@@ -414,6 +415,7 @@ declare namespace OSFramework.OSUI.GlobalEnum {
     enum InputTypeAttr {
         Date = "date",
         DateTime = "date-time-edit",
+        Password = "password",
         Text = "text",
         Time = "time"
     }
@@ -2146,7 +2148,6 @@ declare namespace OSFramework.OSUI.Patterns.FlipContent {
         FlipSelf: boolean;
         IsFlipped: boolean;
         constructor(config: JSON);
-        validateCanChange(isBuilt: boolean, key: string): boolean;
     }
 }
 declare namespace OSFramework.OSUI.Patterns.FlipContent {
@@ -2331,7 +2332,6 @@ declare namespace OSFramework.OSUI.Patterns.Notification.Enum {
 declare namespace OSFramework.OSUI.Patterns.Notification {
     interface INotification extends Interface.IPattern {
         hide(): void;
-        registerCallback(eventName: string, callback: GlobalCallbacks.OSGeneric): void;
         show(): void;
     }
 }
@@ -2392,8 +2392,6 @@ declare namespace OSFramework.OSUI.Patterns.Notification {
         Position: string;
         StartsOpen: boolean;
         Width: string;
-        validateCanChange(isBuilt: boolean, key: string): boolean;
-        validateDefault(key: string, value: unknown): unknown;
     }
 }
 declare namespace OSFramework.OSUI.Patterns.OverflowMenu.Callbacks {
@@ -2904,9 +2902,9 @@ declare namespace OSFramework.OSUI.Patterns.SectionIndexItem.Enum {
 }
 declare namespace OSFramework.OSUI.Patterns.SectionIndexItem {
     interface ISectionIndexItem extends Interface.IChild {
-        get IsSelected(): boolean;
-        get TargetElement(): HTMLElement;
-        get TargetElementOffset(): OffsetValues;
+        IsSelected: boolean;
+        TargetElement: HTMLElement;
+        TargetElementOffset: OffsetValues;
         setIsActive(): void;
         unsetIsActive(): void;
     }
@@ -2950,7 +2948,6 @@ declare namespace OSFramework.OSUI.Patterns.SectionIndexItem {
 declare namespace OSFramework.OSUI.Patterns.SectionIndexItem {
     class SectionIndexItemConfig extends AbstractConfiguration {
         ScrollToWidgetId: string;
-        validateCanChange(isBuilt: boolean, key: string): boolean;
     }
 }
 declare namespace OSFramework.OSUI.Patterns.Sidebar.Callbacks {
@@ -2984,7 +2981,6 @@ declare namespace OSFramework.OSUI.Patterns.Sidebar.Enum {
 declare namespace OSFramework.OSUI.Patterns.Sidebar {
     interface ISidebar extends Interface.IPattern, Interface.IOpenable {
         clickOutsideToClose(closeOnOutSIdeClick: boolean): void;
-        registerCallback(eventName: string, callback: GlobalCallbacks.OSGeneric): void;
         toggleGestures(enableSwipe: boolean): void;
     }
 }
@@ -3048,8 +3044,6 @@ declare namespace OSFramework.OSUI.Patterns.Sidebar {
         StartsOpen: boolean;
         Width: string;
         constructor(config: JSON);
-        validateCanChange(isBuilt: boolean, key: string): boolean;
-        validateDefault(key: string, value: unknown): unknown;
     }
 }
 declare namespace OSFramework.OSUI.Patterns.Submenu.Enum {
@@ -3319,13 +3313,11 @@ declare namespace OSFramework.OSUI.Patterns.Tabs {
         StartingTab: number;
         TabsOrientation: GlobalEnum.Orientation;
         TabsVerticalPosition: GlobalEnum.Direction;
-        validateCanChange(isBuilt: boolean, key: string): boolean;
-        validateDefault(key: string, value: unknown): unknown;
     }
 }
 declare namespace OSFramework.OSUI.Patterns.TabsContentItem {
     interface ITabsContentItem extends Interface.IChild {
-        get IsActive(): boolean;
+        IsActive: boolean;
         getDataTab(): number;
         getOffsetLeft(): number;
         setAriaLabelledByAttribute(headerItemId: string): void;
@@ -3367,7 +3359,7 @@ declare namespace OSFramework.OSUI.Patterns.TabsContentItem {
 }
 declare namespace OSFramework.OSUI.Patterns.TabsHeaderItem {
     interface ITabsHeaderItem extends Interface.IChild {
-        get IsActive(): boolean;
+        IsActive: boolean;
         disable(): void;
         enable(): void;
         getDataTab(): number;
@@ -4617,7 +4609,7 @@ declare namespace OutSystems.OSUI.Utils {
     function MoveElement(ElementId: string, TargetSelector: string, TimeoutVal?: number): string;
     function SetActiveElement(ElementId: string, IsActive: boolean): string;
     function SetSelectedTableRow(TableId: string, RowNumber: number, IsSelected: boolean): string;
-    function ShowPassword(): string;
+    function ShowPassword(WidgetId?: string): string;
 }
 declare namespace Providers.OSUI.ErrorCodes {
     const FloatingUI: {

--- a/dist/OutSystemsUI.d.ts
+++ b/dist/OutSystemsUI.d.ts
@@ -1327,6 +1327,7 @@ declare namespace OSFramework.OSUI.Patterns.Accordion {
     class AccordionConfig extends AbstractConfiguration {
         MultipleItems: boolean;
         constructor(config: JSON);
+        validateDefault(key: string, value: unknown): unknown;
     }
 }
 declare namespace OSFramework.OSUI.Patterns.Accordion.Enum {
@@ -1404,6 +1405,8 @@ declare namespace OSFramework.OSUI.Patterns.AccordionItem {
         IsDisabled: boolean;
         StartsExpanded: boolean;
         constructor(config: JSON);
+        validateCanChange(isBuilt: boolean, key: string): boolean;
+        validateDefault(key: string, value: unknown): unknown;
     }
 }
 declare namespace OSFramework.OSUI.Patterns.AccordionItem.Enum {
@@ -1555,6 +1558,7 @@ declare namespace OSFramework.OSUI.Patterns.BottomSheet {
         Shape: GlobalEnum.ShapeTypes;
         ShowHandler: boolean;
         constructor(config: JSON);
+        validateDefault(key: string, value: unknown): unknown;
     }
 }
 declare namespace OSFramework.OSUI.Patterns.BottomSheet.Callbacks {
@@ -1708,6 +1712,10 @@ declare namespace OSFramework.OSUI.Patterns.Carousel.Enum {
         Both = "both",
         Dots = "dots",
         None = "none"
+    }
+    enum Defaults {
+        Height = "auto",
+        SpaceNone = "0px"
     }
 }
 declare namespace OSFramework.OSUI.Patterns.Carousel {
@@ -2144,6 +2152,7 @@ declare namespace OSFramework.OSUI.Patterns.FlipContent {
         FlipSelf: boolean;
         IsFlipped: boolean;
         constructor(config: JSON);
+        validateCanChange(isBuilt: boolean, key: string): boolean;
     }
 }
 declare namespace OSFramework.OSUI.Patterns.FlipContent {
@@ -2388,6 +2397,8 @@ declare namespace OSFramework.OSUI.Patterns.Notification {
         Position: string;
         StartsOpen: boolean;
         Width: string;
+        validateCanChange(isBuilt: boolean, key: string): boolean;
+        validateDefault(key: string, value: unknown): unknown;
     }
 }
 declare namespace OSFramework.OSUI.Patterns.OverflowMenu.Callbacks {
@@ -2944,6 +2955,7 @@ declare namespace OSFramework.OSUI.Patterns.SectionIndexItem {
 declare namespace OSFramework.OSUI.Patterns.SectionIndexItem {
     class SectionIndexItemConfig extends AbstractConfiguration {
         ScrollToWidgetId: string;
+        validateCanChange(isBuilt: boolean, key: string): boolean;
     }
 }
 declare namespace OSFramework.OSUI.Patterns.Sidebar.Callbacks {
@@ -2957,6 +2969,9 @@ declare namespace OSFramework.OSUI.Patterns.Sidebar.Enum {
         Direction = "Direction",
         Width = "Width",
         HasOverlay = "HasOverlay"
+    }
+    enum Defaults {
+        Width = "500px"
     }
     enum CssClass {
         Aside = "osui-sidebar",
@@ -3040,6 +3055,8 @@ declare namespace OSFramework.OSUI.Patterns.Sidebar {
         StartsOpen: boolean;
         Width: string;
         constructor(config: JSON);
+        validateCanChange(isBuilt: boolean, key: string): boolean;
+        validateDefault(key: string, value: unknown): unknown;
     }
 }
 declare namespace OSFramework.OSUI.Patterns.Submenu.Enum {
@@ -3309,6 +3326,8 @@ declare namespace OSFramework.OSUI.Patterns.Tabs {
         StartingTab: number;
         TabsOrientation: GlobalEnum.Orientation;
         TabsVerticalPosition: GlobalEnum.Direction;
+        validateCanChange(isBuilt: boolean, key: string): boolean;
+        validateDefault(key: string, value: unknown): unknown;
     }
 }
 declare namespace OSFramework.OSUI.Patterns.TabsContentItem {

--- a/dist/OutSystemsUI.d.ts
+++ b/dist/OutSystemsUI.d.ts
@@ -1327,7 +1327,6 @@ declare namespace OSFramework.OSUI.Patterns.Accordion {
     class AccordionConfig extends AbstractConfiguration {
         MultipleItems: boolean;
         constructor(config: JSON);
-        validateDefault(key: string, value: unknown): unknown;
     }
 }
 declare namespace OSFramework.OSUI.Patterns.Accordion.Enum {
@@ -1405,8 +1404,6 @@ declare namespace OSFramework.OSUI.Patterns.AccordionItem {
         IsDisabled: boolean;
         StartsExpanded: boolean;
         constructor(config: JSON);
-        validateCanChange(isBuilt: boolean, key: string): boolean;
-        validateDefault(key: string, value: unknown): unknown;
     }
 }
 declare namespace OSFramework.OSUI.Patterns.AccordionItem.Enum {
@@ -1558,7 +1555,6 @@ declare namespace OSFramework.OSUI.Patterns.BottomSheet {
         Shape: GlobalEnum.ShapeTypes;
         ShowHandler: boolean;
         constructor(config: JSON);
-        validateDefault(key: string, value: unknown): unknown;
     }
 }
 declare namespace OSFramework.OSUI.Patterns.BottomSheet.Callbacks {

--- a/dist/OutSystemsUI.js
+++ b/dist/OutSystemsUI.js
@@ -247,6 +247,7 @@ var OSFramework;
                 CssClassElements["LayoutSide"] = "layout-side";
                 CssClassElements["LayoutTop"] = "layout-top";
                 CssClassElements["List"] = "list";
+                CssClassElements["LoginPassword"] = "login-password";
                 CssClassElements["MainContent"] = "main-content";
                 CssClassElements["MenuLinks"] = "app-menu-links";
                 CssClassElements["Placeholder"] = "ph";
@@ -358,7 +359,7 @@ var OSFramework;
                 HTMLAttributes["Name"] = "name";
                 HTMLAttributes["StatusBar"] = "data-status-bar-height";
                 HTMLAttributes["Style"] = "style";
-                HTMLAttributes["type"] = "type";
+                HTMLAttributes["Type"] = "type";
             })(HTMLAttributes = GlobalEnum.HTMLAttributes || (GlobalEnum.HTMLAttributes = {}));
             let HTMLElement;
             (function (HTMLElement) {
@@ -500,6 +501,7 @@ var OSFramework;
             (function (InputTypeAttr) {
                 InputTypeAttr["Date"] = "date";
                 InputTypeAttr["DateTime"] = "date-time-edit";
+                InputTypeAttr["Password"] = "password";
                 InputTypeAttr["Text"] = "text";
                 InputTypeAttr["Time"] = "time";
             })(InputTypeAttr = GlobalEnum.InputTypeAttr || (GlobalEnum.InputTypeAttr = {}));
@@ -6367,12 +6369,6 @@ var OSFramework;
                     constructor(config) {
                         super(config);
                     }
-                    validateCanChange(isBuilt, key) {
-                        if (isBuilt) {
-                            return key !== FlipContent.Enum.Properties.IsFlipped;
-                        }
-                        return true;
-                    }
                 }
                 FlipContent.FlipContentConfig = FlipContentConfig;
             })(FlipContent = Patterns.FlipContent || (Patterns.FlipContent = {}));
@@ -7073,37 +7069,6 @@ var OSFramework;
             var Notification;
             (function (Notification) {
                 class NotificationConfig extends Patterns.AbstractConfiguration {
-                    validateCanChange(isBuilt, key) {
-                        if (isBuilt) {
-                            return key !== Notification.Enum.Properties.StartsOpen;
-                        }
-                        return true;
-                    }
-                    validateDefault(key, value) {
-                        let validatedValue = undefined;
-                        switch (key) {
-                            case Notification.Enum.Properties.InteractToClose:
-                                validatedValue = this.validateBoolean(value, true);
-                                break;
-                            case Notification.Enum.Properties.NeedsSwipes:
-                            case Notification.Enum.Properties.StartsOpen:
-                                validatedValue = this.validateBoolean(value, false);
-                                break;
-                            case Notification.Enum.Properties.Position:
-                                validatedValue = this.validateString(value, Notification.Enum.Defaults.DefaultPosition);
-                                break;
-                            case Notification.Enum.Properties.Width:
-                                validatedValue = this.validateString(value, Notification.Enum.Defaults.DefaultWidth);
-                                break;
-                            case Notification.Enum.Properties.CloseAfterTime:
-                                validatedValue = this.validateNumber(value, undefined);
-                                break;
-                            default:
-                                validatedValue = super.validateDefault(key, value);
-                                break;
-                        }
-                        return validatedValue;
-                    }
                 }
                 Notification.NotificationConfig = NotificationConfig;
             })(Notification = Patterns.Notification || (Patterns.Notification = {}));
@@ -7267,7 +7232,7 @@ var OSFramework;
                     disable() {
                         this._isDisabled = true;
                         this.close();
-                        OSUI.Helper.Dom.Attribute.Set(this._triggerElem, OSUI.GlobalEnum.HTMLAttributes.Disabled, '');
+                        OSUI.Helper.Dom.Attribute.Set(this._triggerElem, OSUI.GlobalEnum.HTMLAttributes.Disabled, OSFramework.OSUI.Constants.EmptyString);
                     }
                     dispose() {
                         var _a;
@@ -8891,12 +8856,6 @@ var OSFramework;
             var SectionIndexItem;
             (function (SectionIndexItem) {
                 class SectionIndexItemConfig extends Patterns.AbstractConfiguration {
-                    validateCanChange(isBuilt, key) {
-                        if (isBuilt) {
-                            return key !== SectionIndexItem.Enum.Properties.ScrollToWidgetId;
-                        }
-                        return true;
-                    }
                 }
                 SectionIndexItem.SectionIndexItemConfig = SectionIndexItemConfig;
             })(SectionIndexItem = Patterns.SectionIndexItem || (Patterns.SectionIndexItem = {}));
@@ -9231,31 +9190,6 @@ var OSFramework;
                 class SidebarConfig extends Patterns.AbstractConfiguration {
                     constructor(config) {
                         super(config);
-                    }
-                    validateCanChange(isBuilt, key) {
-                        if (isBuilt) {
-                            return key !== Sidebar.Enum.Properties.StartsOpen;
-                        }
-                        return true;
-                    }
-                    validateDefault(key, value) {
-                        let validatedValue = undefined;
-                        switch (key) {
-                            case Sidebar.Enum.Properties.Direction:
-                                validatedValue = this.validateInRange(value, OSUI.GlobalEnum.Direction.Right, OSUI.GlobalEnum.Direction.Right, OSUI.GlobalEnum.Direction.Left);
-                                break;
-                            case Sidebar.Enum.Properties.HasOverlay:
-                            case Sidebar.Enum.Properties.StartsOpen:
-                                validatedValue = this.validateBoolean(value, false);
-                                break;
-                            case Sidebar.Enum.Properties.Width:
-                                validatedValue = this.validateString(value, '500px');
-                                break;
-                            default:
-                                validatedValue = super.validateDefault(key, value);
-                                break;
-                        }
-                        return validatedValue;
                     }
                 }
                 Sidebar.SidebarConfig = SidebarConfig;
@@ -10383,34 +10317,6 @@ var OSFramework;
             var Tabs;
             (function (Tabs) {
                 class TabsConfig extends Patterns.AbstractConfiguration {
-                    validateCanChange(isBuilt, key) {
-                        if (isBuilt) {
-                            return key !== Tabs.Enum.Properties.StartingTab;
-                        }
-                        return true;
-                    }
-                    validateDefault(key, value) {
-                        let validatedValue = undefined;
-                        switch (key) {
-                            case Tabs.Enum.Properties.TabsOrientation:
-                                validatedValue = this.validateInRange(value, OSUI.GlobalEnum.Orientation.Horizontal, OSUI.GlobalEnum.Orientation.Vertical);
-                                break;
-                            case Tabs.Enum.Properties.TabsVerticalPosition:
-                                validatedValue = this.validateInRange(value, OSUI.GlobalEnum.Direction.Left, OSUI.GlobalEnum.Direction.Right);
-                                break;
-                            case Tabs.Enum.Properties.ContentAutoHeight:
-                            case Tabs.Enum.Properties.JustifyHeaders:
-                                validatedValue = this.validateBoolean(value, false);
-                                break;
-                            case Tabs.Enum.Properties.Height:
-                                validatedValue = this.validateString(value, OSUI.GlobalEnum.CssProperties.Auto);
-                                break;
-                            default:
-                                validatedValue = super.validateDefault(key, value);
-                                break;
-                        }
-                        return validatedValue;
-                    }
                 }
                 Tabs.TabsConfig = TabsConfig;
             })(Tabs = Patterns.Tabs || (Patterns.Tabs = {}));
@@ -16869,13 +16775,29 @@ var OutSystems;
                 return result;
             }
             Utils.SetSelectedTableRow = SetSelectedTableRow;
-            function ShowPassword() {
+            function ShowPassword(WidgetId) {
                 const result = OutSystems.OSUI.Utils.CreateApiResponse({
                     errorCode: OSUI.ErrorCodes.Utilities.FailShowPassword,
                     callback: () => {
-                        const inputPassword = OSFramework.OSUI.Helper.Dom.ClassSelector(document, 'login-password');
-                        const typeInputPassword = inputPassword.type;
-                        OSFramework.OSUI.Helper.Dom.Attribute.Set(inputPassword, 'type', typeInputPassword === 'password' ? 'text' : 'password');
+                        if (WidgetId) {
+                            const _inputPassword = OSFramework.OSUI.Helper.Dom.GetElementById(WidgetId);
+                            if (_inputPassword.tagName.toLowerCase() !== OSFramework.OSUI.GlobalEnum.HTMLElement.Input ||
+                                (_inputPassword.type !== OSFramework.OSUI.GlobalEnum.InputTypeAttr.Text &&
+                                    _inputPassword.type !== OSFramework.OSUI.GlobalEnum.InputTypeAttr.Password)) {
+                                console.warn(`Object with WidgetId '${WidgetId}' should be an input element.`);
+                            }
+                            const _typeInputPassword = _inputPassword.type === OSFramework.OSUI.GlobalEnum.InputTypeAttr.Password
+                                ? OSFramework.OSUI.GlobalEnum.InputTypeAttr.Text
+                                : OSFramework.OSUI.GlobalEnum.InputTypeAttr.Password;
+                            OSFramework.OSUI.Helper.Dom.Attribute.Set(_inputPassword, OSFramework.OSUI.GlobalEnum.HTMLAttributes.Type, _typeInputPassword);
+                        }
+                        else {
+                            const _inputPassword = OSFramework.OSUI.Helper.Dom.ClassSelector(document, OSFramework.OSUI.GlobalEnum.CssClassElements.LoginPassword);
+                            const _typeInputPassword = _inputPassword.type;
+                            OSFramework.OSUI.Helper.Dom.Attribute.Set(_inputPassword, OSFramework.OSUI.GlobalEnum.HTMLAttributes.Type, _typeInputPassword === OSFramework.OSUI.GlobalEnum.InputTypeAttr.Password
+                                ? OSFramework.OSUI.GlobalEnum.InputTypeAttr.Text
+                                : OSFramework.OSUI.GlobalEnum.InputTypeAttr.Password);
+                        }
                     },
                 });
                 return result;
@@ -17795,7 +17717,7 @@ var Providers;
                             this.jumpIntoToday();
                         }
                         updatePlatformInputAttrs() {
-                            OSFramework.OSUI.Helper.Dom.Attribute.Set(this.datePickerPlatformInputElem, OSFramework.OSUI.GlobalEnum.HTMLAttributes.type, OSFramework.OSUI.GlobalEnum.InputTypeAttr.Text);
+                            OSFramework.OSUI.Helper.Dom.Attribute.Set(this.datePickerPlatformInputElem, OSFramework.OSUI.GlobalEnum.HTMLAttributes.Type, OSFramework.OSUI.GlobalEnum.InputTypeAttr.Text);
                         }
                         build() {
                             super.build();
@@ -17941,7 +17863,7 @@ var Providers;
                             const dateType = this.configs.TimeFormat === OSFramework.OSUI.Patterns.DatePicker.Enum.TimeFormatMode.Disable
                                 ? OSFramework.OSUI.GlobalEnum.InputTypeAttr.Date
                                 : OSFramework.OSUI.GlobalEnum.InputTypeAttr.DateTime;
-                            OSFramework.OSUI.Helper.Dom.Attribute.Set(this.datePickerPlatformInputElem, OSFramework.OSUI.GlobalEnum.HTMLAttributes.type, dateType);
+                            OSFramework.OSUI.Helper.Dom.Attribute.Set(this.datePickerPlatformInputElem, OSFramework.OSUI.GlobalEnum.HTMLAttributes.Type, dateType);
                         }
                         build() {
                             super.build();
@@ -19379,7 +19301,7 @@ var Providers;
                         this.monthPickerPlatformInputElem = undefined;
                     }
                     updatePlatformInputAttrs() {
-                        OSFramework.OSUI.Helper.Dom.Attribute.Set(this.monthPickerPlatformInputElem, OSFramework.OSUI.GlobalEnum.HTMLAttributes.type, OSFramework.OSUI.GlobalEnum.InputTypeAttr.Text);
+                        OSFramework.OSUI.Helper.Dom.Attribute.Set(this.monthPickerPlatformInputElem, OSFramework.OSUI.GlobalEnum.HTMLAttributes.Type, OSFramework.OSUI.GlobalEnum.InputTypeAttr.Text);
                     }
                     build() {
                         super.build();
@@ -20635,7 +20557,7 @@ var Providers;
                         this.timePickerPlatformInputElem = undefined;
                     }
                     updatePlatformInputAttrs() {
-                        OSFramework.OSUI.Helper.Dom.Attribute.Set(this.timePickerPlatformInputElem, OSFramework.OSUI.GlobalEnum.HTMLAttributes.type, OSFramework.OSUI.GlobalEnum.InputTypeAttr.Time);
+                        OSFramework.OSUI.Helper.Dom.Attribute.Set(this.timePickerPlatformInputElem, OSFramework.OSUI.GlobalEnum.HTMLAttributes.Type, OSFramework.OSUI.GlobalEnum.InputTypeAttr.Time);
                     }
                     build() {
                         super.build();

--- a/dist/OutSystemsUI.js
+++ b/dist/OutSystemsUI.js
@@ -3748,6 +3748,18 @@ var OSFramework;
                     constructor(config) {
                         super(config);
                     }
+                    validateDefault(key, value) {
+                        let validatedValue = undefined;
+                        switch (key) {
+                            case Accordion.Enum.Properties.MultipleItems:
+                                validatedValue = this.validateBoolean(value, false);
+                                break;
+                            default:
+                                validatedValue = super.validateDefault(key, value);
+                                break;
+                        }
+                        return validatedValue;
+                    }
                 }
                 Accordion.AccordionConfig = AccordionConfig;
             })(Accordion = Patterns.Accordion || (Patterns.Accordion = {}));
@@ -4098,6 +4110,30 @@ var OSFramework;
                 class AccordionItemConfig extends Patterns.AbstractConfiguration {
                     constructor(config) {
                         super(config);
+                    }
+                    validateCanChange(isBuilt, key) {
+                        if (isBuilt) {
+                            return key !== AccordionItem.Enum.Properties.StartsExpanded;
+                        }
+                        return true;
+                    }
+                    validateDefault(key, value) {
+                        let validatedValue = undefined;
+                        switch (key) {
+                            case AccordionItem.Enum.Properties.IsDisabled:
+                                validatedValue = this.validateBoolean(value, false);
+                                break;
+                            case AccordionItem.Enum.Properties.Icon:
+                                validatedValue = this.validateString(value, AccordionItem.Enum.IconType.Caret);
+                                break;
+                            case AccordionItem.Enum.Properties.IconPosition:
+                                validatedValue = this.validateString(value, OSUI.GlobalEnum.Direction.Right);
+                                break;
+                            default:
+                                validatedValue = super.validateDefault(key, value);
+                                break;
+                        }
+                        return validatedValue;
                     }
                 }
                 AccordionItem.AccordionItemConfig = AccordionItemConfig;
@@ -4549,6 +4585,21 @@ var OSFramework;
                     constructor(config) {
                         super(config);
                     }
+                    validateDefault(key, value) {
+                        let validatedValue = undefined;
+                        switch (key) {
+                            case BottomSheet.Enum.Properties.Shape:
+                                validatedValue = this.validateInRange(value, OSUI.GlobalEnum.ShapeTypes.SoftRounded, OSUI.GlobalEnum.ShapeTypes.Sharp, OSUI.GlobalEnum.ShapeTypes.Rounded);
+                                break;
+                            case BottomSheet.Enum.Properties.ShowHandler:
+                                validatedValue = this.validateBoolean(value, false);
+                                break;
+                            default:
+                                validatedValue = super.validateDefault(key, value);
+                                break;
+                        }
+                        return validatedValue;
+                    }
                 }
                 BottomSheet.BottomSheetConfig = BottomSheetConfig;
             })(BottomSheet = Patterns.BottomSheet || (Patterns.BottomSheet = {}));
@@ -4780,19 +4831,19 @@ var OSFramework;
                                 validatedValue = this.validateNumber(value, 1);
                                 break;
                             case Carousel.Enum.Properties.Height:
-                                validatedValue = this.validateString(value, 'auto');
+                                validatedValue = this.validateString(value, Carousel.Enum.Defaults.Height);
                                 break;
                             case Carousel.Enum.Properties.AutoPlay:
                                 validatedValue = this.validateBoolean(value, false);
                                 break;
                             case Carousel.Enum.Properties.ItemsGap:
-                                validatedValue = this.validateString(value, '0px');
+                                validatedValue = this.validateString(value, Carousel.Enum.Defaults.SpaceNone);
                                 break;
                             case Carousel.Enum.Properties.Loop:
                                 validatedValue = this.validateBoolean(value, true);
                                 break;
                             case Carousel.Enum.Properties.Padding:
-                                validatedValue = this.validateString(value, '0px');
+                                validatedValue = this.validateString(value, Carousel.Enum.Defaults.SpaceNone);
                                 break;
                             default:
                                 validatedValue = super.validateDefault(key, value);
@@ -4887,6 +4938,11 @@ var OSFramework;
                         Navigation["Dots"] = "dots";
                         Navigation["None"] = "none";
                     })(Navigation = Enum.Navigation || (Enum.Navigation = {}));
+                    let Defaults;
+                    (function (Defaults) {
+                        Defaults["Height"] = "auto";
+                        Defaults["SpaceNone"] = "0px";
+                    })(Defaults = Enum.Defaults || (Enum.Defaults = {}));
                 })(Enum = Carousel.Enum || (Carousel.Enum = {}));
             })(Carousel = Patterns.Carousel || (Patterns.Carousel = {}));
         })(Patterns = OSUI.Patterns || (OSUI.Patterns = {}));
@@ -6318,6 +6374,12 @@ var OSFramework;
                     constructor(config) {
                         super(config);
                     }
+                    validateCanChange(isBuilt, key) {
+                        if (isBuilt) {
+                            return key !== FlipContent.Enum.Properties.IsFlipped;
+                        }
+                        return true;
+                    }
                 }
                 FlipContent.FlipContentConfig = FlipContentConfig;
             })(FlipContent = Patterns.FlipContent || (Patterns.FlipContent = {}));
@@ -6561,7 +6623,7 @@ var OSFramework;
                         let validatedValue = undefined;
                         switch (key) {
                             case InlineSvg.Enum.Properties.SVGCode:
-                                validatedValue = super.validateString(value, '');
+                                validatedValue = super.validateString(value, OSFramework.OSUI.Constants.EmptyString);
                                 break;
                             default:
                                 validatedValue = super.validateDefault(key, value);
@@ -7018,6 +7080,37 @@ var OSFramework;
             var Notification;
             (function (Notification) {
                 class NotificationConfig extends Patterns.AbstractConfiguration {
+                    validateCanChange(isBuilt, key) {
+                        if (isBuilt) {
+                            return key !== Notification.Enum.Properties.StartsOpen;
+                        }
+                        return true;
+                    }
+                    validateDefault(key, value) {
+                        let validatedValue = undefined;
+                        switch (key) {
+                            case Notification.Enum.Properties.InteractToClose:
+                                validatedValue = this.validateBoolean(value, true);
+                                break;
+                            case Notification.Enum.Properties.NeedsSwipes:
+                            case Notification.Enum.Properties.StartsOpen:
+                                validatedValue = this.validateBoolean(value, false);
+                                break;
+                            case Notification.Enum.Properties.Position:
+                                validatedValue = this.validateString(value, Notification.Enum.Defaults.DefaultPosition);
+                                break;
+                            case Notification.Enum.Properties.Width:
+                                validatedValue = this.validateString(value, Notification.Enum.Defaults.DefaultWidth);
+                                break;
+                            case Notification.Enum.Properties.CloseAfterTime:
+                                validatedValue = this.validateNumber(value, undefined);
+                                break;
+                            default:
+                                validatedValue = super.validateDefault(key, value);
+                                break;
+                        }
+                        return validatedValue;
+                    }
                 }
                 Notification.NotificationConfig = NotificationConfig;
             })(Notification = Patterns.Notification || (Patterns.Notification = {}));
@@ -8805,6 +8898,12 @@ var OSFramework;
             var SectionIndexItem;
             (function (SectionIndexItem) {
                 class SectionIndexItemConfig extends Patterns.AbstractConfiguration {
+                    validateCanChange(isBuilt, key) {
+                        if (isBuilt) {
+                            return key !== SectionIndexItem.Enum.Properties.ScrollToWidgetId;
+                        }
+                        return true;
+                    }
                 }
                 SectionIndexItem.SectionIndexItemConfig = SectionIndexItemConfig;
             })(SectionIndexItem = Patterns.SectionIndexItem || (Patterns.SectionIndexItem = {}));
@@ -8828,6 +8927,10 @@ var OSFramework;
                         Properties["Width"] = "Width";
                         Properties["HasOverlay"] = "HasOverlay";
                     })(Properties = Enum.Properties || (Enum.Properties = {}));
+                    let Defaults;
+                    (function (Defaults) {
+                        Defaults["Width"] = "500px";
+                    })(Defaults = Enum.Defaults || (Enum.Defaults = {}));
                     let CssClass;
                     (function (CssClass) {
                         CssClass["Aside"] = "osui-sidebar";
@@ -9139,6 +9242,31 @@ var OSFramework;
                 class SidebarConfig extends Patterns.AbstractConfiguration {
                     constructor(config) {
                         super(config);
+                    }
+                    validateCanChange(isBuilt, key) {
+                        if (isBuilt) {
+                            return key !== Sidebar.Enum.Properties.StartsOpen;
+                        }
+                        return true;
+                    }
+                    validateDefault(key, value) {
+                        let validatedValue = undefined;
+                        switch (key) {
+                            case Sidebar.Enum.Properties.Direction:
+                                validatedValue = this.validateInRange(value, OSUI.GlobalEnum.Direction.Right, OSUI.GlobalEnum.Direction.Right, OSUI.GlobalEnum.Direction.Left);
+                                break;
+                            case Sidebar.Enum.Properties.HasOverlay:
+                            case Sidebar.Enum.Properties.StartsOpen:
+                                validatedValue = this.validateBoolean(value, false);
+                                break;
+                            case Sidebar.Enum.Properties.Width:
+                                validatedValue = this.validateString(value, Sidebar.Enum.Defaults.Width);
+                                break;
+                            default:
+                                validatedValue = super.validateDefault(key, value);
+                                break;
+                        }
+                        return validatedValue;
                     }
                 }
                 Sidebar.SidebarConfig = SidebarConfig;
@@ -10266,6 +10394,34 @@ var OSFramework;
             var Tabs;
             (function (Tabs) {
                 class TabsConfig extends Patterns.AbstractConfiguration {
+                    validateCanChange(isBuilt, key) {
+                        if (isBuilt) {
+                            return key !== Tabs.Enum.Properties.StartingTab;
+                        }
+                        return true;
+                    }
+                    validateDefault(key, value) {
+                        let validatedValue = undefined;
+                        switch (key) {
+                            case Tabs.Enum.Properties.TabsOrientation:
+                                validatedValue = this.validateInRange(value, OSUI.GlobalEnum.Orientation.Horizontal, OSUI.GlobalEnum.Orientation.Vertical);
+                                break;
+                            case Tabs.Enum.Properties.TabsVerticalPosition:
+                                validatedValue = this.validateInRange(value, OSUI.GlobalEnum.Direction.Left, OSUI.GlobalEnum.Direction.Right);
+                                break;
+                            case Tabs.Enum.Properties.ContentAutoHeight:
+                            case Tabs.Enum.Properties.JustifyHeaders:
+                                validatedValue = this.validateBoolean(value, false);
+                                break;
+                            case Tabs.Enum.Properties.Height:
+                                validatedValue = this.validateString(value, OSUI.GlobalEnum.CssProperties.Auto);
+                                break;
+                            default:
+                                validatedValue = super.validateDefault(key, value);
+                                break;
+                        }
+                        return validatedValue;
+                    }
                 }
                 Tabs.TabsConfig = TabsConfig;
             })(Tabs = Patterns.Tabs || (Patterns.Tabs = {}));

--- a/dist/OutSystemsUI.js
+++ b/dist/OutSystemsUI.js
@@ -3748,18 +3748,6 @@ var OSFramework;
                     constructor(config) {
                         super(config);
                     }
-                    validateDefault(key, value) {
-                        let validatedValue = undefined;
-                        switch (key) {
-                            case Accordion.Enum.Properties.MultipleItems:
-                                validatedValue = this.validateBoolean(value, false);
-                                break;
-                            default:
-                                validatedValue = super.validateDefault(key, value);
-                                break;
-                        }
-                        return validatedValue;
-                    }
                 }
                 Accordion.AccordionConfig = AccordionConfig;
             })(Accordion = Patterns.Accordion || (Patterns.Accordion = {}));
@@ -4110,30 +4098,6 @@ var OSFramework;
                 class AccordionItemConfig extends Patterns.AbstractConfiguration {
                     constructor(config) {
                         super(config);
-                    }
-                    validateCanChange(isBuilt, key) {
-                        if (isBuilt) {
-                            return key !== AccordionItem.Enum.Properties.StartsExpanded;
-                        }
-                        return true;
-                    }
-                    validateDefault(key, value) {
-                        let validatedValue = undefined;
-                        switch (key) {
-                            case AccordionItem.Enum.Properties.IsDisabled:
-                                validatedValue = this.validateBoolean(value, false);
-                                break;
-                            case AccordionItem.Enum.Properties.Icon:
-                                validatedValue = this.validateString(value, AccordionItem.Enum.IconType.Caret);
-                                break;
-                            case AccordionItem.Enum.Properties.IconPosition:
-                                validatedValue = this.validateString(value, OSUI.GlobalEnum.Direction.Right);
-                                break;
-                            default:
-                                validatedValue = super.validateDefault(key, value);
-                                break;
-                        }
-                        return validatedValue;
                     }
                 }
                 AccordionItem.AccordionItemConfig = AccordionItemConfig;
@@ -4584,21 +4548,6 @@ var OSFramework;
                 class BottomSheetConfig extends Patterns.AbstractConfiguration {
                     constructor(config) {
                         super(config);
-                    }
-                    validateDefault(key, value) {
-                        let validatedValue = undefined;
-                        switch (key) {
-                            case BottomSheet.Enum.Properties.Shape:
-                                validatedValue = this.validateInRange(value, OSUI.GlobalEnum.ShapeTypes.SoftRounded, OSUI.GlobalEnum.ShapeTypes.Sharp, OSUI.GlobalEnum.ShapeTypes.Rounded);
-                                break;
-                            case BottomSheet.Enum.Properties.ShowHandler:
-                                validatedValue = this.validateBoolean(value, false);
-                                break;
-                            default:
-                                validatedValue = super.validateDefault(key, value);
-                                break;
-                        }
-                        return validatedValue;
                     }
                 }
                 BottomSheet.BottomSheetConfig = BottomSheetConfig;

--- a/src/scripts/OSFramework/OSUI/Pattern/Accordion/Accordion.ts
+++ b/src/scripts/OSFramework/OSUI/Pattern/Accordion/Accordion.ts
@@ -9,7 +9,7 @@ namespace OSFramework.OSUI.Patterns.Accordion {
 		}
 
 		/**
-		 * Sets the A11Y properties when the pattern is built.
+		 * Method to set the A11Y properties when the pattern is built.
 		 *
 		 * @protected
 		 * @memberof OSFramework.Patterns.Accordion.Accordion
@@ -110,7 +110,7 @@ namespace OSFramework.OSUI.Patterns.Accordion {
 		}
 
 		/**
-		 * Method to build the pattern.
+		 * Method to build the Accordion
 		 *
 		 * @memberof OSFramework.Patterns.Accordion.Accordion
 		 */

--- a/src/scripts/OSFramework/OSUI/Pattern/Accordion/AccordionConfig.ts
+++ b/src/scripts/OSFramework/OSUI/Pattern/Accordion/AccordionConfig.ts
@@ -1,32 +1,17 @@
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 namespace OSFramework.OSUI.Patterns.Accordion {
+	/**
+	 * Class that represents the custom configurations received by Accordion.
+	 *
+	 * @export
+	 * @class AccordionConfig
+	 * @extends {AbstractConfiguration}
+	 */
 	export class AccordionConfig extends AbstractConfiguration {
 		public MultipleItems: boolean;
 
 		constructor(config: JSON) {
 			super(config);
-		}
-
-		/**
-		 * Method used to validate default value before apply it's change!
-		 *
-		 * @param key property name
-		 * @param value value to be set
-		 * @returns {*}
-		 * @memberof OSFramework.Patterns.Accordion.AccordionConfig
-		 */
-		public validateDefault(key: string, value: unknown): unknown {
-			let validatedValue = undefined;
-			switch (key) {
-				case Enum.Properties.MultipleItems:
-					validatedValue = this.validateBoolean(value as boolean, false);
-					break;
-				default:
-					validatedValue = super.validateDefault(key, value);
-					break;
-			}
-
-			return validatedValue;
 		}
 	}
 }

--- a/src/scripts/OSFramework/OSUI/Pattern/Accordion/AccordionConfig.ts
+++ b/src/scripts/OSFramework/OSUI/Pattern/Accordion/AccordionConfig.ts
@@ -13,5 +13,27 @@ namespace OSFramework.OSUI.Patterns.Accordion {
 		constructor(config: JSON) {
 			super(config);
 		}
+
+		/**
+		 * Method used to validate default value before apply it's change!
+		 *
+		 * @param key property name
+		 * @param value value to be set
+		 * @returns {*}
+		 * @memberof OSFramework.Patterns.Accordion.AccordionConfig
+		 */
+		public validateDefault(key: string, value: unknown): unknown {
+			let validatedValue = undefined;
+			switch (key) {
+				case Enum.Properties.MultipleItems:
+					validatedValue = this.validateBoolean(value as boolean, false);
+					break;
+				default:
+					validatedValue = super.validateDefault(key, value);
+					break;
+			}
+
+			return validatedValue;
+		}
 	}
 }

--- a/src/scripts/OSFramework/OSUI/Pattern/Accordion/IAccordion.ts
+++ b/src/scripts/OSFramework/OSUI/Pattern/Accordion/IAccordion.ts
@@ -4,10 +4,42 @@ namespace OSFramework.OSUI.Patterns.Accordion {
 	 * Defines the interface for OutSystemsUI Accordion Pattern
 	 */
 	export interface IAccordion extends Interface.IParent {
+		/**
+		 * Method to add a new accordionItem
+		 *
+		 * @param {AccordionItem.IAccordionItem} accordionItem
+		 * @memberof IAccordion
+		 */
 		addAccordionItem(accordionItem: AccordionItem.IAccordionItem): void;
+
+		/**
+		 * Method to close all accordionItems
+		 *
+		 * @memberof IAccordion
+		 */
 		collapseAllItems(): void;
+
+		/**
+		 * Method to open all accordionItems
+		 *
+		 * @memberof IAccordion
+		 */
 		expandAllItems(): void;
+
+		/**
+		 * Method to remove an accordionItem
+		 *
+		 * @param {string} uniqueId
+		 * @memberof IAccordion
+		 */
 		removeAccordionItem(uniqueId: string): void;
+
+		/**
+		 * Method to close all accordionItems
+		 *
+		 * @param {string} accordionItemId
+		 * @memberof IAccordion
+		 */
 		triggerAccordionItemClose(accordionItemId: string): void;
 	}
 }

--- a/src/scripts/OSFramework/OSUI/Pattern/AccordionItem/AccordionItem.ts
+++ b/src/scripts/OSFramework/OSUI/Pattern/AccordionItem/AccordionItem.ts
@@ -42,7 +42,14 @@ namespace OSFramework.OSUI.Patterns.AccordionItem {
 			this._isOpen = this.configs.StartsExpanded;
 		}
 
-		// Method to handle the click event
+		/**
+		 * Method to handle the click event
+		 *
+		 * @private
+		 * @param {MouseEvent} event
+		 * @return {*}  {void}
+		 * @memberof AccordionItem
+		 */
 		private _accordionOnClickHandler(event: MouseEvent): void {
 			if (this._allowTitleEvents) {
 				if (
@@ -61,13 +68,24 @@ namespace OSFramework.OSUI.Patterns.AccordionItem {
 			}
 		}
 
-		// Method to add the event listeners
+		/**
+		 * Method to add the event listeners
+		 *
+		 * @private
+		 * @memberof AccordionItem
+		 */
 		private _addEvents(): void {
 			this._accordionItemTitleElem.addEventListener(GlobalEnum.HTMLEvent.Click, this._eventOnClick);
 			this._accordionItemTitleElem.addEventListener(GlobalEnum.HTMLEvent.keyDown, this._eventOnkeyPress);
 		}
 
-		// Method to handle async animation
+		/**
+		 * Method to handle async animation
+		 *
+		 * @private
+		 * @param {boolean} isExpand
+		 * @memberof AccordionItem
+		 */
 		private _animationAsync(isExpand: boolean): void {
 			const finalHeight = isExpand ? this._expandedHeight : this._collapsedHeight;
 
@@ -103,7 +121,12 @@ namespace OSFramework.OSUI.Patterns.AccordionItem {
 			this._onToggleCallback();
 		}
 
-		// Method to handle the tabindex values
+		/**
+		 * Method to handle the tabindex values
+		 *
+		 * @private
+		 * @memberof AccordionItem
+		 */
 		private _handleTabIndex(): void {
 			const titleTabindexValue = this.configs.IsDisabled
 				? Constants.A11YAttributes.States.TabIndexHidden
@@ -121,7 +144,14 @@ namespace OSFramework.OSUI.Patterns.AccordionItem {
 			}
 		}
 
-		// Method to hadle Keyboardpress event
+		/**
+		 * Method to handle Keyboardpress event
+		 *
+		 * @private
+		 * @param {KeyboardEvent} event
+		 * @return {*}  {void}
+		 * @memberof AccordionItem
+		 */
 		private _onKeyboardPress(event: KeyboardEvent): void {
 			const isEscapedKey = event.key === GlobalEnum.Keycodes.Escape;
 			const isEnterOrSpaceKey =
@@ -143,18 +173,33 @@ namespace OSFramework.OSUI.Patterns.AccordionItem {
 			}
 		}
 
-		// Method to handle the keyboard interactions
+		/**
+		 * Method to handle the keyboard interactions
+		 *
+		 * @private
+		 * @memberof AccordionItem
+		 */
 		private _onToggleCallback(): void {
 			this.triggerPlatformEventCallback(this._platformEventOnToggle, this._isOpen);
 		}
 
-		// Method to remove the event listeners
+		/**
+		 * Method to remove the event listeners
+		 *
+		 * @private
+		 * @memberof AccordionItem
+		 */
 		private _removeEvents(): void {
 			this._accordionItemTitleElem.removeEventListener(GlobalEnum.HTMLEvent.Click, this._eventOnClick);
 			this._accordionItemTitleElem.removeEventListener(GlobalEnum.HTMLEvent.keyDown, this._eventOnkeyPress);
 		}
 
-		// Method to set the parent Info, if an accordion wrapper is being used
+		/**
+		 * Method to set the parent Info, if an accordion wrapper is being used
+		 *
+		 * @private
+		 * @memberof AccordionItem
+		 */
 		private _setAccordionParent(): void {
 			// Get parent info
 			this.setParentInfo(
@@ -169,7 +214,12 @@ namespace OSFramework.OSUI.Patterns.AccordionItem {
 			}
 		}
 
-		// Method that changes the icon's position
+		/**
+		 * Method that changes the icon's position
+		 *
+		 * @private
+		 * @memberof AccordionItem
+		 */
 		private _setIconPosition(): void {
 			//If the page we're on is RTL, the icon's position has to change accordingly.
 			if (this.configs.IconPosition === GlobalEnum.Direction.Right) {
@@ -181,7 +231,12 @@ namespace OSFramework.OSUI.Patterns.AccordionItem {
 			}
 		}
 
-		// Method that changes the icon's type (Caret, Plus/Minus, Custom)
+		/**
+		 * Method that changes the icon's type (Caret, Plus/Minus, Custom)
+		 *
+		 * @private
+		 * @memberof AccordionItem
+		 */
 		private _setIconType(): void {
 			switch (this.configs.Icon) {
 				case Enum.IconType.PlusMinus:
@@ -208,7 +263,12 @@ namespace OSFramework.OSUI.Patterns.AccordionItem {
 			}
 		}
 
-		// Method to handle the IsDisabled state
+		/**
+		 * Method to handle the IsDisabled state
+		 *
+		 * @private
+		 * @memberof AccordionItem
+		 */
 		private _setIsDisabledState(): void {
 			if (this.configs.IsDisabled) {
 				Helper.Dom.Styles.AddClass(this.selfElement, Enum.CssClass.PatternDisabled);
@@ -226,7 +286,12 @@ namespace OSFramework.OSUI.Patterns.AccordionItem {
 			this._handleTabIndex();
 		}
 
-		// Method to handle the onTransitionEnd on accordion toggle animation
+		/**
+		 * Method to handle the onTransitionEnd on accordion toggle animation
+		 *
+		 * @private
+		 * @memberof AccordionItem
+		 */
 		private _transitionEndHandler(): void {
 			if (this._accordionItemContentElem) {
 				Helper.Dom.Styles.RemoveClass(this._accordionItemContentElem, Enum.CssClass.PatternAnimating);
@@ -304,7 +369,7 @@ namespace OSFramework.OSUI.Patterns.AccordionItem {
 		}
 
 		/**
-		 * Method that sets the HTML elements of the Accordion Item
+		 * Method to set the HTML elements of the Accordion Item
 		 *
 		 * @protected
 		 * @memberof OSFramework.Patterns.AccordionItem.AccordionItem
@@ -373,7 +438,7 @@ namespace OSFramework.OSUI.Patterns.AccordionItem {
 		}
 
 		/**
-		 * isDisabled getter
+		 * Method to return the isDisabled value
 		 *
 		 * @readonly
 		 * @type {boolean}
@@ -384,7 +449,7 @@ namespace OSFramework.OSUI.Patterns.AccordionItem {
 		}
 
 		/**
-		 * IsOpen getter
+		 * Method to return the IsOpen value
 		 *
 		 * @readonly
 		 * @type {boolean}
@@ -404,7 +469,7 @@ namespace OSFramework.OSUI.Patterns.AccordionItem {
 		}
 
 		/**
-		 * Method to build the pattern.
+		 * Method to build the AccordionItem
 		 *
 		 * @memberof OSFramework.Patterns.AccordionItem.AccordionItem
 		 */
@@ -546,7 +611,7 @@ namespace OSFramework.OSUI.Patterns.AccordionItem {
 		}
 
 		/**
-		 * Register a given callback event handler.
+		 * Method to register a given callback event handler.
 		 *
 		 * @param {string} eventName
 		 * @param {GlobalCallbacks.OSGeneric} callback

--- a/src/scripts/OSFramework/OSUI/Pattern/AccordionItem/AccordionItemConfig.ts
+++ b/src/scripts/OSFramework/OSUI/Pattern/AccordionItem/AccordionItemConfig.ts
@@ -1,5 +1,12 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
 namespace OSFramework.OSUI.Patterns.AccordionItem {
+	/**
+	 * Class that represents the custom configurations received by AccordionItem.
+	 *
+	 * @export
+	 * @class AccordionItemConfig
+	 * @extends {AbstractConfiguration}
+	 */
 	export class AccordionItemConfig extends AbstractConfiguration {
 		public Icon: string;
 		public IconPosition: string;
@@ -8,49 +15,6 @@ namespace OSFramework.OSUI.Patterns.AccordionItem {
 
 		constructor(config: JSON) {
 			super(config);
-		}
-
-		/**
-		 * Method used to check if a given property can be changed!
-		 *
-		 * @param isBuilt if pattern is already built
-		 * @param key key name to be checked
-		 * @returns {boolean}
-		 * @memberof OSFramework.Patterns.AccordionItem.AccordionItemConfig
-		 */
-		public validateCanChange(isBuilt: boolean, key: string): boolean {
-			if (isBuilt) {
-				return key !== Enum.Properties.StartsExpanded;
-			}
-			return true;
-		}
-
-		/**
-		 * Method used to validate default value before apply it's change!
-		 *
-		 * @param key property name
-		 * @param value value to be set
-		 * @returns {*}
-		 * @memberof OSFramework.Patterns.AccordionItem.AccordionItemConfig
-		 */
-		public validateDefault(key: string, value: unknown): unknown {
-			let validatedValue = undefined;
-			switch (key) {
-				case Enum.Properties.IsDisabled:
-					validatedValue = this.validateBoolean(value as boolean, false);
-					break;
-				case Enum.Properties.Icon:
-					validatedValue = this.validateString(value as string, Enum.IconType.Caret);
-					break;
-				case Enum.Properties.IconPosition:
-					validatedValue = this.validateString(value as string, GlobalEnum.Direction.Right);
-					break;
-				default:
-					validatedValue = super.validateDefault(key, value);
-					break;
-			}
-
-			return validatedValue;
 		}
 	}
 }

--- a/src/scripts/OSFramework/OSUI/Pattern/AccordionItem/AccordionItemConfig.ts
+++ b/src/scripts/OSFramework/OSUI/Pattern/AccordionItem/AccordionItemConfig.ts
@@ -16,5 +16,48 @@ namespace OSFramework.OSUI.Patterns.AccordionItem {
 		constructor(config: JSON) {
 			super(config);
 		}
+
+		/**
+		 * Method used to check if a given property can be changed!
+		 *
+		 * @param isBuilt if pattern is already built
+		 * @param key key name to be checked
+		 * @returns {boolean}
+		 * @memberof OSFramework.Patterns.AccordionItem.AccordionItemConfig
+		 */
+		public validateCanChange(isBuilt: boolean, key: string): boolean {
+			if (isBuilt) {
+				return key !== Enum.Properties.StartsExpanded;
+			}
+			return true;
+		}
+
+		/**
+		 * Method used to validate default value before apply it's change!
+		 *
+		 * @param key property name
+		 * @param value value to be set
+		 * @returns {*}
+		 * @memberof OSFramework.Patterns.AccordionItem.AccordionItemConfig
+		 */
+		public validateDefault(key: string, value: unknown): unknown {
+			let validatedValue = undefined;
+			switch (key) {
+				case Enum.Properties.IsDisabled:
+					validatedValue = this.validateBoolean(value as boolean, false);
+					break;
+				case Enum.Properties.Icon:
+					validatedValue = this.validateString(value as string, Enum.IconType.Caret);
+					break;
+				case Enum.Properties.IconPosition:
+					validatedValue = this.validateString(value as string, GlobalEnum.Direction.Right);
+					break;
+				default:
+					validatedValue = super.validateDefault(key, value);
+					break;
+			}
+
+			return validatedValue;
+		}
 	}
 }

--- a/src/scripts/OSFramework/OSUI/Pattern/AccordionItem/Enum.ts
+++ b/src/scripts/OSFramework/OSUI/Pattern/AccordionItem/Enum.ts
@@ -33,14 +33,14 @@ namespace OSFramework.OSUI.Patterns.AccordionItem.Enum {
 
 	/**
 	 * Callbacks eventName
-	 *
-	 * @export
-	 * @enum {number}
 	 */
 	export enum Events {
 		OnToggle = 'OnToggle',
 	}
 
+	/**
+	 * AccordionItem Enum IconType
+	 */
 	export enum IconType {
 		Caret = 'Caret',
 		Custom = 'Custom',

--- a/src/scripts/OSFramework/OSUI/Pattern/AccordionItem/IAccordionItem.ts
+++ b/src/scripts/OSFramework/OSUI/Pattern/AccordionItem/IAccordionItem.ts
@@ -4,8 +4,27 @@ namespace OSFramework.OSUI.Patterns.AccordionItem {
 	 * Defines the interface for OutSystemsUI AccordionItem Pattern
 	 */
 	export interface IAccordionItem extends Interface.IChild, Interface.IOpenable {
+		/**
+		 *  Returns the value of disable state
+		 *
+		 * @type {boolean}
+		 * @memberof IAccordionItem
+		 */
 		isDisabled: boolean;
+
+		/**
+		 *  Returns the value of open state
+		 *
+		 * @type {boolean}
+		 * @memberof IAccordionItem
+		 */
 		isOpen: boolean;
+
+		/**
+		 * Method to prevent clicks inside thte title to open the accordion
+		 *
+		 * @memberof IAccordionItem
+		 */
 		allowTitleEvents(): void;
 	}
 }

--- a/src/scripts/OSFramework/OSUI/Pattern/AnimatedLabel/AnimatedLabel.ts
+++ b/src/scripts/OSFramework/OSUI/Pattern/AnimatedLabel/AnimatedLabel.ts
@@ -165,7 +165,7 @@ namespace OSFramework.OSUI.Patterns.AnimatedLabel {
 		}
 
 		/**
-		 * Builds the animation label.
+		 *  Method to build the animation label.
 		 *
 		 * @memberof OSFramework.Patterns.AnimatedLabel.AnimatedLabel
 		 */

--- a/src/scripts/OSFramework/OSUI/Pattern/AnimatedLabel/AnimatedLabel.ts
+++ b/src/scripts/OSFramework/OSUI/Pattern/AnimatedLabel/AnimatedLabel.ts
@@ -30,36 +30,65 @@ namespace OSFramework.OSUI.Patterns.AnimatedLabel {
 			this._isLabelFocus = false;
 		}
 
-		// Add Pattern Events
+		/**
+		 * Method to add Pattern Events
+		 *
+		 * @private
+		 * @memberof AnimatedLabel
+		 */
 		private _addEvents(): void {
 			this._inputElement.addEventListener(GlobalEnum.HTMLEvent.Blur, this._eventBlur);
 			this._inputElement.addEventListener(GlobalEnum.HTMLEvent.Focus, this._eventFocus);
 			this._inputElement.addEventListener(GlobalEnum.HTMLEvent.AnimationStart, this._eventAnimationStart);
 		}
 
-		// Callback to the event onAnimationStart
+		/**
+		 * Method to set callback to the event onAnimationStart
+		 *
+		 * @private
+		 * @param {AnimationEvent} e
+		 * @memberof AnimatedLabel
+		 */
 		private _inputAnimationStartCallback(e: AnimationEvent): void {
 			if (e.animationName === Enum.AnimationEvent.OnAutoFillStart) {
 				this._inputStateToggle(true);
 			}
 		}
 
-		//  Callback to the event "blur" of the input
+		/**
+		 * Method to set callback to the event "blur" of the input
+		 *
+		 * @private
+		 * @param {UIEvent} evt
+		 * @memberof AnimatedLabel
+		 */
 		private _inputBlurCallback(evt: UIEvent): void {
 			if (evt.type === GlobalEnum.HTMLEvent.Blur) {
 				this._inputStateToggle(false);
 			}
 		}
 
-		//  Callback to the event "focus" of the input
+		/**
+		 * Method to set callback to the event "focus" of the input
+		 *
+		 * @private
+		 * @param {UIEvent} evt
+		 * @memberof AnimatedLabel
+		 */
 		private _inputFocusCallback(evt: UIEvent): void {
 			if (evt.type === GlobalEnum.HTMLEvent.Focus) {
 				this._inputStateToggle(true);
 			}
 		}
 
-		// Method that implements the toggle of the state of the input.
-		// It can either add or remove the class "active" of the input.
+		/**
+		 * Method that implements the toggle of the state of the input.
+		 * It can either add or remove the class "active" of the input.
+		 *
+		 * @private
+		 * @param {boolean} [isFocus=false]
+		 * @memberof AnimatedLabel
+		 */
 		private _inputStateToggle(isFocus = false): void {
 			const inputHasText = this._inputElement && this._inputElement.value !== '';
 
@@ -78,7 +107,12 @@ namespace OSFramework.OSUI.Patterns.AnimatedLabel {
 			}
 		}
 
-		// Remove Pattern Events
+		/**
+		 * Method to remove Pattern Events
+		 *
+		 * @private
+		 * @memberof AnimatedLabel
+		 */
 		private _removeEvents(): void {
 			this._inputElement.removeEventListener(GlobalEnum.HTMLEvent.Blur, this._eventBlur);
 			this._inputElement.removeEventListener(GlobalEnum.HTMLEvent.Focus, this._eventFocus);
@@ -93,7 +127,7 @@ namespace OSFramework.OSUI.Patterns.AnimatedLabel {
 		}
 
 		/**
-		 * Set the callbacks that will be assigned to the window click event
+		 * Method to set the callbacks that will be assigned to the window click event
 		 *
 		 * @protected
 		 * @memberof OSFramework.Patterns.AnimatedLabel.AnimatedLabel
@@ -107,7 +141,7 @@ namespace OSFramework.OSUI.Patterns.AnimatedLabel {
 		}
 
 		/**
-		 * Update info based on htmlContent
+		 * method to update info based on htmlContent
 		 *
 		 * @protected
 		 * @memberof OSFramework.Patterns.AnimatedLabel.AnimatedLabel
@@ -139,7 +173,7 @@ namespace OSFramework.OSUI.Patterns.AnimatedLabel {
 		}
 
 		/**
-		 * Removes the listeners that were added in the code and unsets the callbacks.
+		 * Method to remove the listeners that were added in the code and unsets the callbacks.
 		 *
 		 * @protected
 		 * @memberof OSFramework.Patterns.AnimatedLabel.AnimatedLabel
@@ -153,7 +187,7 @@ namespace OSFramework.OSUI.Patterns.AnimatedLabel {
 		}
 
 		/**
-		 * Removes the local value of the variables pointing to HTML elements;
+		 * Method to remove the local value of the variables pointing to HTML elements;
 		 *
 		 * @protected
 		 * @memberof OSFramework.Patterns.AnimatedLabel.AnimatedLabel
@@ -165,7 +199,7 @@ namespace OSFramework.OSUI.Patterns.AnimatedLabel {
 		}
 
 		/**
-		 *  Method to build the animation label.
+		 * Method to build the animation label.
 		 *
 		 * @memberof OSFramework.Patterns.AnimatedLabel.AnimatedLabel
 		 */
@@ -183,7 +217,7 @@ namespace OSFramework.OSUI.Patterns.AnimatedLabel {
 		}
 
 		/**
-		 * Destroy the Animatedlabel.
+		 * Method to destroy the Animatedlabel.
 		 *
 		 * @memberof OSFramework.Patterns.AnimatedLabel.AnimatedLabel
 		 */
@@ -197,7 +231,7 @@ namespace OSFramework.OSUI.Patterns.AnimatedLabel {
 		}
 
 		/**
-		 * Update Label active status accordingly when the input info has changed.
+		 * Method to update Label active status accordingly when the input info has changed.
 		 *
 		 * @memberof OSFramework.Patterns.AnimatedLabel.AnimatedLabel
 		 */

--- a/src/scripts/OSFramework/OSUI/Pattern/AnimatedLabel/Enum.ts
+++ b/src/scripts/OSFramework/OSUI/Pattern/AnimatedLabel/Enum.ts
@@ -8,7 +8,9 @@ namespace OSFramework.OSUI.Patterns.AnimatedLabel.Enum {
 		OnAutoFillStart = 'onAutoFillStart',
 	}
 
-	// Css Classes
+	/**
+	 * Css Classes
+	 */
 	export enum CssClasses {
 		InputPlaceholder = 'animated-label-input',
 		IsActive = 'active',
@@ -16,7 +18,9 @@ namespace OSFramework.OSUI.Patterns.AnimatedLabel.Enum {
 		Pattern = 'animated-label',
 	}
 
-	// Warning/Error messages
+	/**
+	 * Warning/Error messages
+	 */
 	export enum Messages {
 		InputNotFound = 'Missing input or textarea.',
 		LabelNotFound = 'We notice that a label is missing inside the Label Placeholder. In order to grant accessibility add it and assign the Input Widget accordingly.',

--- a/src/scripts/OSFramework/OSUI/Pattern/BottomSheet/BottomSheet.ts
+++ b/src/scripts/OSFramework/OSUI/Pattern/BottomSheet/BottomSheet.ts
@@ -322,7 +322,7 @@ namespace OSFramework.OSUI.Patterns.BottomSheet {
 		}
 
 		/**
-		 *  Builds the BottomSheet.
+		 * Method to build the BottomSheet.
 		 *
 		 * @memberof OSFramework.Patterns.BottomSheet.BottomSheet
 		 */

--- a/src/scripts/OSFramework/OSUI/Pattern/BottomSheet/BottomSheet.ts
+++ b/src/scripts/OSFramework/OSUI/Pattern/BottomSheet/BottomSheet.ts
@@ -42,7 +42,7 @@ namespace OSFramework.OSUI.Patterns.BottomSheet {
 		};
 
 		/**
-		 * Get Gesture Events Instance
+		 * Method to get Gesture Events Instance
 		 *
 		 * @readonly
 		 * @type {Event.GestureEvent.DragEvent}
@@ -53,7 +53,7 @@ namespace OSFramework.OSUI.Patterns.BottomSheet {
 		}
 
 		/**
-		 * Get if has gesture events
+		 * Method to get if has gesture events
 		 *
 		 * @readonly
 		 * @type {boolean}
@@ -67,7 +67,12 @@ namespace OSFramework.OSUI.Patterns.BottomSheet {
 			super(uniqueId, new BottomSheetConfig(configs));
 		}
 
-		// Add Focus Trap to Pattern
+		/**
+		 * Method to add Focus Trap to Pattern
+		 *
+		 * @private
+		 * @memberof BottomSheet
+		 */
 		private _handleFocusTrap(): void {
 			const opts = {
 				focusTargetElement: this._parentSelf,
@@ -76,7 +81,12 @@ namespace OSFramework.OSUI.Patterns.BottomSheet {
 			this._focusTrapInstance = new Behaviors.FocusTrap(opts);
 		}
 
-		// Method to handle the creation of the GestureEvents
+		/**
+		 * Method to handle the creation of the GestureEvents
+		 *
+		 * @private
+		 * @memberof BottomSheet
+		 */
 		private _handleGestureEvents(): void {
 			if (!Helper.DeviceInfo.IsDesktop) {
 				// Create and save gesture event instance. Created here and not on constructor,
@@ -88,7 +98,13 @@ namespace OSFramework.OSUI.Patterns.BottomSheet {
 			}
 		}
 
-		// Method to handle the Shape config css variable
+		/**
+		 * Method to handle the Shape config css variable
+		 *
+		 * @private
+		 * @param {GlobalEnum.ShapeTypes} shape
+		 * @memberof BottomSheet
+		 */
 		private _handleShape(shape: GlobalEnum.ShapeTypes): void {
 			Helper.Dom.Styles.SetStyleAttribute(
 				this.selfElement,
@@ -97,7 +113,12 @@ namespace OSFramework.OSUI.Patterns.BottomSheet {
 			);
 		}
 
-		// Method to be called as callback on scroll event, to toggle class on BottomSheet when it has scroll active
+		/**
+		 * Method to be called as callback on scroll event, to toggle class on BottomSheet when it has scroll active
+		 *
+		 * @private
+		 * @memberof BottomSheet
+		 */
 		private _onContentScrollCallback(): void {
 			if (this._bottomSheetContentElem.scrollTop === 0) {
 				Helper.Dom.Styles.RemoveClass(this.selfElement, Enum.CssClass.HasSCroll);
@@ -106,7 +127,15 @@ namespace OSFramework.OSUI.Patterns.BottomSheet {
 			}
 		}
 
-		// Method to handle the start of a gesture
+		/**
+		 * Method to handle the start of a gesture
+		 *
+		 * @private
+		 * @param {number} offsetX
+		 * @param {number} offsetY
+		 * @param {number} timeTaken
+		 * @memberof BottomSheet
+		 */
 		private _onGestureEnd(offsetX: number, offsetY: number, timeTaken: number): void {
 			this._animateOnDragInstance.onDragEnd(
 				offsetX,
@@ -117,12 +146,29 @@ namespace OSFramework.OSUI.Patterns.BottomSheet {
 			);
 		}
 
-		// Method to handle the gesture move
+		/**
+		 * Method to handle the gesture move
+		 *
+		 * @private
+		 * @param {number} x
+		 * @param {number} y
+		 * @param {number} offsetX
+		 * @param {number} offsetY
+		 * @param {TouchEvent} evt
+		 * @memberof BottomSheet
+		 */
 		private _onGestureMove(x: number, y: number, offsetX: number, offsetY: number, evt: TouchEvent): void {
 			this._animateOnDragInstance.onDragMove(offsetX, offsetY, x, y, evt);
 		}
 
-		// Method to handle the end of a gesture
+		/**
+		 * Method to handle the end of a gesture
+		 *
+		 * @private
+		 * @param {number} x
+		 * @param {number} y
+		 * @memberof BottomSheet
+		 */
 		private _onGestureStart(x: number, y: number): void {
 			this._animateOnDragInstance.onDragStart(
 				true,
@@ -134,7 +180,13 @@ namespace OSFramework.OSUI.Patterns.BottomSheet {
 			);
 		}
 
-		// Call methods to open or close, based on e.key and behaviour applied
+		/**
+		 * Method to call open or close, based on e.key and behaviour applied
+		 *
+		 * @private
+		 * @param {KeyboardEvent} e
+		 * @memberof BottomSheet
+		 */
 		private _onkeypressCallback(e: KeyboardEvent): void {
 			const isEscapedPressed = e.key === GlobalEnum.Keycodes.Escape;
 
@@ -144,7 +196,13 @@ namespace OSFramework.OSUI.Patterns.BottomSheet {
 			}
 		}
 
-		// Method to toggle the open/close the BottomSheet
+		/**
+		 * Method to toggle the open/close the BottomSheet
+		 *
+		 * @private
+		 * @param {boolean} isOpen
+		 * @memberof BottomSheet
+		 */
 		private _toggleBottomSheet(isOpen: boolean): void {
 			// Cancel animation if active
 			if (this._animateOnDragInstance?.dragParams.SpringAnimation) {
@@ -187,7 +245,13 @@ namespace OSFramework.OSUI.Patterns.BottomSheet {
 			this._triggerOnToggleEvent();
 		}
 
-		// Method that toggles the showHandler config
+		/**
+		 * Method that toggles the showHandler config
+		 *
+		 * @private
+		 * @param {boolean} ShowHandler
+		 * @memberof BottomSheet
+		 */
 		private _toggleHandler(ShowHandler: boolean): void {
 			if (ShowHandler) {
 				Helper.Dom.Styles.AddClass(this.selfElement, Enum.CssClass.HasHandler);
@@ -196,7 +260,12 @@ namespace OSFramework.OSUI.Patterns.BottomSheet {
 			}
 		}
 
-		// Method that triggers the OnToggle event
+		/**
+		 * Method that triggers the OnToggle event
+		 *
+		 * @private
+		 * @memberof BottomSheet
+		 */
 		private _triggerOnToggleEvent(): void {
 			this.triggerPlatformEventCallback(this._platformEventOnToggle, this._isOpen);
 		}
@@ -215,7 +284,7 @@ namespace OSFramework.OSUI.Patterns.BottomSheet {
 		}
 
 		/**
-		 * Add the Accessibility Attributes values
+		 * Method to add the Accessibility Attributes values
 		 *
 		 * @protected
 		 * @memberof OSFramework.Patterns.BottomSheet.BottomSheet
@@ -275,7 +344,7 @@ namespace OSFramework.OSUI.Patterns.BottomSheet {
 		}
 
 		/**
-		 * Update info based on htmlContent
+		 * Method to update info based on htmlContent
 		 *
 		 * @protected
 		 * @memberof OSFramework.Patterns.BottomSheet.BottomSheet
@@ -310,7 +379,7 @@ namespace OSFramework.OSUI.Patterns.BottomSheet {
 		}
 
 		/**
-		 * Removes the local value of the variables pointing to HTML elements;
+		 * Method to remove the local value of the variables pointing to HTML elements;
 		 *
 		 * @protected
 		 * @memberof OSFramework.Patterns.BottomSheet.BottomSheet
@@ -338,7 +407,7 @@ namespace OSFramework.OSUI.Patterns.BottomSheet {
 		}
 
 		/**
-		 * Applies the changes of state/value of the configurations.
+		 * Method to apply the changes of state/value of the configurations.
 		 *
 		 * @param {string} propertyName
 		 * @param {unknown} propertyValue
@@ -372,7 +441,7 @@ namespace OSFramework.OSUI.Patterns.BottomSheet {
 		}
 
 		/**
-		 * Disposes the current pattern.
+		 * Method to destroy pattern.
 		 *
 		 * @memberof OSFramework.Patterns.BottomSheet.BottomSheet
 		 */
@@ -403,7 +472,7 @@ namespace OSFramework.OSUI.Patterns.BottomSheet {
 		}
 
 		/**
-		 * Register a given callback event handler.
+		 * Method to register a given callback event handler.
 		 *
 		 * @param {string} eventName
 		 * @param {GlobalCallbacks.OSGeneric} callback
@@ -422,7 +491,7 @@ namespace OSFramework.OSUI.Patterns.BottomSheet {
 		}
 
 		/**
-		 * Removes the gesture events to open/close the BottomSheet on Native Apps
+		 * Method to remove the gesture events to open/close the BottomSheet on Native Apps
 		 *
 		 * @memberof OSFramework.Patterns.BottomSheet.BottomSheet
 		 */
@@ -437,7 +506,7 @@ namespace OSFramework.OSUI.Patterns.BottomSheet {
 		}
 
 		/**
-		 * Sets the gesture events to open/close the BottomSheet on Native Apps
+		 * Method to set the gesture events to open/close the BottomSheet on Native Apps
 		 *
 		 * @protected
 		 * @memberof OSFramework.Patterns.BottomSheet.BottomSheet

--- a/src/scripts/OSFramework/OSUI/Pattern/BottomSheet/BottomSheetConfig.ts
+++ b/src/scripts/OSFramework/OSUI/Pattern/BottomSheet/BottomSheetConfig.ts
@@ -14,35 +14,5 @@ namespace OSFramework.OSUI.Patterns.BottomSheet {
 		constructor(config: JSON) {
 			super(config);
 		}
-
-		/**
-		 * Override, Validate configs key values
-		 *
-		 * @param {string} key
-		 * @param {unknown} value
-		 * @return {*}  {unknown}
-		 * @memberof OSFramework.Patterns.BottomSheet.BottomSheetConfig
-		 */
-		public validateDefault(key: string, value: unknown): unknown {
-			let validatedValue = undefined;
-			switch (key) {
-				case Enum.Properties.Shape:
-					validatedValue = this.validateInRange(
-						value,
-						GlobalEnum.ShapeTypes.SoftRounded,
-						GlobalEnum.ShapeTypes.Sharp,
-						GlobalEnum.ShapeTypes.Rounded
-					);
-					break;
-				case Enum.Properties.ShowHandler:
-					validatedValue = this.validateBoolean(value as boolean, false);
-					break;
-				default:
-					validatedValue = super.validateDefault(key, value);
-					break;
-			}
-
-			return validatedValue;
-		}
 	}
 }

--- a/src/scripts/OSFramework/OSUI/Pattern/BottomSheet/BottomSheetConfig.ts
+++ b/src/scripts/OSFramework/OSUI/Pattern/BottomSheet/BottomSheetConfig.ts
@@ -14,5 +14,35 @@ namespace OSFramework.OSUI.Patterns.BottomSheet {
 		constructor(config: JSON) {
 			super(config);
 		}
+
+		/**
+		 * Override, Validate configs key values
+		 *
+		 * @param {string} key
+		 * @param {unknown} value
+		 * @return {*}  {unknown}
+		 * @memberof OSFramework.Patterns.BottomSheet.BottomSheetConfig
+		 */
+		public validateDefault(key: string, value: unknown): unknown {
+			let validatedValue = undefined;
+			switch (key) {
+				case Enum.Properties.Shape:
+					validatedValue = this.validateInRange(
+						value,
+						GlobalEnum.ShapeTypes.SoftRounded,
+						GlobalEnum.ShapeTypes.Sharp,
+						GlobalEnum.ShapeTypes.Rounded
+					);
+					break;
+				case Enum.Properties.ShowHandler:
+					validatedValue = this.validateBoolean(value as boolean, false);
+					break;
+				default:
+					validatedValue = super.validateDefault(key, value);
+					break;
+			}
+
+			return validatedValue;
+		}
 	}
 }

--- a/src/scripts/OSFramework/OSUI/Pattern/BottomSheet/IBottomSheet.ts
+++ b/src/scripts/OSFramework/OSUI/Pattern/BottomSheet/IBottomSheet.ts
@@ -8,7 +8,18 @@ namespace OSFramework.OSUI.Patterns.BottomSheet {
 	 * @extends {Interface.IPattern}
 	 */
 	export interface IBottomSheet extends Interface.IPattern {
+		/**
+		 * Method to close the BottomSheet
+		 *
+		 * @memberof IBottomSheet
+		 */
 		close(): void;
+
+		/**
+		 * Method to open the BottomSheet
+		 *
+		 * @memberof IBottomSheet
+		 */
 		open(): void;
 	}
 }

--- a/src/scripts/OSFramework/OSUI/Pattern/ButtonLoading/ButtonLoading.ts
+++ b/src/scripts/OSFramework/OSUI/Pattern/ButtonLoading/ButtonLoading.ts
@@ -124,7 +124,7 @@ namespace OSFramework.OSUI.Patterns.ButtonLoading {
 		}
 
 		/**
-		 *  Builds the button loading.
+		 * Method to build the button loading.
 		 *
 		 * @memberof OSFramework.Patterns.ButtonLoading.ButtonLoading
 		 */

--- a/src/scripts/OSFramework/OSUI/Pattern/Carousel/AbstractCarouselConfig.ts
+++ b/src/scripts/OSFramework/OSUI/Pattern/Carousel/AbstractCarouselConfig.ts
@@ -58,19 +58,19 @@ namespace OSFramework.OSUI.Patterns.Carousel {
 					validatedValue = this.validateNumber(value as number, 1);
 					break;
 				case Enum.Properties.Height:
-					validatedValue = this.validateString(value as string, 'auto');
+					validatedValue = this.validateString(value as string, Enum.Defaults.Height);
 					break;
 				case Enum.Properties.AutoPlay:
 					validatedValue = this.validateBoolean(value as boolean, false);
 					break;
 				case Enum.Properties.ItemsGap:
-					validatedValue = this.validateString(value as string, '0px');
+					validatedValue = this.validateString(value as string, Enum.Defaults.SpaceNone);
 					break;
 				case Enum.Properties.Loop:
 					validatedValue = this.validateBoolean(value as boolean, true);
 					break;
 				case Enum.Properties.Padding:
-					validatedValue = this.validateString(value as string, '0px');
+					validatedValue = this.validateString(value as string, Enum.Defaults.SpaceNone);
 					break;
 				default:
 					validatedValue = super.validateDefault(key, value);

--- a/src/scripts/OSFramework/OSUI/Pattern/Carousel/Enum.ts
+++ b/src/scripts/OSFramework/OSUI/Pattern/Carousel/Enum.ts
@@ -65,4 +65,12 @@ namespace OSFramework.OSUI.Patterns.Carousel.Enum {
 		Dots = 'dots',
 		None = 'none',
 	}
+
+	/**
+	 * Carousel default properties
+	 */
+	export enum Defaults {
+		Height = 'auto',
+		SpaceNone = '0px',
+	}
 }

--- a/src/scripts/OSFramework/OSUI/Pattern/Dropdown/ServerSide/DropdownServerSide.ts
+++ b/src/scripts/OSFramework/OSUI/Pattern/Dropdown/ServerSide/DropdownServerSide.ts
@@ -1062,6 +1062,11 @@ namespace OSFramework.OSUI.Patterns.Dropdown.ServerSide {
 			}
 		}
 
+		/**
+		 * Method to build the DropdownServerSide
+		 *
+		 * @memberof OSUIDropdownServerSide
+		 */
 		public build(): void {
 			super.build();
 			this.setCallbacks();

--- a/src/scripts/OSFramework/OSUI/Pattern/DropdownServerSideItem/DropdownServerSideItem.ts
+++ b/src/scripts/OSFramework/OSUI/Pattern/DropdownServerSideItem/DropdownServerSideItem.ts
@@ -165,7 +165,7 @@ namespace OSFramework.OSUI.Patterns.DropdownServerSideItem {
 		}
 
 		/**
-		 *  Builds the DropdownServerSideItem.
+		 * Method to build the DropdownServerSideItem.
 		 *
 		 * @memberof OSFramework.Patterns.DropdownServerSideItem.DropdownServerSideItem
 		 */

--- a/src/scripts/OSFramework/OSUI/Pattern/FlipContent/Enum.ts
+++ b/src/scripts/OSFramework/OSUI/Pattern/FlipContent/Enum.ts
@@ -22,9 +22,6 @@ namespace OSFramework.OSUI.Patterns.FlipContent.Enum {
 
 	/**
 	 * Callbacks eventName
-	 *
-	 * @export
-	 * @enum {number}
 	 */
 	export enum Events {
 		OnToggle = 'OnToggle',

--- a/src/scripts/OSFramework/OSUI/Pattern/FlipContent/FlipContent.ts
+++ b/src/scripts/OSFramework/OSUI/Pattern/FlipContent/FlipContent.ts
@@ -18,7 +18,13 @@ namespace OSFramework.OSUI.Patterns.FlipContent {
 			super(uniqueId, new FlipContentConfig(configs));
 		}
 
-		// Toggle pattern on keypress
+		/**
+		 * Method to toggle pattern on keypress
+		 *
+		 * @private
+		 * @param {KeyboardEvent} e
+		 * @memberof FlipContent
+		 */
 		private _keydownCallback(e: KeyboardEvent): void {
 			//If ENTER or SPACE use toggle to validate & If ESC is pressed then we need to close Flip
 			if (
@@ -32,13 +38,23 @@ namespace OSFramework.OSUI.Patterns.FlipContent {
 			}
 		}
 
-		// Method to remove the event listeners
+		/**
+		 * Method to remove the event listeners
+		 *
+		 * @private
+		 * @memberof FlipContent
+		 */
 		private _removeEvents(): void {
 			this.selfElement.removeEventListener(GlobalEnum.HTMLEvent.keyDown, this._eventKeydown);
 			this._flipWrapperElement.removeEventListener(GlobalEnum.HTMLEvent.Click, this._eventClick);
 		}
 
-		// Setting the handlers and the classes for when the FlipSelf is active or not
+		/**
+		 * Method to set the handlers and the classes for when the FlipSelf is active or not
+		 *
+		 * @private
+		 * @memberof FlipContent
+		 */
 		private _setEventHandlers(): void {
 			if (this.configs.FlipSelf) {
 				this.selfElement.addEventListener(GlobalEnum.HTMLEvent.keyDown, this._eventKeydown);
@@ -53,14 +69,24 @@ namespace OSFramework.OSUI.Patterns.FlipContent {
 			}
 		}
 
-		// Toggle FlipContent if is to start flipped
+		/**
+		 * Method to toggle FlipContent, if is to start flipped
+		 *
+		 * @private
+		 * @memberof FlipContent
+		 */
 		private _setStartsFlipped() {
 			if (this.isBuilt === false) {
 				this._toggleClasses();
 			}
 		}
 
-		// Set the classes on the pattern's first render, toggle click & parameters changed
+		/**
+		 * Method to set the classes on the pattern's first render, toggle click & parameters changed
+		 *
+		 * @private
+		 * @memberof FlipContent
+		 */
 		private _toggleClasses(): void {
 			if (this.configs.IsFlipped) {
 				Helper.Dom.Styles.AddClass(this.selfElement, Enum.CssClass.PatternIsFlipped);
@@ -69,12 +95,22 @@ namespace OSFramework.OSUI.Patterns.FlipContent {
 			}
 		}
 
-		// Triggers the toggle event on the platform
+		/**
+		 * Method to trigger the toggle event on the platform
+		 *
+		 * @private
+		 * @memberof FlipContent
+		 */
 		private _triggerPlatformEvent(): void {
 			this.triggerPlatformEventCallback(this._platformEventOnToggle, this.configs.IsFlipped);
 		}
 
-		// Update the A11Y attributes
+		/**
+		 * Method to update the A11Y attributes
+		 *
+		 * @private
+		 * @memberof FlipContent
+		 */
 		private _updateA11yProperties(): void {
 			if (this.configs.FlipSelf) {
 				Helper.A11Y.AriaAtomicTrue(this.selfElement);
@@ -86,7 +122,7 @@ namespace OSFramework.OSUI.Patterns.FlipContent {
 		}
 
 		/**
-		 * Set the A11Y attributes
+		 * Method to set the A11Y attributes
 		 *
 		 * @protected
 		 * @memberof OSFramework.Patterns.FlipContent.FlipContent
@@ -101,7 +137,7 @@ namespace OSFramework.OSUI.Patterns.FlipContent {
 		}
 
 		/**
-		 * Set the events
+		 * Method to set the events
 		 *
 		 * @protected
 		 * @memberof OSFramework.Patterns.FlipContent.FlipContent
@@ -114,7 +150,7 @@ namespace OSFramework.OSUI.Patterns.FlipContent {
 		}
 
 		/**
-		 * Set the HTML elements
+		 * Method to set the HTML elements
 		 *
 		 * @protected
 		 * @memberof OSFramework.Patterns.FlipContent.FlipContent
@@ -137,7 +173,7 @@ namespace OSFramework.OSUI.Patterns.FlipContent {
 		}
 
 		/**
-		 * Set the HTML elements
+		 * Method to set the HTML elements
 		 *
 		 * @protected
 		 * @memberof OSFramework.Patterns.FlipContent.FlipContent
@@ -168,7 +204,7 @@ namespace OSFramework.OSUI.Patterns.FlipContent {
 		}
 
 		/**
-		 * Update value when a parameters changed occurs
+		 * Method to update value when a parameters changed occurs
 		 *
 		 * @param {string} propertyName
 		 * @param {unknown} propertyValue
@@ -191,7 +227,7 @@ namespace OSFramework.OSUI.Patterns.FlipContent {
 		}
 
 		/**
-		 * Destroy FlipContent
+		 * Method to destroy FlipContent
 		 *
 		 * @memberof OSFramework.Patterns.FlipContent.FlipContent
 		 */
@@ -203,7 +239,7 @@ namespace OSFramework.OSUI.Patterns.FlipContent {
 		}
 
 		/**
-		 * Register a given callback event handler.
+		 * Method to register a given callback event handler.
 		 *
 		 * @param {string} eventName
 		 * @param {GlobalCallbacks.OSGeneric} callback
@@ -221,6 +257,11 @@ namespace OSFramework.OSUI.Patterns.FlipContent {
 			}
 		}
 
+		/**
+		 * Method to show the back content
+		 *
+		 * @memberof FlipContent
+		 */
 		public showBackContent(): void {
 			if (this.configs.IsFlipped === false) {
 				this.toggleFlipContent();
@@ -228,7 +269,7 @@ namespace OSFramework.OSUI.Patterns.FlipContent {
 		}
 
 		/**
-		 * Tries to show the font
+		 * Method to show the front content
 		 *
 		 * @memberof OSFramework.Patterns.FlipContent.FlipContent
 		 */
@@ -239,7 +280,7 @@ namespace OSFramework.OSUI.Patterns.FlipContent {
 		}
 
 		/**
-		 * Public method to trigger the flipping of the pattern and the event on the platform's side
+		 * Method to trigger the flipping of the pattern and the event on the platform's side
 		 *
 		 * @memberof OSFramework.Patterns.FlipContent.FlipContent
 		 */

--- a/src/scripts/OSFramework/OSUI/Pattern/FlipContent/FlipContent.ts
+++ b/src/scripts/OSFramework/OSUI/Pattern/FlipContent/FlipContent.ts
@@ -147,7 +147,7 @@ namespace OSFramework.OSUI.Patterns.FlipContent {
 		}
 
 		/**
-		 * Building Flip Content
+		 * Method to build the Flip Content
 		 *
 		 * @memberof OSFramework.Patterns.FlipContent.FlipContent
 		 */

--- a/src/scripts/OSFramework/OSUI/Pattern/FlipContent/FlipContentConfig.ts
+++ b/src/scripts/OSFramework/OSUI/Pattern/FlipContent/FlipContentConfig.ts
@@ -1,26 +1,18 @@
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 namespace OSFramework.OSUI.Patterns.FlipContent {
+	/**
+	 * Class that represents the custom configurations received by the FlipContent.
+	 *
+	 * @export
+	 * @class FlipContentConfig
+	 * @extends {AbstractConfiguration}
+	 */
 	export class FlipContentConfig extends AbstractConfiguration {
 		public FlipSelf: boolean;
 		public IsFlipped: boolean;
 
 		constructor(config: JSON) {
 			super(config);
-		}
-
-		/**
-		 * Method that will check if a given property (key) can be changed/updated!
-		 *
-		 * @param isBuilt True when pattern has been built!
-		 * @param key property name
-		 * @returns {boolean} boolean
-		 * @memberof  OSFramework.Patterns.FlipContent.FlipContentConfig
-		 */
-		public validateCanChange(isBuilt: boolean, key: string): boolean {
-			if (isBuilt) {
-				return key !== Enum.Properties.IsFlipped;
-			}
-			return true;
 		}
 	}
 }

--- a/src/scripts/OSFramework/OSUI/Pattern/FlipContent/FlipContentConfig.ts
+++ b/src/scripts/OSFramework/OSUI/Pattern/FlipContent/FlipContentConfig.ts
@@ -14,5 +14,20 @@ namespace OSFramework.OSUI.Patterns.FlipContent {
 		constructor(config: JSON) {
 			super(config);
 		}
+
+		/**
+		 * Method that will check if a given property (key) can be changed/updated!
+		 *
+		 * @param isBuilt True when pattern has been built!
+		 * @param key property name
+		 * @returns {boolean} boolean
+		 * @memberof  OSFramework.Patterns.FlipContent.FlipContentConfig
+		 */
+		public validateCanChange(isBuilt: boolean, key: string): boolean {
+			if (isBuilt) {
+				return key !== Enum.Properties.IsFlipped;
+			}
+			return true;
+		}
 	}
 }

--- a/src/scripts/OSFramework/OSUI/Pattern/FlipContent/IFlipContent.ts
+++ b/src/scripts/OSFramework/OSUI/Pattern/FlipContent/IFlipContent.ts
@@ -4,8 +4,25 @@ namespace OSFramework.OSUI.Patterns.FlipContent {
 	 * Defines the interface for OutSystemsUI flipContent Pattern
 	 */
 	export interface IFlipContent extends Interface.IPattern {
+		/**
+		 * Method to show the back content
+		 *
+		 * @memberof IFlipContent
+		 */
 		showBackContent(): void;
+
+		/**
+		 * Method to show the front content
+		 *
+		 * @memberof IFlipContent
+		 */
 		showFrontContent(): void;
+
+		/**
+		 * Method to trigger the flipping of the pattern
+		 *
+		 * @memberof IFlipContent
+		 */
 		toggleFlipContent(): void;
 	}
 }

--- a/src/scripts/OSFramework/OSUI/Pattern/Gallery/Enum.ts
+++ b/src/scripts/OSFramework/OSUI/Pattern/Gallery/Enum.ts
@@ -2,9 +2,6 @@
 namespace OSFramework.OSUI.Patterns.Gallery.Enum {
 	/**
 	 * Gallery CSS Variables
-	 *
-	 * @export
-	 * @enum {number}
 	 */
 	export enum CssVariables {
 		PatternItemsDesktop = '--gallery-desktop-items',
@@ -17,9 +14,6 @@ namespace OSFramework.OSUI.Patterns.Gallery.Enum {
 	}
 	/**
 	 * Gallery Enum properties
-	 *
-	 * @export
-	 * @enum {number}
 	 */
 	export enum Properties {
 		ItemsGap = 'ItemsGap',

--- a/src/scripts/OSFramework/OSUI/Pattern/Gallery/Gallery.ts
+++ b/src/scripts/OSFramework/OSUI/Pattern/Gallery/Gallery.ts
@@ -164,7 +164,7 @@ namespace OSFramework.OSUI.Patterns.Gallery {
 		}
 
 		/**
-		 * Build Gallery
+		 * Method to build the Gallery
 		 *
 		 * @memberof OSFramework.Patterns.Gallery.Gallery
 		 */

--- a/src/scripts/OSFramework/OSUI/Pattern/Gallery/GalleryConfig.ts
+++ b/src/scripts/OSFramework/OSUI/Pattern/Gallery/GalleryConfig.ts
@@ -1,7 +1,7 @@
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 namespace OSFramework.OSUI.Patterns.Gallery {
 	/**
-	 * Defines the interface for OutSystemsUI Gallery Pattern
+	 * Class that represents the custom configurations received by the Gallery.
 	 *
 	 * @export
 	 * @class GalleryConfig

--- a/src/scripts/OSFramework/OSUI/Pattern/InlineSvg/InlineSvg.ts
+++ b/src/scripts/OSFramework/OSUI/Pattern/InlineSvg/InlineSvg.ts
@@ -81,7 +81,7 @@ namespace OSFramework.OSUI.Patterns.InlineSvg {
 		}
 
 		/**
-		 * Builds the pattern.
+		 * Method to build the InlineSVG
 		 *
 		 * @memberof OSFramework.Patterns.InlineSvg.InlineSvg
 		 */

--- a/src/scripts/OSFramework/OSUI/Pattern/InlineSvg/InlineSvgConfig.ts
+++ b/src/scripts/OSFramework/OSUI/Pattern/InlineSvg/InlineSvgConfig.ts
@@ -20,7 +20,7 @@ namespace OSFramework.OSUI.Patterns.InlineSvg {
 
 			switch (key) {
 				case Enum.Properties.SVGCode:
-					validatedValue = super.validateString(value as string, '');
+					validatedValue = super.validateString(value as string, OSFramework.OSUI.Constants.EmptyString);
 					break;
 				default:
 					validatedValue = super.validateDefault(key, value);

--- a/src/scripts/OSFramework/OSUI/Pattern/Notification/INotification.ts
+++ b/src/scripts/OSFramework/OSUI/Pattern/Notification/INotification.ts
@@ -2,10 +2,24 @@
 namespace OSFramework.OSUI.Patterns.Notification {
 	/**
 	 * Defines the interface for OutSystemsUI Notification Pattern
+	 *
+	 * @export
+	 * @interface INotification
+	 * @extends {Interface.IPattern}
 	 */
 	export interface INotification extends Interface.IPattern {
+		/**
+		 * Method to hide the notification
+		 *
+		 * @memberof INotification
+		 */
 		hide(): void;
-		registerCallback(eventName: string, callback: GlobalCallbacks.OSGeneric): void;
+
+		/**
+		 * Method to show the notification
+		 *
+		 * @memberof INotification
+		 */
 		show(): void;
 	}
 }

--- a/src/scripts/OSFramework/OSUI/Pattern/Notification/Notification.ts
+++ b/src/scripts/OSFramework/OSUI/Pattern/Notification/Notification.ts
@@ -38,7 +38,12 @@ namespace OSFramework.OSUI.Patterns.Notification {
 			this._isOpen = this.configs.StartsOpen;
 		}
 
-		// Close Notification after wait the time defined
+		/**
+		 * Method to close Notification after wait the time defined
+		 *
+		 * @private
+		 * @memberof Notification
+		 */
 		private _autoCloseNotification(): void {
 			setTimeout(() => {
 				if (this._isOpen) {
@@ -47,14 +52,25 @@ namespace OSFramework.OSUI.Patterns.Notification {
 			}, this.configs.CloseAfterTime);
 		}
 
-		// Trigger the notification at toggle behaviour
+		/**
+		 * Method to trigger the notification at toggle behaviour
+		 *
+		 * @private
+		 * @param {MouseEvent} e
+		 * @memberof Notification
+		 */
 		private _clickCallback(e: MouseEvent): void {
 			e.stopPropagation();
 			e.preventDefault();
 			this.hide();
 		}
 
-		// Add Focus Trap to Pattern
+		/**
+		 * Method to add Focus Trap to Pattern
+		 *
+		 * @private
+		 * @memberof Notification
+		 */
 		private _handleFocusTrap(): void {
 			const opts = {
 				focusTargetElement: this._parentSelf,
@@ -63,7 +79,12 @@ namespace OSFramework.OSUI.Patterns.Notification {
 			this._focusTrapInstance = new Behaviors.FocusTrap(opts);
 		}
 
-		// Method to handle the creation of the GestureEvents
+		/**
+		 * Method to handle the creation of the GestureEvents
+		 *
+		 * @private
+		 * @memberof Notification
+		 */
 		private _handleGestureEvents(): void {
 			if (Helper.DeviceInfo.IsNative) {
 				// Create and save gesture event instance. Created here and not on constructor,
@@ -80,7 +101,12 @@ namespace OSFramework.OSUI.Patterns.Notification {
 			}
 		}
 
-		// Hide Notification
+		/**
+		 * Method to hide Notification
+		 *
+		 * @private
+		 * @memberof Notification
+		 */
 		private _hideNotification(): void {
 			this._isOpen = false;
 
@@ -108,7 +134,13 @@ namespace OSFramework.OSUI.Patterns.Notification {
 			}
 		}
 
-		// Call methods to open or close, based ok e.key and behavior applied
+		/**
+		 * Method to call open or close, based ok e.key and behavior applied
+		 *
+		 * @private
+		 * @param {KeyboardEvent} e
+		 * @memberof Notification
+		 */
 		private _keypressCallback(e: KeyboardEvent): void {
 			const isEscapedPressed = e.key === GlobalEnum.Keycodes.Escape;
 
@@ -118,13 +150,23 @@ namespace OSFramework.OSUI.Patterns.Notification {
 			}
 		}
 
-		// Remove all the assigned Events
+		/**
+		 * Method to remove all the assigned events
+		 *
+		 * @private
+		 * @memberof Notification
+		 */
 		private _removeEvents(): void {
 			this.selfElement.removeEventListener(this._eventType, this._eventOnClick);
 			this.selfElement.removeEventListener(GlobalEnum.HTMLEvent.keyDown, this._eventOnKeypress);
 		}
 
-		// Show Notification
+		/**
+		 * Method to show Notification
+		 *
+		 * @private
+		 * @memberof Notification
+		 */
 		private _showNotification(): void {
 			this._focusableActiveElement = document.activeElement as HTMLElement;
 			this._isOpen = true;
@@ -155,12 +197,23 @@ namespace OSFramework.OSUI.Patterns.Notification {
 			}
 		}
 
-		// Method that triggers the OnToggle event
+		/**
+		 * Method to trigger the OnToggle event
+		 *
+		 * @private
+		 * @param {boolean} isOpen
+		 * @memberof Notification
+		 */
 		private _triggerOnToggleEvent(isOpen: boolean): void {
 			this.triggerPlatformEventCallback(this._platformEventOnToggle, isOpen);
 		}
 
-		// Set the cssClasses that should be assigned to the element on it's initialization
+		/**
+		 * Method to set the cssClasses that should be assigned to the element on it's initialization
+		 *
+		 * @private
+		 * @memberof Notification
+		 */
 		private _updateA11yProperties(): void {
 			Helper.Dom.Attribute.Set(
 				this.selfElement,
@@ -180,7 +233,13 @@ namespace OSFramework.OSUI.Patterns.Notification {
 			Helper.A11Y.SetElementsTabIndex(this._isOpen, this._focusTrapInstance.focusableElements);
 		}
 
-		// Update time to apply on AutoClose
+		/**
+		 * Method to update time to apply on AutoClose
+		 *
+		 * @private
+		 * @param {number} value
+		 * @memberof Notification
+		 */
 		private _updateCloseAfterTime(value: number): void {
 			this.configs.CloseAfterTime = value;
 			if (this._isOpen) {
@@ -188,7 +247,13 @@ namespace OSFramework.OSUI.Patterns.Notification {
 			}
 		}
 
-		// Update time to apply on AutoClose
+		/**
+		 * Method to update time to apply on AutoClose
+		 *
+		 * @private
+		 * @param {boolean} value
+		 * @memberof Notification
+		 */
 		private _updateInteractToClose(value: boolean): void {
 			if (this.configs.InteractToClose !== value) {
 				this.configs.InteractToClose = value;
@@ -202,7 +267,13 @@ namespace OSFramework.OSUI.Patterns.Notification {
 			}
 		}
 
-		// Update position
+		/**
+		 * Method to update position
+		 *
+		 * @private
+		 * @param {string} position
+		 * @memberof Notification
+		 */
 		private _updatePosition(position: string): void {
 			// Only change classes if are different
 			if (this.configs.Position !== position) {
@@ -215,7 +286,13 @@ namespace OSFramework.OSUI.Patterns.Notification {
 			}
 		}
 
-		// Update width
+		/**
+		 * Method to update width
+		 *
+		 * @private
+		 * @param {string} width
+		 * @memberof Notification
+		 */
 		private _updateWidth(width: string): void {
 			this.configs.Width = width;
 			if (width !== '') {
@@ -226,7 +303,7 @@ namespace OSFramework.OSUI.Patterns.Notification {
 		}
 
 		/**
-		 * Sets the A11Y properties when the pattern is built.
+		 * Method to set the A11Y properties when the pattern is built.
 		 *
 		 * @protected
 		 * @memberof OSFramework.Patterns.Notification.Notification
@@ -243,7 +320,7 @@ namespace OSFramework.OSUI.Patterns.Notification {
 		}
 
 		/**
-		 *  Sets the callbacks to be used in the pattern.
+		 *  Method to set the callbacks to be used in the pattern.
 		 *
 		 * @protected
 		 * @memberof OSFramework.Patterns.Notification.Notification
@@ -254,7 +331,7 @@ namespace OSFramework.OSUI.Patterns.Notification {
 		}
 
 		/**
-		 * Set the html references that will be used to manage the cssClasses and atribute properties
+		 * Method to set the html references that will be used to manage the cssClasses and atribute properties
 		 *
 		 * @protected
 		 * @memberof OSFramework.Patterns.Notification.Notification
@@ -264,7 +341,7 @@ namespace OSFramework.OSUI.Patterns.Notification {
 		}
 
 		/**
-		 * Set the cssClasses that should be assigned to the element on it's initialization
+		 * Method to set the cssClasses that should be assigned to the element on it's initialization
 		 *
 		 * @protected
 		 * @memberof OSFramework.Patterns.Notification.Notification
@@ -309,7 +386,7 @@ namespace OSFramework.OSUI.Patterns.Notification {
 		}
 
 		/**
-		 * Reassign the HTML elements to undefined, preventing memory leaks
+		 * Method to reassign the HTML elements to undefined, preventing memory leaks
 		 *
 		 * @protected
 		 * @memberof OSFramework.Patterns.Notification.Notification
@@ -339,7 +416,7 @@ namespace OSFramework.OSUI.Patterns.Notification {
 		}
 
 		/**
-		 * Update value when a parameters changed occurs
+		 * Method to update value when a parameters changed occurs
 		 *
 		 * @param {string} propertyName
 		 * @param {unknown} propertyValue
@@ -383,7 +460,7 @@ namespace OSFramework.OSUI.Patterns.Notification {
 		}
 
 		/**
-		 * Destroy the Notification
+		 * Method to destroy the Notification
 		 *
 		 * @memberof OSFramework.Patterns.Notification.Notification
 		 */
@@ -409,7 +486,7 @@ namespace OSFramework.OSUI.Patterns.Notification {
 		}
 
 		/**
-		 * Public method to hide the notification, if it's visible.
+		 * Method to hide the notification, if it's visible.
 		 *
 		 * @memberof OSFramework.Patterns.Notification.Notification
 		 */
@@ -420,7 +497,7 @@ namespace OSFramework.OSUI.Patterns.Notification {
 		}
 
 		/**
-		 * Handle the platform swipe bottom gesture
+		 * Method to handle the platform swipe bottom gesture
 		 *
 		 * @memberof OSFramework.Patterns.Notification.Notification
 		 */
@@ -436,7 +513,7 @@ namespace OSFramework.OSUI.Patterns.Notification {
 		}
 
 		/**
-		 * Handle the platform swipe left gesture
+		 * Method to handle the platform swipe left gesture
 		 *
 		 * @memberof OSFramework.Patterns.Notification.Notification
 		 */
@@ -451,7 +528,7 @@ namespace OSFramework.OSUI.Patterns.Notification {
 		}
 
 		/**
-		 * Handle the platform swipe right gesture
+		 * Method to handle the platform swipe right gesture
 		 *
 		 * @memberof OSFramework.Patterns.Notification.Notification
 		 */
@@ -466,7 +543,7 @@ namespace OSFramework.OSUI.Patterns.Notification {
 		}
 
 		/**
-		 * Handle the platform swipe top gesture
+		 * Method to handle the platform swipe top gesture
 		 *
 		 * @memberof OSFramework.Patterns.Notification.Notification
 		 */
@@ -475,7 +552,7 @@ namespace OSFramework.OSUI.Patterns.Notification {
 		}
 
 		/**
-		 * Method used to register the provider callback
+		 * Method to register the provider callback
 		 *
 		 * @param {string} eventName
 		 * @param {GlobalCallbacks.OSGeneric} callback
@@ -495,7 +572,7 @@ namespace OSFramework.OSUI.Patterns.Notification {
 		}
 
 		/**
-		 * Removes the gesture events to open/close the Notification on Mobile Apps
+		 * Method to remove the gesture events to open/close the Notification on Mobile Apps
 		 *
 		 * @memberof OSFramework.Patterns.Notification.Notification
 		 */
@@ -510,7 +587,7 @@ namespace OSFramework.OSUI.Patterns.Notification {
 		}
 
 		/**
-		 * Sets the gesture events to open/close the Notification on Native Apps
+		 * Method to set the gesture events to open/close the Notification on Native Apps
 		 *
 		 * @protected
 		 * @memberof OSFramework.Patterns.Notification.Notification
@@ -531,7 +608,7 @@ namespace OSFramework.OSUI.Patterns.Notification {
 		}
 
 		/**
-		 * Public method to show the notification, if it's closed.
+		 * Method to show the notification, if it's closed.
 		 *
 		 * @memberof OSFramework.Patterns.Notification.Notification
 		 */
@@ -542,7 +619,7 @@ namespace OSFramework.OSUI.Patterns.Notification {
 		}
 
 		/**
-		 * Get Gesture Events Instance
+		 * Method to get Gesture Events Instance
 		 *
 		 * @readonly
 		 * @type {Event.GestureEvent.SwipeEvent}
@@ -553,7 +630,7 @@ namespace OSFramework.OSUI.Patterns.Notification {
 		}
 
 		/**
-		 * Get if has gesture events
+		 * Method to check if gesture events is applied
 		 *
 		 * @readonly
 		 * @type {boolean}

--- a/src/scripts/OSFramework/OSUI/Pattern/Notification/Notification.ts
+++ b/src/scripts/OSFramework/OSUI/Pattern/Notification/Notification.ts
@@ -396,6 +396,11 @@ namespace OSFramework.OSUI.Patterns.Notification {
 			this._platformEventOnToggle = undefined;
 		}
 
+		/**
+		 * Method to build the Notification
+		 *
+		 * @memberof Notification
+		 */
 		public build(): void {
 			super.build();
 

--- a/src/scripts/OSFramework/OSUI/Pattern/Notification/NotificationConfig.ts
+++ b/src/scripts/OSFramework/OSUI/Pattern/Notification/NotificationConfig.ts
@@ -14,5 +14,61 @@ namespace OSFramework.OSUI.Patterns.Notification {
 		public Position: string;
 		public StartsOpen: boolean;
 		public Width: string;
+
+		/**
+		 * Method that will check if a given property (key) can be changed/updated!
+		 *
+		 * @param isBuilt True when pattern has been built!
+		 * @param key property name
+		 * @returns {boolean} boolean
+		 * @memberof  OSFramework.Patterns.Notification.NotificationConfig
+		 */
+		public validateCanChange(isBuilt: boolean, key: string): boolean {
+			if (isBuilt) {
+				return key !== Enum.Properties.StartsOpen;
+			}
+			return true;
+		}
+
+		/**
+		 * Method that will check if a given property (key) value is the type expected!
+		 *
+		 * @param key property name
+		 * @param value value to be check
+		 * @returns {unknown} value
+		 * @memberof  OSFramework.Patterns.Notification.NotificationConfig
+		 */
+		public validateDefault(key: string, value: unknown): unknown {
+			let validatedValue = undefined;
+
+			switch (key) {
+				case Enum.Properties.InteractToClose:
+					validatedValue = this.validateBoolean(value as boolean, true);
+					break;
+
+				case Enum.Properties.NeedsSwipes:
+				case Enum.Properties.StartsOpen:
+					validatedValue = this.validateBoolean(value as boolean, false);
+					break;
+
+				case Enum.Properties.Position:
+					validatedValue = this.validateString(value as string, Enum.Defaults.DefaultPosition);
+					break;
+
+				case Enum.Properties.Width:
+					validatedValue = this.validateString(value as string, Enum.Defaults.DefaultWidth);
+					break;
+
+				case Enum.Properties.CloseAfterTime:
+					validatedValue = this.validateNumber(value as number, undefined);
+					break;
+
+				default:
+					validatedValue = super.validateDefault(key, value);
+					break;
+			}
+
+			return validatedValue;
+		}
 	}
 }

--- a/src/scripts/OSFramework/OSUI/Pattern/Notification/NotificationConfig.ts
+++ b/src/scripts/OSFramework/OSUI/Pattern/Notification/NotificationConfig.ts
@@ -1,5 +1,12 @@
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 namespace OSFramework.OSUI.Patterns.Notification {
+	/**
+	 * Class that represents the custom configurations received by the Notification.
+	 *
+	 * @export
+	 * @class NotificationConfig
+	 * @extends {AbstractConfiguration}
+	 */
 	export class NotificationConfig extends AbstractConfiguration {
 		public CloseAfterTime: number;
 		public InteractToClose: boolean;
@@ -7,61 +14,5 @@ namespace OSFramework.OSUI.Patterns.Notification {
 		public Position: string;
 		public StartsOpen: boolean;
 		public Width: string;
-
-		/**
-		 * Method that will check if a given property (key) can be changed/updated!
-		 *
-		 * @param isBuilt True when pattern has been built!
-		 * @param key property name
-		 * @returns {boolean} boolean
-		 * @memberof  OSFramework.Patterns.Notification.NotificationConfig
-		 */
-		public validateCanChange(isBuilt: boolean, key: string): boolean {
-			if (isBuilt) {
-				return key !== Enum.Properties.StartsOpen;
-			}
-			return true;
-		}
-
-		/**
-		 * Method that will check if a given property (key) value is the type expected!
-		 *
-		 * @param key property name
-		 * @param value value to be check
-		 * @returns {unknown} value
-		 * @memberof  OSFramework.Patterns.Notification.NotificationConfig
-		 */
-		public validateDefault(key: string, value: unknown): unknown {
-			let validatedValue = undefined;
-
-			switch (key) {
-				case Enum.Properties.InteractToClose:
-					validatedValue = this.validateBoolean(value as boolean, true);
-					break;
-
-				case Enum.Properties.NeedsSwipes:
-				case Enum.Properties.StartsOpen:
-					validatedValue = this.validateBoolean(value as boolean, false);
-					break;
-
-				case Enum.Properties.Position:
-					validatedValue = this.validateString(value as string, Enum.Defaults.DefaultPosition);
-					break;
-
-				case Enum.Properties.Width:
-					validatedValue = this.validateString(value as string, Enum.Defaults.DefaultWidth);
-					break;
-
-				case Enum.Properties.CloseAfterTime:
-					validatedValue = this.validateNumber(value as number, undefined);
-					break;
-
-				default:
-					validatedValue = super.validateDefault(key, value);
-					break;
-			}
-
-			return validatedValue;
-		}
 	}
 }

--- a/src/scripts/OSFramework/OSUI/Pattern/OverflowMenu/OverflowMenu.ts
+++ b/src/scripts/OSFramework/OSUI/Pattern/OverflowMenu/OverflowMenu.ts
@@ -191,7 +191,7 @@ namespace OSFramework.OSUI.Patterns.OverflowMenu {
 		}
 
 		/**
-		 * Method to build the Pattern
+		 * Method to build the OverflowMenu
 		 *
 		 * @memberof OverflowMenu
 		 */

--- a/src/scripts/OSFramework/OSUI/Pattern/Progress/Bar/ProgressBar.ts
+++ b/src/scripts/OSFramework/OSUI/Pattern/Progress/Bar/ProgressBar.ts
@@ -155,6 +155,11 @@ namespace OSFramework.OSUI.Patterns.Progress.Bar {
 			super.unsetHtmlElements();
 		}
 
+		/**
+		 * Method to build the ProgressBar
+		 *
+		 * @memberof Bar
+		 */
 		public build(): void {
 			super.build();
 

--- a/src/scripts/OSFramework/OSUI/Pattern/Progress/Circle/ProgressCircle.ts
+++ b/src/scripts/OSFramework/OSUI/Pattern/Progress/Circle/ProgressCircle.ts
@@ -376,6 +376,11 @@ namespace OSFramework.OSUI.Patterns.Progress.Circle {
 			);
 		}
 
+		/**
+		 * Method to build the ProgressCircle
+		 *
+		 * @memberof Circle
+		 */
 		public build(): void {
 			super.build();
 

--- a/src/scripts/OSFramework/OSUI/Pattern/Rating/Enum.ts
+++ b/src/scripts/OSFramework/OSUI/Pattern/Rating/Enum.ts
@@ -15,9 +15,6 @@ namespace OSFramework.OSUI.Patterns.Rating.Enum {
 
 	/**
 	 * Callbacks eventName
-	 *
-	 * @export
-	 * @enum {number}
 	 */
 	export enum Events {
 		OnSelected = 'OnSelected',

--- a/src/scripts/OSFramework/OSUI/Pattern/Rating/IRating.ts
+++ b/src/scripts/OSFramework/OSUI/Pattern/Rating/IRating.ts
@@ -2,6 +2,10 @@
 namespace OSFramework.OSUI.Patterns.Rating {
 	/**
 	 * Defines the interface for OutSystemsUI Rating Pattern
+	 *
+	 * @export
+	 * @interface IRating
+	 * @extends {Interface.IPattern}
 	 */
 	export interface IRating extends Interface.IPattern {}
 }

--- a/src/scripts/OSFramework/OSUI/Pattern/Rating/Rating.ts
+++ b/src/scripts/OSFramework/OSUI/Pattern/Rating/Rating.ts
@@ -29,7 +29,12 @@ namespace OSFramework.OSUI.Patterns.Rating {
 			super(uniqueId, new RatingConfig(configs));
 		}
 
-		// Medthod that will iterate on the RatingScale, to crate an item for each one
+		/**
+		 * Method that will iterate on the RatingScale, to crate an item for each one
+		 *
+		 * @private
+		 * @memberof Rating
+		 */
 		private _createItems(): void {
 			// Check if the the we should limit the amount of items
 			if (this.configs.RatingScale > Enum.Properties.MaxRatingScale) {
@@ -47,12 +52,26 @@ namespace OSFramework.OSUI.Patterns.Rating {
 			}
 		}
 
-		// Get the rating decimal value
+		/**
+		 * Method to get the rating decimal value
+		 *
+		 * @private
+		 * @param {number} value
+		 * @return {*}  {number}
+		 * @memberof Rating
+		 */
 		private _getDecimalValue(value: number): number {
 			return Math.round((value - Math.floor(value)) * 100) / 100;
 		}
 
-		// Get if the valie is-half
+		/**
+		 * Method to get if the valie is-half
+		 *
+		 * @private
+		 * @param {number} value
+		 * @return {*}  {boolean}
+		 * @memberof Rating
+		 */
 		private _getIsHalfValue(value: number): boolean {
 			const decimalValue = this._getDecimalValue(value);
 			// If bigger than 0.3 and lower than 0.7 means it should be represented as a half value.
@@ -60,13 +79,24 @@ namespace OSFramework.OSUI.Patterns.Rating {
 			return !!(decimalValue >= 0.3 && decimalValue <= 0.7);
 		}
 
-		// Get the rating value
+		/**
+		 * Method to get the rating value
+		 *
+		 * @private
+		 * @return {*}  {number}
+		 * @memberof Rating
+		 */
 		private _getValue(): number {
 			const inputChecked = Helper.Dom.TagSelector(this.selfElement, 'input:checked') as HTMLInputElement;
 			return parseInt(inputChecked.value);
 		}
 
-		// Method that handles the placeholders content storage and DOM lifecycle
+		/**
+		 * Method that handles the placeholders content storage and DOM lifecycle
+		 *
+		 * @private
+		 * @memberof Rating
+		 */
 		private _handlePlaceholders(): void {
 			// Store the placholders content to cloned after
 			this._clonedPlaceholders = this._ratingIconStatesElem.innerHTML;
@@ -75,7 +105,12 @@ namespace OSFramework.OSUI.Patterns.Rating {
 			this._ratingIconStatesElem.remove();
 		}
 
-		// Method to manage the click event
+		/**
+		 * Method to manage the click event
+		 *
+		 * @private
+		 * @memberof Rating
+		 */
 		private _manageRatingEvent(): void {
 			// Check if a event was already added
 			if (this._ratingHasEventAdded) {
@@ -92,7 +127,13 @@ namespace OSFramework.OSUI.Patterns.Rating {
 			}
 		}
 
-		// Method that handles the click event and set the new value, by checking the input:checked
+		/**
+		 * Method that handles the click event and set the new value, by checking the input:checked
+		 *
+		 * @private
+		 * @param {MouseEvent} e
+		 * @memberof Rating
+		 */
 		private _ratingOnClick(e: MouseEvent): void {
 			const currentTarget = e.target as HTMLElement;
 			// Remove the is-half when clicking, as a click will never result in a half value
@@ -107,7 +148,12 @@ namespace OSFramework.OSUI.Patterns.Rating {
 				this._setValue(true);
 			}
 		}
-		// Method to remove the event listeners
+		/**
+		 * Method to remove the event listeners
+		 *
+		 * @private
+		 * @memberof Rating
+		 */
 		private _removeEvents(): void {
 			// remove event listener if any was added
 			if (this.selfElement && this._ratingHasEventAdded) {
@@ -115,7 +161,13 @@ namespace OSFramework.OSUI.Patterns.Rating {
 			}
 		}
 
-		// Method called on createItems() to render the correct HTML structure for each item
+		/**
+		 * Method called on createItems() to render the correct HTML structure for each item
+		 *
+		 * @private
+		 * @param {number} index
+		 * @memberof Rating
+		 */
 		private _renderItem(index: number): void {
 			// If first input, whihc is hidden, than also hide the label
 			const hideLabelClass: string = index === 0 ? Enum.CssClass.WCAGHideText : '';
@@ -132,7 +184,13 @@ namespace OSFramework.OSUI.Patterns.Rating {
 			this._ratingFieldsetElem.innerHTML += input + label;
 		}
 
-		// Toggle fieldset disbaled status
+		/**
+		 * Method to toggle fieldset disbaled status
+		 *
+		 * @private
+		 * @param {boolean} isDisabled
+		 * @memberof Rating
+		 */
 		private _setFieldsetDisabledStatus(isDisabled: boolean): void {
 			const isFieldsetDisabled = Helper.Dom.Attribute.Get(
 				this._ratingFieldsetElem,
@@ -146,7 +204,12 @@ namespace OSFramework.OSUI.Patterns.Rating {
 			}
 		}
 
-		// Set the cssClasses that should be assigned to the element on it's initialization
+		/**
+		 * Method to set the cssClasses that should be assigned to the element on it's initialization
+		 *
+		 * @private
+		 * @memberof Rating
+		 */
 		private _setInitialCssClasses(): void {
 			// Set IsHalf class
 			if (this._isHalfValue) {
@@ -164,21 +227,37 @@ namespace OSFramework.OSUI.Patterns.Rating {
 			}
 		}
 
-		// Set the initial and local properties values
+		/**
+		 * Method to set the initial and local properties values
+		 *
+		 * @private
+		 * @memberof Rating
+		 */
 		private _setInitialPropertiesValues(): void {
 			this._disabled = !this.configs.IsEdit;
 			this._ratingInputName = 'rating-' + this.uniqueId;
 			this._ratingHasEventAdded = false;
 		}
 
-		// Set disabled status
+		/**
+		 * Method to set disabled status
+		 *
+		 * @private
+		 * @param {boolean} isDisabled
+		 * @memberof Rating
+		 */
 		private _setIsDisabled(isDisabled: boolean): void {
 			this._setFieldsetDisabledStatus(isDisabled);
 
 			this._disabled = isDisabled;
 		}
 
-		// Set the IsEdit option
+		/**
+		 * Method to set the IsEdit option
+		 *
+		 * @private
+		 * @memberof Rating
+		 */
 		private _setIsEdit(): void {
 			// Set the fieldset and input disabled attribute status
 			this._setIsDisabled(!this.configs.IsEdit);
@@ -192,7 +271,12 @@ namespace OSFramework.OSUI.Patterns.Rating {
 			this._manageRatingEvent();
 		}
 
-		// Set a RatingScale - The amout of stars pattern will have
+		/**
+		 * Method to set a RatingScale - The amout of stars pattern will have
+		 *
+		 * @private
+		 * @memberof Rating
+		 */
 		private _setScale(): void {
 			// Clean (if already exist) old Stars inside pattern
 			this._ratingFieldsetElem.innerHTML = '';
@@ -202,7 +286,13 @@ namespace OSFramework.OSUI.Patterns.Rating {
 			this._setValue();
 		}
 
-		// Set the Rating Size
+		/**
+		 * Method to set the Rating Size
+		 *
+		 * @private
+		 * @param {string} oldSize
+		 * @memberof Rating
+		 */
 		private _setSize(oldSize: string): void {
 			// Reset current class
 			if (oldSize !== '') {
@@ -215,7 +305,14 @@ namespace OSFramework.OSUI.Patterns.Rating {
 			}
 		}
 
-		// Set a rating value
+		/**
+		 * Method to set a rating value
+		 *
+		 * @private
+		 * @param {boolean} [triggerEvent=false]
+		 * @return {*}  {void}
+		 * @memberof Rating
+		 */
 		private _setValue(triggerEvent = false): void {
 			// Check if passed value is decimal
 			this._decimalValue = this._getDecimalValue(this.configs.RatingValue);
@@ -276,7 +373,13 @@ namespace OSFramework.OSUI.Patterns.Rating {
 			}
 		}
 
-		// Method that triggers the OnSelect event
+		/**
+		 * Method that triggers the OnSelect event
+		 *
+		 * @private
+		 * @param {number} value
+		 * @memberof Rating
+		 */
 		private _triggerOnSelectEvent(value: number): void {
 			if (this._platformEventOnSelect !== undefined) {
 				this.triggerPlatformEventCallback(this._platformEventOnSelect, value);
@@ -294,7 +397,7 @@ namespace OSFramework.OSUI.Patterns.Rating {
 		}
 
 		/**
-		 * Set the events
+		 * Method to set the events
 		 *
 		 * @protected
 		 * @memberof OSFramework.Patterns.Rating.Rating
@@ -304,7 +407,7 @@ namespace OSFramework.OSUI.Patterns.Rating {
 		}
 
 		/**
-		 * Set the html references that will be used to manage the cssClasses and atribute properties
+		 * Method to set the html references that will be used to manage the cssClasses and atribute properties
 		 *
 		 * @protected
 		 * @memberof OSFramework.Patterns.Rating.Rating
@@ -325,7 +428,7 @@ namespace OSFramework.OSUI.Patterns.Rating {
 		}
 
 		/**
-		 * UnSet the HTML elements
+		 * Method to unset the HTML elements
 		 *
 		 * @protected
 		 * @memberof OSFramework.Patterns.Rating.Rating
@@ -339,7 +442,7 @@ namespace OSFramework.OSUI.Patterns.Rating {
 		}
 
 		/**
-		 * Building Rating
+		 * Method to build the pattern.
 		 *
 		 * @memberof OSFramework.Patterns.Rating.Rating
 		 */
@@ -368,7 +471,7 @@ namespace OSFramework.OSUI.Patterns.Rating {
 		}
 
 		/**
-		 * Update value when a parameters changed occurs
+		 * Method to update value when a parameters changed occurs
 		 *
 		 * @param {string} propertyName
 		 * @param {*} propertyValue
@@ -403,7 +506,7 @@ namespace OSFramework.OSUI.Patterns.Rating {
 		}
 
 		/**
-		 * Destroy the Rating pattern
+		 * Method to destroy the Rating pattern
 		 *
 		 * @memberof OSFramework.Patterns.Rating.Rating
 		 */
@@ -417,7 +520,7 @@ namespace OSFramework.OSUI.Patterns.Rating {
 		}
 
 		/**
-		 * Register a given callback event handler.
+		 * Method to register a given callback event handler.
 		 *
 		 * @param {string} eventName
 		 * @param {GlobalCallbacks.OSGeneric} callback

--- a/src/scripts/OSFramework/OSUI/Pattern/Rating/Rating.ts
+++ b/src/scripts/OSFramework/OSUI/Pattern/Rating/Rating.ts
@@ -442,7 +442,7 @@ namespace OSFramework.OSUI.Patterns.Rating {
 		}
 
 		/**
-		 * Method to build the pattern.
+		 * Method to build the Rating
 		 *
 		 * @memberof OSFramework.Patterns.Rating.Rating
 		 */

--- a/src/scripts/OSFramework/OSUI/Pattern/Rating/RatingConfig.ts
+++ b/src/scripts/OSFramework/OSUI/Pattern/Rating/RatingConfig.ts
@@ -1,5 +1,12 @@
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 namespace OSFramework.OSUI.Patterns.Rating {
+	/**
+	 * Class that represents the custom configurations received by the Rating.
+	 *
+	 * @export
+	 * @class RatingConfig
+	 * @extends {AbstractConfiguration}
+	 */
 	export class RatingConfig extends AbstractConfiguration {
 		public IsEdit: boolean;
 		public RatingScale: number;

--- a/src/scripts/OSFramework/OSUI/Pattern/SectionIndex/SectionIndex.ts
+++ b/src/scripts/OSFramework/OSUI/Pattern/SectionIndex/SectionIndex.ts
@@ -250,7 +250,7 @@ namespace OSFramework.OSUI.Patterns.SectionIndex {
 		}
 
 		/**
-		 *  Builds the SectionIndex.
+		 * Method to build the SectionIndex.
 		 *
 		 * @memberof OSFramework.Patterns.SectionIndex.SectionIndex
 		 */

--- a/src/scripts/OSFramework/OSUI/Pattern/SectionIndexItem/Enum.ts
+++ b/src/scripts/OSFramework/OSUI/Pattern/SectionIndexItem/Enum.ts
@@ -7,6 +7,9 @@ namespace OSFramework.OSUI.Patterns.SectionIndexItem.Enum {
 		ScrollToWidgetId = 'ScrollToWidgetId',
 	}
 
+	/**
+	 * SectionIndexItem Enum DataTypes
+	 */
 	export enum DataTypes {
 		dataItem = 'data-item',
 	}

--- a/src/scripts/OSFramework/OSUI/Pattern/SectionIndexItem/ISectionIndexItem.ts
+++ b/src/scripts/OSFramework/OSUI/Pattern/SectionIndexItem/ISectionIndexItem.ts
@@ -8,11 +8,42 @@ namespace OSFramework.OSUI.Patterns.SectionIndexItem {
 	 * @extends {Interface.IChild}
 	 */
 	export interface ISectionIndexItem extends Interface.IChild {
-		get IsSelected(): boolean;
-		get TargetElement(): HTMLElement;
-		get TargetElementOffset(): OffsetValues;
+		/**
+		 * Readable property to get the active state of the element
+		 *
+		 * @type {boolean}
+		 * @memberof ISectionIndexItem
+		 */
+		IsSelected: boolean;
 
+		/**
+		 * Readable property to get targetElement object
+		 *
+		 * @type {HTMLElement}
+		 * @memberof ISectionIndexItem
+		 */
+		TargetElement: HTMLElement;
+
+		/**
+		 * Readable property to get targetElementOffset info
+		 *
+		 * @type {OffsetValues}
+		 * @memberof ISectionIndexItem
+		 */
+		TargetElementOffset: OffsetValues;
+
+		/**
+		 * Method to add the active state
+		 *
+		 * @memberof ISectionIndexItem
+		 */
 		setIsActive(): void;
+
+		/**
+		 * Method to remove the active state
+		 *
+		 * @memberof ISectionIndexItem
+		 */
 		unsetIsActive(): void;
 	}
 }

--- a/src/scripts/OSFramework/OSUI/Pattern/SectionIndexItem/SectionIndexItem.ts
+++ b/src/scripts/OSFramework/OSUI/Pattern/SectionIndexItem/SectionIndexItem.ts
@@ -284,7 +284,7 @@ namespace OSFramework.OSUI.Patterns.SectionIndexItem {
 		}
 
 		/**
-		 *  Builds the SectionIndexItem.
+		 * Method to build the SectionIndexItem.
 		 *
 		 * @memberof OSFramework.Patterns.SectionIndexItem.SectionIndexItem
 		 */

--- a/src/scripts/OSFramework/OSUI/Pattern/SectionIndexItem/SectionIndexItem.ts
+++ b/src/scripts/OSFramework/OSUI/Pattern/SectionIndexItem/SectionIndexItem.ts
@@ -38,7 +38,12 @@ namespace OSFramework.OSUI.Patterns.SectionIndexItem {
 			super(uniqueId, new SectionIndexItemConfig(configs));
 		}
 
-		// spies the scroll to know if the target element is visible and sets the item as active
+		/**
+		 * Method to check the scroll to know if the target element is visible and sets the item as active
+		 *
+		 * @private
+		 * @memberof SectionIndexItem
+		 */
 		private _onBodyScroll(): void {
 			// Set target element offset info!
 			this._setTargetOffsetInfo();
@@ -67,7 +72,13 @@ namespace OSFramework.OSUI.Patterns.SectionIndexItem {
 			}
 		}
 
-		// A11y keyboard navigation
+		/**
+		 * Method to set the A11y keyboard navigation
+		 *
+		 * @private
+		 * @param {KeyboardEvent} event
+		 * @memberof SectionIndexItem
+		 */
 		private _onKeyboardPressed(event: KeyboardEvent): void {
 			event.preventDefault();
 			event.stopPropagation();
@@ -82,7 +93,13 @@ namespace OSFramework.OSUI.Patterns.SectionIndexItem {
 			}
 		}
 
-		// Method to handle the click event
+		/**
+		 * Method to handle the click event
+		 *
+		 * @private
+		 * @param {Event} event
+		 * @memberof SectionIndexItem
+		 */
 		private _onSelected(event: Event): void {
 			event.preventDefault();
 			event.stopPropagation();
@@ -94,7 +111,12 @@ namespace OSFramework.OSUI.Patterns.SectionIndexItem {
 			this.notifyParent(SectionIndex.Enum.ChildNotifyActionType.Click);
 		}
 
-		// Remove Pattern Events
+		/**
+		 * Method to remove Pattern events
+		 *
+		 * @private
+		 * @memberof SectionIndexItem
+		 */
 		private _removeEvents(): void {
 			this.selfElement.removeEventListener(GlobalEnum.HTMLEvent.Click, this._eventOnClick);
 			this.selfElement.removeEventListener(GlobalEnum.HTMLEvent.keyDown, this._eventOnkeyBoardPress);
@@ -104,7 +126,12 @@ namespace OSFramework.OSUI.Patterns.SectionIndexItem {
 			);
 		}
 
-		// Check if header IsFixed
+		/**
+		 * Method to check if header IsFixed
+		 *
+		 * @private
+		 * @memberof SectionIndexItem
+		 */
 		private _setHeaderSize(): void {
 			const header = Helper.Dom.ClassSelector(document.body, GlobalEnum.CssClassElements.Header);
 			this._headerIsFixed = !!Helper.Dom.ClassSelector(document.body, GlobalEnum.CssClassElements.HeaderIsFixed);
@@ -115,12 +142,23 @@ namespace OSFramework.OSUI.Patterns.SectionIndexItem {
 			}
 		}
 
-		// Adds a data attribute to be used in automated tests and to have info on DOM of which element the index is pointing
+		/**
+		 * Method to add a data attribute to be used in automated tests
+		 * and to have info on DOM of which element the index is pointing
+		 *
+		 * @private
+		 * @memberof SectionIndexItem
+		 */
 		private _setLinkAttribute(): void {
 			Helper.Dom.Attribute.Set(this.selfElement, Enum.DataTypes.dataItem, this.configs.ScrollToWidgetId);
 		}
 
-		// Set TargetElement
+		/**
+		 * Method to set the TargetElement
+		 *
+		 * @private
+		 * @memberof SectionIndexItem
+		 */
 		private _setTargetElement(): void {
 			// Check if the element has been already defined!
 			if (this._targetElement === undefined) {
@@ -136,7 +174,12 @@ namespace OSFramework.OSUI.Patterns.SectionIndexItem {
 			}
 		}
 
-		// Set offset info related with TargetElement
+		/**
+		 * Method to set the offset info related with TargetElement
+		 *
+		 * @private
+		 * @memberof SectionIndexItem
+		 */
 		private _setTargetOffsetInfo(): void {
 			// Check if TargetElement has been already defined, otherwise define it!
 			this._setTargetElement();
@@ -149,7 +192,12 @@ namespace OSFramework.OSUI.Patterns.SectionIndexItem {
 				this._targetElement.offsetTop + this._headerHeight + (this.parentObject.contentPaddingTop as number);
 		}
 
-		// Method to set the event listeners
+		/**
+		 * Method to set the event listeners
+		 *
+		 * @private
+		 * @memberof SectionIndexItem
+		 */
 		private _setUpEvents(): void {
 			this.selfElement.addEventListener(GlobalEnum.HTMLEvent.Click, this._eventOnClick);
 			this.selfElement.addEventListener(GlobalEnum.HTMLEvent.keyDown, this._eventOnkeyBoardPress);
@@ -161,7 +209,7 @@ namespace OSFramework.OSUI.Patterns.SectionIndexItem {
 		}
 
 		/**
-		 * Add the Accessibility Attributes values
+		 * Method to add the A11Y attributes values
 		 *
 		 * @protected
 		 * @memberof OSFramework.Patterns.SectionIndexItem.SectionIndexItem

--- a/src/scripts/OSFramework/OSUI/Pattern/SectionIndexItem/SectionIndexItemConfig.ts
+++ b/src/scripts/OSFramework/OSUI/Pattern/SectionIndexItem/SectionIndexItemConfig.ts
@@ -9,20 +9,5 @@ namespace OSFramework.OSUI.Patterns.SectionIndexItem {
 	 */
 	export class SectionIndexItemConfig extends AbstractConfiguration {
 		public ScrollToWidgetId: string;
-
-		/**
-		 * Method that will check if a given property (key) can be changed/updated!
-		 *
-		 * @param isBuilt True when pattern has been built!
-		 * @param key property name
-		 * @returns {boolean} boolean
-		 * @memberof  OSFramework.Patterns.SectionIndexItem.SectionIndexItemConfig
-		 */
-		public validateCanChange(isBuilt: boolean, key: string): boolean {
-			if (isBuilt) {
-				return key !== Enum.Properties.ScrollToWidgetId;
-			}
-			return true;
-		}
 	}
 }

--- a/src/scripts/OSFramework/OSUI/Pattern/SectionIndexItem/SectionIndexItemConfig.ts
+++ b/src/scripts/OSFramework/OSUI/Pattern/SectionIndexItem/SectionIndexItemConfig.ts
@@ -9,5 +9,20 @@ namespace OSFramework.OSUI.Patterns.SectionIndexItem {
 	 */
 	export class SectionIndexItemConfig extends AbstractConfiguration {
 		public ScrollToWidgetId: string;
+
+		/**
+		 * Method that will check if a given property (key) can be changed/updated!
+		 *
+		 * @param isBuilt True when pattern has been built!
+		 * @param key property name
+		 * @returns {boolean} boolean
+		 * @memberof  OSFramework.Patterns.SectionIndexItem.SectionIndexItemConfig
+		 */
+		public validateCanChange(isBuilt: boolean, key: string): boolean {
+			if (isBuilt) {
+				return key !== Enum.Properties.ScrollToWidgetId;
+			}
+			return true;
+		}
 	}
 }

--- a/src/scripts/OSFramework/OSUI/Pattern/Sidebar/Enum.ts
+++ b/src/scripts/OSFramework/OSUI/Pattern/Sidebar/Enum.ts
@@ -11,6 +11,13 @@ namespace OSFramework.OSUI.Patterns.Sidebar.Enum {
 	}
 
 	/**
+	 * Sidebar default properties
+	 */
+	export enum Defaults {
+		Width = '500px',
+	}
+
+	/**
 	 * Sidebar Enum for CSS Classes
 	 */
 	export enum CssClass {

--- a/src/scripts/OSFramework/OSUI/Pattern/Sidebar/Enum.ts
+++ b/src/scripts/OSFramework/OSUI/Pattern/Sidebar/Enum.ts
@@ -2,9 +2,6 @@
 namespace OSFramework.OSUI.Patterns.Sidebar.Enum {
 	/**
 	 * Sidebar Enum properties
-	 *
-	 * @export
-	 * @enum {number}
 	 */
 	export enum Properties {
 		StartsOpen = 'StartsOpen',
@@ -15,9 +12,6 @@ namespace OSFramework.OSUI.Patterns.Sidebar.Enum {
 
 	/**
 	 * Sidebar Enum for CSS Classes
-	 *
-	 * @export
-	 * @enum {number}
 	 */
 	export enum CssClass {
 		Aside = 'osui-sidebar',
@@ -31,16 +25,13 @@ namespace OSFramework.OSUI.Patterns.Sidebar.Enum {
 
 	/**
 	 * Sidebar Enum for CSS Custom Properties
-	 *
-	 * @export
-	 * @enum {number}
 	 */
 	export enum CssProperty {
 		Width = '--sidebar-width',
 	}
 
 	/**
-	 * Sidebar Events
+	 * Sidebar Enum Events
 	 */
 	export enum Events {
 		OnToggle = 'OnToggle',

--- a/src/scripts/OSFramework/OSUI/Pattern/Sidebar/ISidebar.ts
+++ b/src/scripts/OSFramework/OSUI/Pattern/Sidebar/ISidebar.ts
@@ -9,8 +9,20 @@ namespace OSFramework.OSUI.Patterns.Sidebar {
 	 * @extends {Interface.ICallback}
 	 */
 	export interface ISidebar extends Interface.IPattern, Interface.IOpenable {
+		/**
+		 * Method to toggle the click on outside to close the Sidebar.
+		 *
+		 * @param {boolean} closeOnOutSIdeClick
+		 * @memberof ISidebar
+		 */
 		clickOutsideToClose(closeOnOutSIdeClick: boolean): void;
-		registerCallback(eventName: string, callback: GlobalCallbacks.OSGeneric): void;
+
+		/**
+		 * Method that toggle swipes on Sidebar.
+		 *
+		 * @param {boolean} enableSwipe
+		 * @memberof ISidebar
+		 */
 		toggleGestures(enableSwipe: boolean): void;
 	}
 }

--- a/src/scripts/OSFramework/OSUI/Pattern/Sidebar/Sidebar.ts
+++ b/src/scripts/OSFramework/OSUI/Pattern/Sidebar/Sidebar.ts
@@ -459,7 +459,7 @@ namespace OSFramework.OSUI.Patterns.Sidebar {
 		}
 
 		/**
-		 * Method to build the pattern.
+		 * Method to build the Sidebar
 		 *
 		 * @memberof OSFramework.Patterns.Sidebar.Sidebar
 		 */

--- a/src/scripts/OSFramework/OSUI/Pattern/Sidebar/Sidebar.ts
+++ b/src/scripts/OSFramework/OSUI/Pattern/Sidebar/Sidebar.ts
@@ -42,7 +42,12 @@ namespace OSFramework.OSUI.Patterns.Sidebar {
 			this._currentDirectionCssClass = Enum.CssClass.ClassModifier + this.configs.Direction;
 		}
 
-		// Actual method that knows what is to close the sidebar
+		/**
+		 * Method to close Sidebar
+		 *
+		 * @private
+		 * @memberof Sidebar
+		 */
 		private _closeSidebar(): void {
 			this._isOpen = false;
 
@@ -73,7 +78,12 @@ namespace OSFramework.OSUI.Patterns.Sidebar {
 			}
 		}
 
-		// Add Focus Trap to Pattern
+		/**
+		 * Method to add Focus Trap to Pattern
+		 *
+		 * @private
+		 * @memberof Sidebar
+		 */
 		private _handleFocusTrap(): void {
 			const opts = {
 				focusTargetElement: this._parentSelf,
@@ -88,7 +98,12 @@ namespace OSFramework.OSUI.Patterns.Sidebar {
 			}
 		}
 
-		// Method to handle the creation of the GestureEvents
+		/**
+		 * Method to handle the creation of the GestureEvents
+		 *
+		 * @private
+		 * @memberof Sidebar
+		 */
 		private _handleGestureEvents(): void {
 			if (Helper.DeviceInfo.IsNative) {
 				// Create and save gesture event instance. Created here and not on constructor,
@@ -106,7 +121,15 @@ namespace OSFramework.OSUI.Patterns.Sidebar {
 			}
 		}
 
-		// Method to handle the start of a gesture
+		/**
+		 * Method to handle the start of a gesture
+		 *
+		 * @private
+		 * @param {number} offsetX
+		 * @param {number} offsetY
+		 * @param {number} timeTaken
+		 * @memberof Sidebar
+		 */
 		private _onGestureEnd(offsetX: number, offsetY: number, timeTaken: number): void {
 			this._animateOnDragInstance.onDragEnd(offsetX, offsetY, timeTaken, this._toggle.bind(this));
 
@@ -115,7 +138,17 @@ namespace OSFramework.OSUI.Patterns.Sidebar {
 			}
 		}
 
-		// Method to handle the gesture move
+		/**
+		 * Method to handle the gesture move
+		 *
+		 * @private
+		 * @param {number} x
+		 * @param {number} y
+		 * @param {number} offsetX
+		 * @param {number} offsetY
+		 * @param {TouchEvent} evt
+		 * @memberof Sidebar
+		 */
 		private _onGestureMove(x: number, y: number, offsetX: number, offsetY: number, evt: TouchEvent): void {
 			this._animateOnDragInstance.onDragMove(offsetX, offsetY, x, y, evt);
 
@@ -124,7 +157,14 @@ namespace OSFramework.OSUI.Patterns.Sidebar {
 			}
 		}
 
-		// Method to handle the end of a gesture
+		/**
+		 * Method to handle the end of a gesture
+		 *
+		 * @private
+		 * @param {number} x
+		 * @param {number} y
+		 * @memberof Sidebar
+		 */
 		private _onGestureStart(x: number, y: number): void {
 			this._animateOnDragInstance.onDragStart(
 				false,
@@ -136,7 +176,12 @@ namespace OSFramework.OSUI.Patterns.Sidebar {
 			);
 		}
 
-		// Actual method that knows what is to open the sidebar
+		/**
+		 * Method to open Sidebar
+		 *
+		 * @private
+		 * @memberof Sidebar
+		 */
 		private _openSidebar() {
 			Helper.Dom.Styles.AddClass(this.selfElement, Enum.CssClass.IsOpen);
 			Helper.A11Y.TabIndexTrue(this.selfElement);
@@ -169,7 +214,14 @@ namespace OSFramework.OSUI.Patterns.Sidebar {
 			Helper.A11Y.SetElementsTabIndex(this._isOpen, this._focusTrapInstance.focusableElements);
 		}
 
-		// Overlay onClick event to close the Sidebar
+		/**
+		 * Method to close Sidebar on an overlay click
+		 *
+		 * @private
+		 * @param {string} _args
+		 * @param {MouseEvent} e
+		 * @memberof Sidebar
+		 */
 		private _overlayClickCallback(_args: string, e: MouseEvent): void {
 			// If the sidebar is opened and the mouse down event occured outside the sidebar, close it.
 			if (
@@ -182,8 +234,15 @@ namespace OSFramework.OSUI.Patterns.Sidebar {
 			e.stopPropagation();
 		}
 
-		// Method to check if the mouse down event happened outside the sidebar
-		// This is required to cover the cases when selecting text and moving the cursor to the sidebar's overlay.
+		/**
+		 * Method to check if the mouse down event happened outside the sidebar
+		 * This is required to cover the cases when selecting text and moving the cursor to the sidebar's overlay.
+		 *
+		 * @private
+		 * @param {string} _args
+		 * @param {MouseEvent} e
+		 * @memberof Sidebar
+		 */
 		private _overlayMouseDownCallback(_args: string, e: MouseEvent): void {
 			const targetElem = e.target as HTMLElement;
 			this._clickedOutsideElement = true;
@@ -197,7 +256,12 @@ namespace OSFramework.OSUI.Patterns.Sidebar {
 			}
 		}
 
-		// Method to remove the event listeners
+		/**
+		 * Method to remove the event listeners
+		 *
+		 * @private
+		 * @memberof Sidebar
+		 */
 		private _removeEvents(): void {
 			this.selfElement.removeEventListener(GlobalEnum.HTMLEvent.keyDown, this._eventSidebarKeypress);
 			Event.DOMEvents.Listeners.GlobalListenerManager.Instance.removeHandler(
@@ -210,7 +274,12 @@ namespace OSFramework.OSUI.Patterns.Sidebar {
 			);
 		}
 
-		// Set the Sidebar opening/closing direction
+		/**
+		 * Method to set the Sidebar opening/closing direction
+		 *
+		 * @private
+		 * @memberof Sidebar
+		 */
 		private _setDirection(): void {
 			// Reset direction class
 			if (this._currentDirectionCssClass !== '') {
@@ -220,7 +289,12 @@ namespace OSFramework.OSUI.Patterns.Sidebar {
 			Helper.Dom.Styles.AddClass(this.selfElement, this._currentDirectionCssClass);
 		}
 
-		// Sets the Sidebar overlay
+		/**
+		 * Method to sets the Sidebar overlay
+		 *
+		 * @private
+		 * @memberof Sidebar
+		 */
 		private _setHasOverlay(): void {
 			const alreadyHasOverlayClass = Helper.Dom.Styles.ContainsClass(this.selfElement, Enum.CssClass.HasOverlay);
 
@@ -231,7 +305,12 @@ namespace OSFramework.OSUI.Patterns.Sidebar {
 			}
 		}
 
-		// Set the cssClasses that should be assigned to the element on it's initialization
+		/**
+		 * Method to set the cssClasses that should be assigned to the element on it's initialization
+		 *
+		 * @private
+		 * @memberof Sidebar
+		 */
 		private _setInitialCssClasses(): void {
 			this._setDirection();
 			this._setWidth();
@@ -242,12 +321,23 @@ namespace OSFramework.OSUI.Patterns.Sidebar {
 			}
 		}
 
-		// Set the Sidebar width
+		/**
+		 * Method to set the Sidebar width
+		 *
+		 * @private
+		 * @memberof Sidebar
+		 */
 		private _setWidth(): void {
 			Helper.Dom.Styles.SetStyleAttribute(this.selfElement, Enum.CssProperty.Width, this.configs.Width);
 		}
 
-		// Method that will handle the tab navigation and sidebar closing on Escape
+		/**
+		 * Method that will handle the tab navigation and sidebar closing on Escape
+		 *
+		 * @private
+		 * @param {KeyboardEvent} e
+		 * @memberof Sidebar
+		 */
 		private _sidebarKeypressCallback(e: KeyboardEvent): void {
 			const isEscapedPressed = e.key === GlobalEnum.Keycodes.Escape;
 
@@ -259,7 +349,12 @@ namespace OSFramework.OSUI.Patterns.Sidebar {
 			e.stopPropagation();
 		}
 
-		// Method to toggle the Sidebar
+		/**
+		 * Method to toggle the Sidebar
+		 *
+		 * @private
+		 * @memberof Sidebar
+		 */
 		private _toggle(): void {
 			if (this._isOpen) {
 				this.close();
@@ -268,7 +363,13 @@ namespace OSFramework.OSUI.Patterns.Sidebar {
 			}
 		}
 
-		// Method to toggle gestures on Sidebar
+		/**
+		 * Method to toggle gestures on Sidebar
+		 *
+		 * @private
+		 * @param {boolean} enableSwipes
+		 * @memberof Sidebar
+		 */
 		private _toggleGesturesSidebar(enableSwipes: boolean): void {
 			if (enableSwipes && this._hasGestureEvents === false) {
 				if (this._gestureEventInstance === undefined) {
@@ -279,7 +380,12 @@ namespace OSFramework.OSUI.Patterns.Sidebar {
 			}
 		}
 
-		// Method that triggers the OnToggle event
+		/**
+		 * Method that triggers the OnToggle event
+		 *
+		 * @private
+		 * @memberof Sidebar
+		 */
 		private _triggerOnToggleEvent(): void {
 			this.triggerPlatformEventCallback(this._platformEventOnToggle, this._isOpen);
 		}
@@ -460,7 +566,7 @@ namespace OSFramework.OSUI.Patterns.Sidebar {
 		}
 
 		/**
-		 * Set callbacks for the pattern
+		 * Method to set the callbacks for the pattern
 		 *
 		 * @param {string} eventName
 		 * @param {GlobalCallbacks.OSGeneric} callback
@@ -482,7 +588,7 @@ namespace OSFramework.OSUI.Patterns.Sidebar {
 		}
 
 		/**
-		 * Removes the gesture events to open/close the Sidebar on Native Apps
+		 * Method that removes the gesture events to open/close the Sidebar on Native Apps
 		 *
 		 * @memberof OSFramework.Patterns.Sidebar.Sidebar
 		 */
@@ -497,7 +603,7 @@ namespace OSFramework.OSUI.Patterns.Sidebar {
 		}
 
 		/**
-		 * Sets the gesture events to open/close the Sidebar on Native Apps
+		 * Method that sets the gesture events to open/close the Sidebar on Native Apps
 		 *
 		 * @protected
 		 * @memberof OSFramework.Patterns.Sidebar.Sidebar
@@ -518,7 +624,8 @@ namespace OSFramework.OSUI.Patterns.Sidebar {
 		/**
 		 * Method that toggle swipes on sidebar.
 		 *
-		 * @memberof OSFramework.Patterns.Sidebar.Sidebar
+		 * @param {boolean} enableSwipe
+		 * @memberof Sidebar
 		 */
 		public toggleGestures(enableSwipe: boolean): void {
 			this._toggleGesturesSidebar(enableSwipe);

--- a/src/scripts/OSFramework/OSUI/Pattern/Sidebar/SidebarConfig.ts
+++ b/src/scripts/OSFramework/OSUI/Pattern/Sidebar/SidebarConfig.ts
@@ -57,7 +57,7 @@ namespace OSFramework.OSUI.Patterns.Sidebar {
 					validatedValue = this.validateBoolean(value as boolean, false);
 					break;
 				case Enum.Properties.Width:
-					validatedValue = this.validateString(value as string, '500px');
+					validatedValue = this.validateString(value as string, Enum.Defaults.Width);
 					break;
 				default:
 					validatedValue = super.validateDefault(key, value);

--- a/src/scripts/OSFramework/OSUI/Pattern/Sidebar/SidebarConfig.ts
+++ b/src/scripts/OSFramework/OSUI/Pattern/Sidebar/SidebarConfig.ts
@@ -1,7 +1,13 @@
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 namespace OSFramework.OSUI.Patterns.Sidebar {
+	/**
+	 * Class that represents the custom configurations received by the Sidebar.
+	 *
+	 * @export
+	 * @class SidebarConfig
+	 * @extends {AbstractConfiguration}
+	 */
 	export class SidebarConfig extends AbstractConfiguration {
-		/** PUBLIC PROPERTIES **/
 		public Direction: GlobalEnum.Direction;
 		public HasOverlay: boolean;
 		public StartsOpen: boolean;
@@ -9,55 +15,6 @@ namespace OSFramework.OSUI.Patterns.Sidebar {
 
 		constructor(config: JSON) {
 			super(config);
-		}
-
-		/**
-		 * Method that will check if a given property (key) can be changed/updated!
-		 *
-		 * @param isBuilt True when pattern has been built!
-		 * @param key property name
-		 * @returns {boolean} boolean
-		 * @memberof  OSFramework.Patterns.Sidebar.SidebarConfig
-		 */
-		public validateCanChange(isBuilt: boolean, key: string): boolean {
-			if (isBuilt) {
-				return key !== Enum.Properties.StartsOpen;
-			}
-			return true;
-		}
-
-		/**
-		 * Method that will check if a given property (key) value is the type expected!
-		 *
-		 * @param key property name
-		 * @param value value to be check
-		 * @returns {unknown} value
-		 * @memberof  OSFramework.Patterns.Sidebar.SidebarConfig
-		 */
-		public validateDefault(key: string, value: unknown): unknown {
-			let validatedValue = undefined;
-			switch (key) {
-				case Enum.Properties.Direction:
-					validatedValue = this.validateInRange(
-						value,
-						GlobalEnum.Direction.Right,
-						GlobalEnum.Direction.Right,
-						GlobalEnum.Direction.Left
-					);
-					break;
-				case Enum.Properties.HasOverlay:
-				case Enum.Properties.StartsOpen:
-					validatedValue = this.validateBoolean(value as boolean, false);
-					break;
-				case Enum.Properties.Width:
-					validatedValue = this.validateString(value as string, '500px');
-					break;
-				default:
-					validatedValue = super.validateDefault(key, value);
-					break;
-			}
-
-			return validatedValue;
 		}
 	}
 }

--- a/src/scripts/OSFramework/OSUI/Pattern/Sidebar/SidebarConfig.ts
+++ b/src/scripts/OSFramework/OSUI/Pattern/Sidebar/SidebarConfig.ts
@@ -8,6 +8,7 @@ namespace OSFramework.OSUI.Patterns.Sidebar {
 	 * @extends {AbstractConfiguration}
 	 */
 	export class SidebarConfig extends AbstractConfiguration {
+		/** PUBLIC PROPERTIES **/
 		public Direction: GlobalEnum.Direction;
 		public HasOverlay: boolean;
 		public StartsOpen: boolean;
@@ -15,6 +16,55 @@ namespace OSFramework.OSUI.Patterns.Sidebar {
 
 		constructor(config: JSON) {
 			super(config);
+		}
+
+		/**
+		 * Method that will check if a given property (key) can be changed/updated!
+		 *
+		 * @param isBuilt True when pattern has been built!
+		 * @param key property name
+		 * @returns {boolean} boolean
+		 * @memberof  OSFramework.Patterns.Sidebar.SidebarConfig
+		 */
+		public validateCanChange(isBuilt: boolean, key: string): boolean {
+			if (isBuilt) {
+				return key !== Enum.Properties.StartsOpen;
+			}
+			return true;
+		}
+
+		/**
+		 * Method that will check if a given property (key) value is the type expected!
+		 *
+		 * @param key property name
+		 * @param value value to be check
+		 * @returns {unknown} value
+		 * @memberof  OSFramework.Patterns.Sidebar.SidebarConfig
+		 */
+		public validateDefault(key: string, value: unknown): unknown {
+			let validatedValue = undefined;
+			switch (key) {
+				case Enum.Properties.Direction:
+					validatedValue = this.validateInRange(
+						value,
+						GlobalEnum.Direction.Right,
+						GlobalEnum.Direction.Right,
+						GlobalEnum.Direction.Left
+					);
+					break;
+				case Enum.Properties.HasOverlay:
+				case Enum.Properties.StartsOpen:
+					validatedValue = this.validateBoolean(value as boolean, false);
+					break;
+				case Enum.Properties.Width:
+					validatedValue = this.validateString(value as string, '500px');
+					break;
+				default:
+					validatedValue = super.validateDefault(key, value);
+					break;
+			}
+
+			return validatedValue;
 		}
 	}
 }

--- a/src/scripts/OSFramework/OSUI/Pattern/Submenu/Submenu.ts
+++ b/src/scripts/OSFramework/OSUI/Pattern/Submenu/Submenu.ts
@@ -292,7 +292,7 @@ namespace OSFramework.OSUI.Patterns.Submenu {
 		}
 
 		/**
-		 * Built the Submenu
+		 * Method to build the Submenu
 		 *
 		 * @memberof OSFramework.Patterns.Submenu.Submenu
 		 */

--- a/src/scripts/OSFramework/OSUI/Pattern/SwipeEvents/SwipeEvents.ts
+++ b/src/scripts/OSFramework/OSUI/Pattern/SwipeEvents/SwipeEvents.ts
@@ -171,7 +171,7 @@ namespace OSFramework.OSUI.Patterns.SwipeEvents {
 		}
 
 		/**
-		 * Build SwipeEvents
+		 * Method to build the SwipeEvents
 		 *
 		 * @memberof OSFramework.Patterns.SwipeEvents.SwipeEvents
 		 */

--- a/src/scripts/OSFramework/OSUI/Pattern/Tabs/Enum.ts
+++ b/src/scripts/OSFramework/OSUI/Pattern/Tabs/Enum.ts
@@ -81,9 +81,6 @@ namespace OSFramework.OSUI.Patterns.Tabs.Enum {
 
 	/**
 	 * Callbacks eventName
-	 *
-	 * @export
-	 * @enum {number}
 	 */
 	export enum Events {
 		OnChange = 'OnChange',

--- a/src/scripts/OSFramework/OSUI/Pattern/Tabs/ITabs.ts
+++ b/src/scripts/OSFramework/OSUI/Pattern/Tabs/ITabs.ts
@@ -16,7 +16,6 @@ namespace OSFramework.OSUI.Patterns.Tabs {
 		 * @param {boolean} [blockObserver]
 		 * @param {boolean} [triggerEvent]
 		 * @param {boolean} [triggeredByObserver]
-		 * @memberof ITabs
 		 */
 		changeTab(
 			tabIndex: number,
@@ -25,11 +24,11 @@ namespace OSFramework.OSUI.Patterns.Tabs {
 			triggerEvent?: boolean,
 			triggeredByObserver?: boolean
 		): void;
+
 		/**
 		 * Function that will toggle the gestures on Tabs
 		 *
 		 * @param {boolean} addDragGestures
-		 * @memberof ITabs
 		 */
 		toggleDragGestures(addDragGestures: boolean): void;
 	}

--- a/src/scripts/OSFramework/OSUI/Pattern/Tabs/ITabs.ts
+++ b/src/scripts/OSFramework/OSUI/Pattern/Tabs/ITabs.ts
@@ -2,8 +2,22 @@
 namespace OSFramework.OSUI.Patterns.Tabs {
 	/**
 	 * Defines the interface for OutSystemsUI Tabs Pattern
+	 *
+	 * @export
+	 * @interface ITabs
+	 * @extends {Interface.IParent}
 	 */
 	export interface ITabs extends Interface.IParent {
+		/**
+		 * Function that will trigger the change tab method
+		 *
+		 * @param {number} tabIndex
+		 * @param {TabsHeaderItem.ITabsHeaderItem} tabsHeaderItem
+		 * @param {boolean} [blockObserver]
+		 * @param {boolean} [triggerEvent]
+		 * @param {boolean} [triggeredByObserver]
+		 * @memberof ITabs
+		 */
 		changeTab(
 			tabIndex: number,
 			tabsHeaderItem: TabsHeaderItem.ITabsHeaderItem,
@@ -11,6 +25,12 @@ namespace OSFramework.OSUI.Patterns.Tabs {
 			triggerEvent?: boolean,
 			triggeredByObserver?: boolean
 		): void;
+		/**
+		 * Function that will toggle the gestures on Tabs
+		 *
+		 * @param {boolean} addDragGestures
+		 * @memberof ITabs
+		 */
 		toggleDragGestures(addDragGestures: boolean): void;
 	}
 }

--- a/src/scripts/OSFramework/OSUI/Pattern/Tabs/Tabs.ts
+++ b/src/scripts/OSFramework/OSUI/Pattern/Tabs/Tabs.ts
@@ -54,7 +54,13 @@ namespace OSFramework.OSUI.Patterns.Tabs {
 			this._isChromium = Helper.DeviceInfo.GetBrowser() === 'chrome' || Helper.DeviceInfo.GetBrowser() === 'edge';
 		}
 
-		// Method that it's called whenever a new TabsContentItem is rendered
+		/**
+		 * Method that it's called whenever a new TabsContentItem is rendered
+		 *
+		 * @private
+		 * @param {Patterns.TabsContentItem.TabsContentItem} tabsContentChildItem
+		 * @memberof Tabs
+		 */
 		private _addContentItem(tabsContentChildItem: Patterns.TabsContentItem.TabsContentItem): void {
 			if (this.getChild(tabsContentChildItem.uniqueId)) {
 				throw new Error(
@@ -86,7 +92,12 @@ namespace OSFramework.OSUI.Patterns.Tabs {
 			}
 		}
 
-		// Add event listener for arrow navigation
+		/**
+		 * Add event listener for arrow navigation
+		 *
+		 * @private
+		 * @memberof Tabs
+		 */
 		private _addEvents(): void {
 			this.selfElement.addEventListener(GlobalEnum.HTMLEvent.keyDown, this._eventOnHeaderKeypress);
 
@@ -105,7 +116,13 @@ namespace OSFramework.OSUI.Patterns.Tabs {
 			}
 		}
 
-		// Method that it's called whenever a new TabsHeaderItem is rendered
+		/**
+		 * Method that it's called whenever a new TabsHeaderItem is rendered
+		 *
+		 * @private
+		 * @param {Patterns.TabsHeaderItem.TabsHeaderItem} tabsHeaderChildItem
+		 * @memberof Tabs
+		 */
 		private _addHeaderItem(tabsHeaderChildItem: Patterns.TabsHeaderItem.TabsHeaderItem): void {
 			if (this.getChild(tabsHeaderChildItem.uniqueId)) {
 				throw new Error(
@@ -146,7 +163,14 @@ namespace OSFramework.OSUI.Patterns.Tabs {
 			}
 		}
 
-		// Method to change the active content item
+		/**
+		 * Method to change the active content item
+		 *
+		 * @private
+		 * @param {number} newTabIndex
+		 * @param {boolean} triggeredByObserver
+		 * @memberof Tabs
+		 */
 		private _changeActiveContentItem(newTabIndex: number, triggeredByObserver: boolean): void {
 			// Get the contentItem, based on the newTabIndex
 			const newContentItem = this.getChildByIndex(
@@ -173,7 +197,13 @@ namespace OSFramework.OSUI.Patterns.Tabs {
 			}
 		}
 
-		// Method to change the active header item
+		/**
+		 * Method to change the active header item
+		 *
+		 * @private
+		 * @param {TabsHeaderItem.ITabsHeaderItem} newHeaderItem
+		 * @memberof Tabs
+		 */
 		private _changeActiveHeaderItem(newHeaderItem: TabsHeaderItem.ITabsHeaderItem): void {
 			// Remove old headerItem as active
 			if (this._activeTabHeaderElement) {
@@ -187,7 +217,14 @@ namespace OSFramework.OSUI.Patterns.Tabs {
 			}
 		}
 
-		// Method to determine the next target index on changeTab method
+		/**
+		 * Method to determine the next target index on changeTab method
+		 *
+		 * @private
+		 * @param {number} tabIndex
+		 * @return {*}  {number}
+		 * @memberof Tabs
+		 */
 		private _getTargetIndex(tabIndex: number): number {
 			let newTabIndex;
 
@@ -205,7 +242,14 @@ namespace OSFramework.OSUI.Patterns.Tabs {
 			return newTabIndex;
 		}
 
-		// Method that handles the Keypress Event, for tabs navigation using arrows
+		/**
+		 * Method that handles the Keypress Event, for tabs navigation using arrows
+		 *
+		 * @private
+		 * @param {KeyboardEvent} e
+		 * @return {*}  {void}
+		 * @memberof Tabs
+		 */
 		private _handleKeypressEvent(e: KeyboardEvent): void {
 			let targetHeaderItemIndex;
 			// Check if target is the header, to do not change tab on x arrow press
@@ -247,13 +291,23 @@ namespace OSFramework.OSUI.Patterns.Tabs {
 			}
 		}
 
-		// Method to adjust the tabs css active item on resize or orientation-change
+		/**
+		 * Method to adjust the tabs css active item on resize or orientation-change
+		 *
+		 * @private
+		 * @memberof Tabs
+		 */
 		private _handleOnResizeEvent(): void {
 			this._scrollToTargetContent(this._activeTabContentElement);
 			Helper.AsyncInvocation(this._handleTabIndicator.bind(this));
 		}
 
-		// Method that handles the indicator size and transition
+		/**
+		 * Method that handles the indicator size and transition
+		 *
+		 * @private
+		 * @memberof Tabs
+		 */
 		private _handleTabIndicator(): void {
 			if (this._activeTabHeaderElement?.selfElement) {
 				// Check if it comes form a disabled tab, to remove the disable class
@@ -329,7 +383,12 @@ namespace OSFramework.OSUI.Patterns.Tabs {
 			}
 		}
 
-		// Method to make neccessary preparations for header and content items, that can't be done on their scope
+		/**
+		 * Method to make neccessary preparations for header and content items, that can't be done on their scope
+		 *
+		 * @private
+		 * @memberof Tabs
+		 */
 		private _prepareHeaderAndContentItems(): void {
 			// Set if the Tabs has only one Content
 			this._hasSingleContent = this.getChildItems(Enum.ChildTypes.TabsContentItem).length === 1;
@@ -362,7 +421,13 @@ namespace OSFramework.OSUI.Patterns.Tabs {
 			this._updateItemsConnection(false);
 		}
 
-		// Method that it's called whenever a new TabsContentItem is destroyed
+		/**
+		 * Method that it's called whenever a new TabsContentItem is destroyed
+		 *
+		 * @private
+		 * @param {string} childContentId
+		 * @memberof Tabs
+		 */
 		private _removeContentItem(childContentId: string): void {
 			const childContentItem = this.getChild(childContentId) as TabsContentItem.ITabsContentItem;
 			let auxIndex: number;
@@ -403,7 +468,12 @@ namespace OSFramework.OSUI.Patterns.Tabs {
 			}
 		}
 
-		// Remove Pattern Events
+		/**
+		 * Remove Pattern Events
+		 *
+		 * @private
+		 * @memberof Tabs
+		 */
 		private _removeEvents(): void {
 			this._tabsHeaderElement.removeEventListener(GlobalEnum.HTMLEvent.keyDown, this._eventOnHeaderKeypress);
 
@@ -422,7 +492,13 @@ namespace OSFramework.OSUI.Patterns.Tabs {
 			}
 		}
 
-		// Method that it's called whenever a new TabsHeaderItem is destroyed
+		/**
+		 * Method that it's called whenever a new TabsHeaderItem is destroyed
+		 *
+		 * @private
+		 * @param {string} childHeaderId
+		 * @memberof Tabs
+		 */
 		private _removeHeaderItem(childHeaderId: string): void {
 			const auxIndex = this.getChildIndex(childHeaderId);
 			const wasActive = this.getChild(childHeaderId).IsActive;
@@ -463,7 +539,13 @@ namespace OSFramework.OSUI.Patterns.Tabs {
 			}
 		}
 
-		// Method to scroll to new target content item
+		/**
+		 * Method to scroll to new target content item
+		 *
+		 * @private
+		 * @param {Patterns.TabsContentItem.ITabsContentItem} newContentItem
+		 * @memberof Tabs
+		 */
 		private _scrollToTargetContent(newContentItem: Patterns.TabsContentItem.ITabsContentItem): void {
 			if (newContentItem) {
 				// Scroll to new content item
@@ -475,7 +557,13 @@ namespace OSFramework.OSUI.Patterns.Tabs {
 			}
 		}
 
-		// Method to set if the Tabs AutoHeight
+		/**
+		 * Method to set if the Tabs AutoHeight
+		 *
+		 * @private
+		 * @param {boolean} hasAutoHeight
+		 * @memberof Tabs
+		 */
 		private _setContentAutoHeight(hasAutoHeight: boolean): void {
 			if (this._hasDragGestures === false) {
 				if (hasAutoHeight) {
@@ -490,7 +578,12 @@ namespace OSFramework.OSUI.Patterns.Tabs {
 			}
 		}
 
-		// Method to set an IntersectionObserver when drag gestures are enable, to detect the activeItem on drag
+		/**
+		 * Method to set an IntersectionObserver when drag gestures are enable, to detect the activeItem on drag
+		 *
+		 * @private
+		 * @memberof Tabs
+		 */
 		private _setDragObserver(): void {
 			// Observer options
 			const observerOptions = {
@@ -521,13 +614,25 @@ namespace OSFramework.OSUI.Patterns.Tabs {
 			});
 		}
 
-		// Method to set the CSS variable that holds the number of header items
+		/**
+		 * Method to set the CSS variable that holds the number of header items
+		 *
+		 * @private
+		 * @param {number} itemsLength
+		 * @memberof Tabs
+		 */
 		private _setHeaderItemsCustomProperty(itemsLength: number): void {
 			// Create css variable
 			Helper.Dom.Styles.SetStyleAttribute(this.selfElement, Enum.CssProperty.TabsHeaderItems, itemsLength);
 		}
 
-		// Method to set the Tabs Height
+		/**
+		 * Method to set the Tabs Height
+		 *
+		 * @private
+		 * @param {string} height
+		 * @memberof Tabs
+		 */
 		private _setHeight(height: string): void {
 			// Set tabs overflow based on height
 			const tabsOverflow =
@@ -544,7 +649,12 @@ namespace OSFramework.OSUI.Patterns.Tabs {
 			);
 		}
 
-		// Method to set the initial options on screen load
+		/**
+		 * Method to set the initial options on screen load
+		 *
+		 * @private
+		 * @memberof Tabs
+		 */
 		private _setInitialOptions(): void {
 			// Call necessary methods that avoid layout shift first
 			// Set the --tabs-header-items css variable
@@ -562,7 +672,13 @@ namespace OSFramework.OSUI.Patterns.Tabs {
 			}
 		}
 
-		// Method to set if the Tabs are justified
+		/**
+		 * Method to set if the Tabs are justified
+		 *
+		 * @private
+		 * @param {boolean} isJustified
+		 * @memberof Tabs
+		 */
 		private _setIsJustified(isJustified: boolean): void {
 			if (isJustified) {
 				Helper.Dom.Styles.AddClass(this.selfElement, Enum.CssClasses.IsJustified);
@@ -576,7 +692,13 @@ namespace OSFramework.OSUI.Patterns.Tabs {
 			}
 		}
 
-		// Method to set the Tabs Orientation
+		/**
+		 * Method to set the Tabs Orientation
+		 *
+		 * @private
+		 * @param {GlobalEnum.Orientation} orientation
+		 * @memberof Tabs
+		 */
 		private _setOrientation(orientation: GlobalEnum.Orientation): void {
 			Helper.Dom.Styles.RemoveClass(this.selfElement, Enum.CssClasses.Modifier + this._currentOrientation);
 			Helper.Dom.Styles.AddClass(this.selfElement, Enum.CssClasses.Modifier + orientation);
@@ -590,7 +712,13 @@ namespace OSFramework.OSUI.Patterns.Tabs {
 			}
 		}
 
-		// Method to set the Tabs Position
+		/**
+		 * Method to set the Tabs Position
+		 *
+		 * @private
+		 * @param {GlobalEnum.Direction} position
+		 * @memberof Tabs
+		 */
 		private _setPosition(position: GlobalEnum.Direction): void {
 			Helper.Dom.Styles.RemoveClass(this.selfElement, Enum.CssClasses.Modifier + this._currentVerticalPositon);
 			Helper.Dom.Styles.AddClass(this.selfElement, Enum.CssClasses.Modifier + position);
@@ -598,7 +726,14 @@ namespace OSFramework.OSUI.Patterns.Tabs {
 			this._currentVerticalPositon = position;
 		}
 
-		// Toggle TableHeaderItem disbaled status
+		/**
+		 * Toggle TableHeaderItem disbaled status
+		 *
+		 * @private
+		 * @param {string} childHeaderId
+		 * @param {boolean} isDisabled
+		 * @memberof Tabs
+		 */
 		private _setTabHeaderItemDisabledStatus(childHeaderId: string, isDisabled: boolean): void {
 			const _tabHeaderItemElement = Helper.Dom.GetElementByUniqueId(childHeaderId);
 			const _tabItemIndex = this.getChildIndex(childHeaderId);
@@ -650,7 +785,13 @@ namespace OSFramework.OSUI.Patterns.Tabs {
 			}
 		}
 
-		// Method to change between tabs
+		/**
+		 * Method to change between tabs
+		 *
+		 * @private
+		 * @param {string} childHeaderId
+		 * @memberof Tabs
+		 */
 		private _tabHeaderItemHasBeenClicked(childHeaderId: string): void {
 			const newHeaderItem = this.getChild(childHeaderId) as TabsHeaderItem.ITabsHeaderItem;
 
@@ -663,19 +804,36 @@ namespace OSFramework.OSUI.Patterns.Tabs {
 			this.changeTab(this.getChildIndex(childHeaderId), newHeaderItem, true);
 		}
 
-		// Method that triggers the OnTabsChange event
+		/**
+		 * Method that triggers the OnTabsChange event
+		 *
+		 * @private
+		 * @param {number} activeTab
+		 * @memberof Tabs
+		 */
 		private _triggerOnChangeEvent(activeTab: number): void {
 			if (this._platformEventTabsOnChange !== undefined) {
 				this.triggerPlatformEventCallback(this._platformEventTabsOnChange, activeTab);
 			}
 		}
 
-		// Method to remove the drag Observer on each contentItem
+		/**
+		 * Method to remove the drag Observer on each contentItem
+		 *
+		 * @private
+		 * @memberof Tabs
+		 */
 		private _unsetDragObserver(): void {
 			this._dragObserver.disconnect();
 		}
 
-		// Method that handles the connection between HeaderItems and ContentItem, related to data-tab and aria-controls/labbeledby
+		/**
+		 * Method that handles the connection between HeaderItems and ContentItem, related to data-tab and aria-controls/labbeledby
+		 *
+		 * @private
+		 * @param {boolean} [updateDataTab=true]
+		 * @memberof Tabs
+		 */
 		private _updateItemsConnection(updateDataTab = true): void {
 			// By default look to the first content item.
 			let currentContentItem = this.getChildByIndex(

--- a/src/scripts/OSFramework/OSUI/Pattern/Tabs/Tabs.ts
+++ b/src/scripts/OSFramework/OSUI/Pattern/Tabs/Tabs.ts
@@ -980,7 +980,7 @@ namespace OSFramework.OSUI.Patterns.Tabs {
 		}
 
 		/**
-		 * Method to build the pattern
+		 * Method to build the Tabs
 		 *
 		 * @memberof OSFramework.Patterns.Tabs.Tabs
 		 */

--- a/src/scripts/OSFramework/OSUI/Pattern/Tabs/TabsConfig.ts
+++ b/src/scripts/OSFramework/OSUI/Pattern/Tabs/TabsConfig.ts
@@ -1,5 +1,12 @@
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 namespace OSFramework.OSUI.Patterns.Tabs {
+	/**
+	 * Class that represents the custom configurations received by Tabs.
+	 *
+	 * @export
+	 * @class TabsConfig
+	 * @extends {AbstractConfiguration}
+	 */
 	export class TabsConfig extends AbstractConfiguration {
 		public ContentAutoHeight: boolean;
 		public Height: string;

--- a/src/scripts/OSFramework/OSUI/Pattern/Tabs/TabsConfig.ts
+++ b/src/scripts/OSFramework/OSUI/Pattern/Tabs/TabsConfig.ts
@@ -14,5 +14,56 @@ namespace OSFramework.OSUI.Patterns.Tabs {
 		public StartingTab: number;
 		public TabsOrientation: GlobalEnum.Orientation;
 		public TabsVerticalPosition: GlobalEnum.Direction;
+
+		/**
+		 * Method that will check if a given property (key) can be changed/updated!
+		 *
+		 * @param isBuilt True when pattern has been built!
+		 * @param key property name
+		 * @returns {boolean} boolean
+		 * @memberof  OSFramework.Patterns.Tabs.TabsConfig
+		 */
+		public validateCanChange(isBuilt: boolean, key: string): boolean {
+			if (isBuilt) {
+				return key !== Enum.Properties.StartingTab;
+			}
+			return true;
+		}
+
+		/**
+		 * Method that will check if a given property (key) value is the type expected!
+		 *
+		 * @param key property name
+		 * @param value value to be check
+		 * @returns {unknown} value
+		 * @memberof  OSFramework.Patterns.Tabs.TabsConfig
+		 */
+		public validateDefault(key: string, value: unknown): unknown {
+			let validatedValue = undefined;
+			switch (key) {
+				case Enum.Properties.TabsOrientation:
+					validatedValue = this.validateInRange(
+						value,
+						GlobalEnum.Orientation.Horizontal,
+						GlobalEnum.Orientation.Vertical
+					);
+					break;
+				case Enum.Properties.TabsVerticalPosition:
+					validatedValue = this.validateInRange(value, GlobalEnum.Direction.Left, GlobalEnum.Direction.Right);
+					break;
+				case Enum.Properties.ContentAutoHeight:
+				case Enum.Properties.JustifyHeaders:
+					validatedValue = this.validateBoolean(value as boolean, false);
+					break;
+				case Enum.Properties.Height:
+					validatedValue = this.validateString(value as string, GlobalEnum.CssProperties.Auto);
+					break;
+				default:
+					validatedValue = super.validateDefault(key, value);
+					break;
+			}
+
+			return validatedValue;
+		}
 	}
 }

--- a/src/scripts/OSFramework/OSUI/Pattern/Tabs/TabsConfig.ts
+++ b/src/scripts/OSFramework/OSUI/Pattern/Tabs/TabsConfig.ts
@@ -14,56 +14,5 @@ namespace OSFramework.OSUI.Patterns.Tabs {
 		public StartingTab: number;
 		public TabsOrientation: GlobalEnum.Orientation;
 		public TabsVerticalPosition: GlobalEnum.Direction;
-
-		/**
-		 * Method that will check if a given property (key) can be changed/updated!
-		 *
-		 * @param isBuilt True when pattern has been built!
-		 * @param key property name
-		 * @returns {boolean} boolean
-		 * @memberof  OSFramework.Patterns.Tabs.TabsConfig
-		 */
-		public validateCanChange(isBuilt: boolean, key: string): boolean {
-			if (isBuilt) {
-				return key !== Enum.Properties.StartingTab;
-			}
-			return true;
-		}
-
-		/**
-		 * Method that will check if a given property (key) value is the type expected!
-		 *
-		 * @param key property name
-		 * @param value value to be check
-		 * @returns {unknown} value
-		 * @memberof  OSFramework.Patterns.Tabs.TabsConfig
-		 */
-		public validateDefault(key: string, value: unknown): unknown {
-			let validatedValue = undefined;
-			switch (key) {
-				case Enum.Properties.TabsOrientation:
-					validatedValue = this.validateInRange(
-						value,
-						GlobalEnum.Orientation.Horizontal,
-						GlobalEnum.Orientation.Vertical
-					);
-					break;
-				case Enum.Properties.TabsVerticalPosition:
-					validatedValue = this.validateInRange(value, GlobalEnum.Direction.Left, GlobalEnum.Direction.Right);
-					break;
-				case Enum.Properties.ContentAutoHeight:
-				case Enum.Properties.JustifyHeaders:
-					validatedValue = this.validateBoolean(value as boolean, false);
-					break;
-				case Enum.Properties.Height:
-					validatedValue = this.validateString(value as string, GlobalEnum.CssProperties.Auto);
-					break;
-				default:
-					validatedValue = super.validateDefault(key, value);
-					break;
-			}
-
-			return validatedValue;
-		}
 	}
 }

--- a/src/scripts/OSFramework/OSUI/Pattern/TabsContentItem/ITabsContentItem.ts
+++ b/src/scripts/OSFramework/OSUI/Pattern/TabsContentItem/ITabsContentItem.ts
@@ -2,6 +2,10 @@
 namespace OSFramework.OSUI.Patterns.TabsContentItem {
 	/**
 	 * Defines the interface for OutSystemsUI TabsContentItem Pattern
+	 *
+	 * @export
+	 * @interface ITabsContentItem
+	 * @extends {Interface.IChild}
 	 */
 	export interface ITabsContentItem extends Interface.IChild {
 		get IsActive(): boolean;

--- a/src/scripts/OSFramework/OSUI/Pattern/TabsContentItem/ITabsContentItem.ts
+++ b/src/scripts/OSFramework/OSUI/Pattern/TabsContentItem/ITabsContentItem.ts
@@ -8,15 +8,74 @@ namespace OSFramework.OSUI.Patterns.TabsContentItem {
 	 * @extends {Interface.IChild}
 	 */
 	export interface ITabsContentItem extends Interface.IChild {
-		get IsActive(): boolean;
+		/**
+		 * Returns the value of active state
+		 *
+		 * @type {boolean}
+		 * @memberof ITabsContentItem
+		 */
+		IsActive: boolean;
 
+		/**
+		 * Method to get the current data-tab value
+		 *
+		 * @return {*}  {number}
+		 * @memberof ITabsContentItem
+		 */
 		getDataTab(): number;
+
+		/**
+		 * Method to get the element offsetLeft value
+		 *
+		 * @return {*}  {number}
+		 * @memberof ITabsContentItem
+		 */
 		getOffsetLeft(): number;
+
+		/**
+		 * Method to set the aria-labelledby attribute
+		 *
+		 * @param {string} headerItemId Element that will receive the aria-labelledby
+		 * @memberof ITabsContentItem
+		 */
 		setAriaLabelledByAttribute(headerItemId: string): void;
+
+		/**
+		 * Method to set the data-tab attribute
+		 *
+		 * @param {number} dataTab Tab that will be the active
+		 * @memberof ITabsContentItem
+		 */
 		setDataTab(dataTab: number): void;
+
+		/**
+		 * Method to set the element as active
+		 *
+		 * @memberof ITabsContentItem
+		 */
 		setIsActive(): void;
+
+		/**
+		 * Method to set the intersection observer
+		 *
+		 * @param {IntersectionObserver} observer
+		 * @memberof ITabsContentItem
+		 */
 		setOnDragObserver(observer: IntersectionObserver): void;
+
+		/**
+		 * Method to stop observing this element in the intersection observer
+		 *
+		 * @param {IntersectionObserver} observer
+		 * @memberof ITabsContentItem
+		 */
 		unobserveDragObserver(observer: IntersectionObserver): void;
+
+		/**
+		 * Method to remove the element as active
+		 *
+		 * @memberof ITabsContentItem
+		 */
 		unsetIsActive(): void;
 	}
 }

--- a/src/scripts/OSFramework/OSUI/Pattern/TabsContentItem/TabsContentItem.ts
+++ b/src/scripts/OSFramework/OSUI/Pattern/TabsContentItem/TabsContentItem.ts
@@ -84,7 +84,7 @@ namespace OSFramework.OSUI.Patterns.TabsContentItem {
 		}
 
 		/**
-		 * Method to build the pattern
+		 * Method to build the TabsContentItem
 		 *
 		 * @memberof OSFramework.Patterns.TabsContentItem.TabsContentItem
 		 */

--- a/src/scripts/OSFramework/OSUI/Pattern/TabsContentItem/TabsContentItemConfig.ts
+++ b/src/scripts/OSFramework/OSUI/Pattern/TabsContentItem/TabsContentItemConfig.ts
@@ -1,7 +1,7 @@
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 namespace OSFramework.OSUI.Patterns.TabsContentItem {
 	/**
-	 *
+	 * Class that represents the custom configurations received by the TabsContentItem.
 	 *
 	 * @export
 	 * @class TabsContentItemConfig

--- a/src/scripts/OSFramework/OSUI/Pattern/TabsContentItem/TabsContentItemConfig.ts
+++ b/src/scripts/OSFramework/OSUI/Pattern/TabsContentItem/TabsContentItemConfig.ts
@@ -1,5 +1,12 @@
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 namespace OSFramework.OSUI.Patterns.TabsContentItem {
+	/**
+	 *
+	 *
+	 * @export
+	 * @class TabsContentItemConfig
+	 * @extends {AbstractConfiguration}
+	 */
 	export class TabsContentItemConfig extends AbstractConfiguration {
 		constructor(config: JSON) {
 			super(config);

--- a/src/scripts/OSFramework/OSUI/Pattern/TabsHeaderItem/ITabsHeaderItem.ts
+++ b/src/scripts/OSFramework/OSUI/Pattern/TabsHeaderItem/ITabsHeaderItem.ts
@@ -2,10 +2,13 @@
 namespace OSFramework.OSUI.Patterns.TabsHeaderItem {
 	/**
 	 * Defines the interface for OutSystemsUI TabsHeaderItem Pattern
+	 *
+	 * @export
+	 * @interface ITabsHeaderItem
+	 * @extends {Interface.IChild}
 	 */
 	export interface ITabsHeaderItem extends Interface.IChild {
 		get IsActive(): boolean;
-
 		disable(): void;
 		enable(): void;
 		getDataTab(): number;

--- a/src/scripts/OSFramework/OSUI/Pattern/TabsHeaderItem/ITabsHeaderItem.ts
+++ b/src/scripts/OSFramework/OSUI/Pattern/TabsHeaderItem/ITabsHeaderItem.ts
@@ -8,15 +8,78 @@ namespace OSFramework.OSUI.Patterns.TabsHeaderItem {
 	 * @extends {Interface.IChild}
 	 */
 	export interface ITabsHeaderItem extends Interface.IChild {
-		get IsActive(): boolean;
+		/**
+		 * Returns the value of active state
+		 *
+		 * @type {boolean}
+		 * @memberof ITabsHeaderItem
+		 */
+		IsActive: boolean;
+
+		/**
+		 * Method to disable TabHeaderItem
+		 *
+		 * @memberof ITabsHeaderItem
+		 */
 		disable(): void;
+
+		/**
+		 * Method to enable TabHeaderItem
+		 *
+		 * @memberof ITabsHeaderItem
+		 */
 		enable(): void;
+
+		/**
+		 * Method to get the current data-tab value
+		 *
+		 * @return {*}  {number}
+		 * @memberof ITabsHeaderItem
+		 */
 		getDataTab(): number;
+
+		/**
+		 * Method to set the aria-controls attribute
+		 *
+		 * @param {string} contentItemId Element that will receive the aria-controls
+		 * @memberof ITabsHeaderItem
+		 */
 		setAriaControlsAttribute(contentItemId: string): void;
+
+		/**
+		 * Method to set the data-tab attribute
+		 *
+		 * @param {number} dataTab Tab that will be the active
+		 * @memberof ITabsHeaderItem
+		 */
 		setDataTab(dataTab: number): void;
+
+		/**
+		 * Method to set the focus on item
+		 *
+		 * @memberof ITabsHeaderItem
+		 */
 		setFocus(): void;
+
+		/**
+		 * Method to set the element as active
+		 *
+		 * @memberof ITabsHeaderItem
+		 */
 		setIsActive(): void;
+
+		/**
+		 * Method to remove the element as active
+		 *
+		 * @memberof ITabsHeaderItem
+		 */
 		unsetIsActive(): void;
+
+		/**
+		 * Method to update tabs indicator size on HeaderItem onRender
+		 *
+		 * @memberof ITabsHeaderItem
+		 */
 		updateOnRender(): void;
 	}
 }

--- a/src/scripts/OSFramework/OSUI/Pattern/TabsHeaderItem/TabsHeaderItem.ts
+++ b/src/scripts/OSFramework/OSUI/Pattern/TabsHeaderItem/TabsHeaderItem.ts
@@ -20,19 +20,34 @@ namespace OSFramework.OSUI.Patterns.TabsHeaderItem {
 			super(uniqueId, new TabsHeaderItemConfig(configs));
 		}
 
-		// Method to handle the click event
+		/**
+		 * Method to handle the click event
+		 *
+		 * @private
+		 * @memberof TabsHeaderItem
+		 */
 		private _handleClickEvent(): void {
 			if (this._isActive === false) {
 				this.notifyParent(Tabs.Enum.ChildNotifyActionType.Click);
 			}
 		}
 
-		// Method to remove the event listeners
+		/**
+		 * Method to remove the event listeners
+		 *
+		 * @private
+		 * @memberof TabsHeaderItem
+		 */
 		private _removeEvents(): void {
 			this.selfElement.removeEventListener(GlobalEnum.HTMLEvent.Click, this._eventOnTabsClick);
 		}
 
-		// Method to set the event listeners
+		/**
+		 * Method to set the event listeners
+		 *
+		 * @private
+		 * @memberof TabsHeaderItem
+		 */
 		private _setUpEvents(): void {
 			this.selfElement.addEventListener(GlobalEnum.HTMLEvent.Click, this._eventOnTabsClick);
 		}
@@ -171,7 +186,7 @@ namespace OSFramework.OSUI.Patterns.TabsHeaderItem {
 		/**
 		 * Method to set the aria-controls attribute, called by the Tabs
 		 *
-		 * @param {string} contentItemId
+		 * @param {string} contentItemId Element that will receive the aria-controls
 		 * @memberof OSFramework.Patterns.TabsHeaderItem.TabsHeaderItem
 		 */
 		public setAriaControlsAttribute(contentItemId: string): void {
@@ -181,7 +196,7 @@ namespace OSFramework.OSUI.Patterns.TabsHeaderItem {
 		/**
 		 * Method to set the data-tab attribute, called by the Tabs
 		 *
-		 * @param {number} dataTab
+		 * @param {number} dataTab Tab that will be the active
 		 * @memberof OSFramework.Patterns.TabsHeaderItem.TabsHeaderItem
 		 */
 		public setDataTab(dataTab: number): void {

--- a/src/scripts/OSFramework/OSUI/Pattern/TabsHeaderItem/TabsHeaderItem.ts
+++ b/src/scripts/OSFramework/OSUI/Pattern/TabsHeaderItem/TabsHeaderItem.ts
@@ -115,7 +115,7 @@ namespace OSFramework.OSUI.Patterns.TabsHeaderItem {
 		}
 
 		/**
-		 * Method to build the pattern
+		 * Method to build the TabsHeaderItem
 		 *
 		 * @memberof OSFramework.Patterns.TabsHeaderItem.TabsHeaderItem
 		 */

--- a/src/scripts/OSFramework/OSUI/Pattern/TabsHeaderItem/TabsHeaderItemConfig.ts
+++ b/src/scripts/OSFramework/OSUI/Pattern/TabsHeaderItem/TabsHeaderItemConfig.ts
@@ -1,5 +1,12 @@
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 namespace OSFramework.OSUI.Patterns.TabsHeaderItem {
+	/**
+	 * Class that represents the custom configurations received by TabsHeaderItem.
+	 *
+	 * @export
+	 * @class TabsHeaderItemConfig
+	 * @extends {AbstractConfiguration}
+	 */
 	export class TabsHeaderItemConfig extends AbstractConfiguration {
 		constructor(config: JSON) {
 			super(config);

--- a/src/scripts/OSFramework/OSUI/Pattern/Tooltip/Tooltip.ts
+++ b/src/scripts/OSFramework/OSUI/Pattern/Tooltip/Tooltip.ts
@@ -721,7 +721,7 @@ namespace OSFramework.OSUI.Patterns.Tooltip {
 		}
 
 		/**
-		 * Build tooltip
+		 * Method to build the Tooltip
 		 *
 		 * @memberof OSFramework.Patterns.Tooltip.Tooltip
 		 */

--- a/src/scripts/OSFramework/OSUI/Pattern/TouchEvents/TouchEvents.ts
+++ b/src/scripts/OSFramework/OSUI/Pattern/TouchEvents/TouchEvents.ts
@@ -195,7 +195,7 @@ namespace OSFramework.OSUI.Patterns.TouchEvents {
 		}
 
 		/**
-		 * Build TouchEvents
+		 * Method to build the TouchEvents
 		 *
 		 * @memberof OSFramework.Patterns.TouchEvents.TouchEvents
 		 */

--- a/src/scripts/OSFramework/OSUI/Pattern/Video/Video.ts
+++ b/src/scripts/OSFramework/OSUI/Pattern/Video/Video.ts
@@ -305,7 +305,7 @@ namespace OSFramework.OSUI.Patterns.Video {
 		}
 
 		/**
-		 * Method to build the pattern.
+		 * Method to build the Video
 		 *
 		 * @memberof OSFramework.Patterns.Video.Video
 		 */

--- a/src/scripts/OSFramework/OSUI/Pattern/Video/VideoConfig.ts
+++ b/src/scripts/OSFramework/OSUI/Pattern/Video/VideoConfig.ts
@@ -1,8 +1,8 @@
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 namespace OSFramework.OSUI.Patterns.Video {
 	/**
-	 *
 	 * Class that represents the custom configurations received by the Video.
+	 *
 	 * @export
 	 * @class VideoConfig
 	 * @extends {AbstractConfiguration}


### PR DESCRIPTION
This PR is to make changeProperty implementation consistent across components. 


### What was done

- **Accordion & Accordion_Item:** Review the change property from that uses the validateDefault and validateCanChange methods before updates. Now this behavior is on the AbstractPattern and AbstractConfigurations.  Applied the correct comments for TypeDocs on TypeScript.
- **BottomSheet:** Review the change property from that uses the validateDefault and validateCanChange methods before updates. Now this behavior is on the AbstractPattern and AbstractConfigurations.  Applied the correct comments for TypeDocs on TypeScript.
- **AnimatedLabel:** Applied the correct comments for TypeDocs on TypeScript.
- **FlipContent:** Review the change property from that uses the validateDefault and validateCanChange methods before updates. Now this behavior is on the AbstractPattern and AbstractConfigurations.  Applied the correct comments for TypeDocs on TypeScript.
- **Gallery:** Changed the action name and descriptions. Applied the correct comments for TypeDocs on TypeScript.
- **Notification:** Review the change property from that uses the validateDefault and validateCanChange methods before updates. Now this behavior is on the AbstractPattern and AbstractConfigurations. Applied the correct comments for TypeDocs on TypeScript.
- **Rating:** Reviewed the change property on OS and apply the correct comments for TypeDocs on TypeScript. 
- **SectionIndex:** Review the change property from that uses the validateDefault and validateCanChange methods before updates. Now this behavior is on the AbstractPattern and AbstractConfigurations. Applied the correct comments for TypeDocs on TypeScript.
- **Sidebar:** Review the change property from that uses the validateDefault and validateCanChange methods before updates. Now this behavior is on the AbstractPattern and AbstractConfigurations. Applied the correct comments for TypeDocs on TypeScript.
- **Tabs:** Reviewed the change property on OS and apply the correct comments for TypeDocs on TypeScript. Review the change property from that uses the validateDefault and validateCanChange methods before updates. Now this behavior is on the AbstractPattern and AbstractConfigurations.

### Checklist
-   [X] tested locally
-   [X] documented the code
-   [X] clean all warnings and errors of eslint
-   [ ] requires changes in OutSystems (if so, provide a module with changes)
-   [ ] requires new sample page in OutSystems (if so, provide a module with changes)
