### PR TITLE
ROU-4443: Fix DropdownSearch with empty option pre-selected

### DIFF
--- a/dist/OutSystemsUI.js
+++ b/dist/OutSystemsUI.js
@@ -9970,24 +9970,24 @@ var OSFramework;
                             }
                             const _isVertical = this.configs.TabsOrientation === OSUI.GlobalEnum.Orientation.Vertical;
                             const _activeElement = this._activeTabHeaderElement.selfElement;
-                            const transformValue = _isVertical
+                            const _transformValue = _isVertical
                                 ? _activeElement.offsetTop
                                 : OutSystems.OSUI.Utils.GetIsRTL()
                                     ? -(this._tabsHeaderElement.offsetWidth - _activeElement.offsetLeft - _activeElement.offsetWidth)
                                     : _activeElement.offsetLeft;
-                            const elementRect = _activeElement.getBoundingClientRect();
-                            const finalScale = _isVertical ? elementRect.height : elementRect.width;
+                            const _elementRect = _activeElement.getBoundingClientRect();
+                            const _finalSize = _isVertical ? _elementRect.height : _elementRect.width;
                             function updateIndicatorUI() {
                                 if (this._tabsIndicatorElement) {
-                                    OSUI.Helper.Dom.Styles.SetStyleAttribute(this._tabsIndicatorElement, Tabs_1.Enum.CssProperty.TabsIndicatorTransform, transformValue + OSUI.GlobalEnum.Units.Pixel);
-                                    OSUI.Helper.Dom.Styles.SetStyleAttribute(this._tabsIndicatorElement, Tabs_1.Enum.CssProperty.TabsIndicatorSize, Math.floor(finalScale) + OSUI.GlobalEnum.Units.Pixel);
+                                    OSUI.Helper.Dom.Styles.SetStyleAttribute(this._tabsIndicatorElement, Tabs_1.Enum.CssProperty.TabsIndicatorTransform, _transformValue + OSUI.GlobalEnum.Units.Pixel);
+                                    OSUI.Helper.Dom.Styles.SetStyleAttribute(this._tabsIndicatorElement, Tabs_1.Enum.CssProperty.TabsIndicatorSize, Math.floor(_finalSize) + OSUI.GlobalEnum.Units.Pixel);
                                 }
                                 else {
                                     cancelAnimationFrame(this._requestAnimationFrameOnIndicatorResize);
                                 }
                             }
                             this._requestAnimationFrameOnIndicatorResize = requestAnimationFrame(updateIndicatorUI.bind(this));
-                            if (isNaN(finalScale) || finalScale === 0) {
+                            if (isNaN(_finalSize) || _finalSize === 0) {
                                 const resizeObserver = new ResizeObserver((entries) => {
                                     for (const entry of entries) {
                                         if (entry.contentBoxSize) {

--- a/dist/OutSystemsUI.js
+++ b/dist/OutSystemsUI.js
@@ -19131,11 +19131,15 @@ var Providers;
                             if (((_a = this.StartingSelection) === null || _a === void 0 ? void 0 : _a.length) > 0) {
                                 if (this.AllowMultipleSelection) {
                                     for (const option of this.StartingSelection) {
-                                        selectedKeyvalues.push(option.value);
+                                        if (option.value !== OSFramework.OSUI.Constants.EmptyString) {
+                                            selectedKeyvalues.push(option.value);
+                                        }
                                     }
                                 }
                                 else {
-                                    selectedKeyvalues.push(this.StartingSelection[0].value);
+                                    if (this.StartingSelection[0].value !== '') {
+                                        selectedKeyvalues.push(this.StartingSelection[0].value);
+                                    }
                                 }
                             }
                             return selectedKeyvalues;
@@ -19210,7 +19214,9 @@ var Providers;
                             const selectedKeyvalues = [];
                             if (this.StartingSelection.length > 0) {
                                 for (const option of this.StartingSelection) {
-                                    selectedKeyvalues.push(option.value);
+                                    if (option.value !== OSFramework.OSUI.Constants.EmptyString) {
+                                        selectedKeyvalues.push(option.value);
+                                    }
                                 }
                             }
                             return selectedKeyvalues;

--- a/src/scripts/Providers/OSUI/Dropdown/VirtualSelect/Search/VirtualSelectSearchConfig.ts
+++ b/src/scripts/Providers/OSUI/Dropdown/VirtualSelect/Search/VirtualSelectSearchConfig.ts
@@ -19,18 +19,21 @@ namespace Providers.OSUI.Dropdown.VirtualSelect.Search {
 		 */
 		protected getSelectedValues(): string[] {
 			const selectedKeyvalues = [];
-
 			// Has selected values?
 			if (this.StartingSelection?.length > 0) {
 				// Check if it's multiple options
 				if (this.AllowMultipleSelection) {
 					// Get the selected key value
 					for (const option of this.StartingSelection) {
-						selectedKeyvalues.push(option.value);
+						if (option.value !== OSFramework.OSUI.Constants.EmptyString) {
+							selectedKeyvalues.push(option.value);
+						}
 					}
 				} else {
 					// It's Single option, set only the first given value
-					selectedKeyvalues.push(this.StartingSelection[0].value);
+					if (this.StartingSelection[0].value !== '') {
+						selectedKeyvalues.push(this.StartingSelection[0].value);
+					}
 				}
 			}
 

--- a/src/scripts/Providers/OSUI/Dropdown/VirtualSelect/Tags/VirtualSelectTagsConfig.ts
+++ b/src/scripts/Providers/OSUI/Dropdown/VirtualSelect/Tags/VirtualSelectTagsConfig.ts
@@ -22,7 +22,9 @@ namespace Providers.OSUI.Dropdown.VirtualSelect.Tags {
 			if (this.StartingSelection.length > 0) {
 				// Get the selected key value
 				for (const option of this.StartingSelection) {
-					selectedKeyvalues.push(option.value);
+					if (option.value !== OSFramework.OSUI.Constants.EmptyString) {
+						selectedKeyvalues.push(option.value);
+					}
 				}
 			}
 


### PR DESCRIPTION
This PR is for fixing the DropdownSearch showing all values pre-selected, when the passed StartingSelection was an empty option.

### Checklist

-   [ ] tested locally
-   [ ] documented the code
-   [ ] clean all warnings and errors of eslint
-   [ ] requires changes in OutSystems (if so, provide a module with changes)
-   [ ] requires new sample page in OutSystems (if so, provide a module with changes)
