### PR TITLE
ROU-4446: Fix tooltip inside notification

### DIFF
--- a/dist/OutSystemsUI.js
+++ b/dist/OutSystemsUI.js
@@ -6813,7 +6813,6 @@ var OSFramework;
                         }, this.configs.CloseAfterTime);
                     }
                     _clickCallback(e) {
-                        e.stopPropagation();
                         e.preventDefault();
                         this.hide();
                     }
@@ -9970,24 +9969,24 @@ var OSFramework;
                             }
                             const _isVertical = this.configs.TabsOrientation === OSUI.GlobalEnum.Orientation.Vertical;
                             const _activeElement = this._activeTabHeaderElement.selfElement;
-                            const transformValue = _isVertical
+                            const _transformValue = _isVertical
                                 ? _activeElement.offsetTop
                                 : OutSystems.OSUI.Utils.GetIsRTL()
                                     ? -(this._tabsHeaderElement.offsetWidth - _activeElement.offsetLeft - _activeElement.offsetWidth)
                                     : _activeElement.offsetLeft;
-                            const elementRect = _activeElement.getBoundingClientRect();
-                            const finalScale = _isVertical ? elementRect.height : elementRect.width;
+                            const _elementRect = _activeElement.getBoundingClientRect();
+                            const _finalSize = _isVertical ? _elementRect.height : _elementRect.width;
                             function updateIndicatorUI() {
                                 if (this._tabsIndicatorElement) {
-                                    OSUI.Helper.Dom.Styles.SetStyleAttribute(this._tabsIndicatorElement, Tabs_1.Enum.CssProperty.TabsIndicatorTransform, transformValue + OSUI.GlobalEnum.Units.Pixel);
-                                    OSUI.Helper.Dom.Styles.SetStyleAttribute(this._tabsIndicatorElement, Tabs_1.Enum.CssProperty.TabsIndicatorSize, Math.floor(finalScale) + OSUI.GlobalEnum.Units.Pixel);
+                                    OSUI.Helper.Dom.Styles.SetStyleAttribute(this._tabsIndicatorElement, Tabs_1.Enum.CssProperty.TabsIndicatorTransform, _transformValue + OSUI.GlobalEnum.Units.Pixel);
+                                    OSUI.Helper.Dom.Styles.SetStyleAttribute(this._tabsIndicatorElement, Tabs_1.Enum.CssProperty.TabsIndicatorSize, Math.floor(_finalSize) + OSUI.GlobalEnum.Units.Pixel);
                                 }
                                 else {
                                     cancelAnimationFrame(this._requestAnimationFrameOnIndicatorResize);
                                 }
                             }
                             this._requestAnimationFrameOnIndicatorResize = requestAnimationFrame(updateIndicatorUI.bind(this));
-                            if (isNaN(finalScale) || finalScale === 0) {
+                            if (isNaN(_finalSize) || _finalSize === 0) {
                                 const resizeObserver = new ResizeObserver((entries) => {
                                     for (const entry of entries) {
                                         if (entry.contentBoxSize) {

--- a/src/scripts/OSFramework/OSUI/Pattern/Notification/Notification.ts
+++ b/src/scripts/OSFramework/OSUI/Pattern/Notification/Notification.ts
@@ -49,7 +49,6 @@ namespace OSFramework.OSUI.Patterns.Notification {
 
 		// Trigger the notification at toggle behaviour
 		private _clickCallback(e: MouseEvent): void {
-			e.stopPropagation();
 			e.preventDefault();
 			this.hide();
 		}


### PR DESCRIPTION
This PR is for fixing the closing of the tooltip, when used inside a Notification (with InteractToClose as true). 

The stopPropagation() was preventing the tooltip callback to close it, to get triggered, when the Notification closes, leaving the tooltip still open on the screen

### Checklist

-   [x] tested locally
-   [x] documented the code
-   [x] clean all warnings and errors of eslint
-   [x] requires changes in OutSystems (if so, provide a module with changes)
-   [ ] requires new sample page in OutSystems (if so, provide a module with changes)
