### PR TITLE
ROU-4410: Add public method VideoJumpToTime

### DIFF
--- a/dist/OutSystemsUI.d.ts
+++ b/dist/OutSystemsUI.d.ts
@@ -3691,6 +3691,7 @@ declare namespace OSFramework.OSUI.Patterns.Video.Enum {
 declare namespace OSFramework.OSUI.Patterns.Video {
     interface IVideo extends Interface.IPattern {
         getVideoState: string;
+        setVideoJumpToTime(time: number): void;
         setVideoPause(): void;
         setVideoPlay(): void;
     }
@@ -3723,6 +3724,7 @@ declare namespace OSFramework.OSUI.Patterns.Video {
         dispose(): void;
         get getVideoState(): string;
         registerCallback(eventName: string, callback: GlobalCallbacks.OSGeneric): void;
+        setVideoJumpToTime(time: number): void;
         setVideoPause(): void;
         setVideoPlay(): void;
     }
@@ -4077,6 +4079,7 @@ declare namespace OutSystems.OSUI.ErrorCodes {
         FailGetState: string;
         FailPause: string;
         FailPlay: string;
+        FailSetTime: string;
     };
     const Legacy: {
         FailAddFavicon_Legacy: string;
@@ -4468,6 +4471,7 @@ declare namespace OutSystems.OSUI.Patterns.VideoAPI {
     function GetState(videoId: string): string;
     function Pause(videoId: string): string;
     function Play(videoId: string): string;
+    function JumpToTime(videoId: string, time: number): string;
 }
 declare namespace OutSystems.OSUI.Utils.Accessibility {
     function SetAccessibilityRole(widgetId: string, role: string): string;

--- a/dist/OutSystemsUI.js
+++ b/dist/OutSystemsUI.js
@@ -11683,6 +11683,9 @@ var OSFramework;
                                 super.registerCallback(eventName, callback);
                         }
                     }
+                    setVideoJumpToTime(time) {
+                        this._videoElement.currentTime = time;
+                    }
                     setVideoPause() {
                         this._videoElement.pause();
                     }
@@ -12111,6 +12114,7 @@ var OutSystems;
                 FailGetState: 'OSUI-API-31004',
                 FailPause: 'OSUI-API-31005',
                 FailPlay: 'OSUI-API-31006',
+                FailSetTime: 'OSUI-API-31007',
             };
             ErrorCodes.Legacy = {
                 FailAddFavicon_Legacy: 'OSUI-LEG-000001',
@@ -15398,6 +15402,17 @@ var OutSystems;
                     return result;
                 }
                 VideoAPI.Play = Play;
+                function JumpToTime(videoId, time) {
+                    const result = OutSystems.OSUI.Utils.CreateApiResponse({
+                        errorCode: OSUI.ErrorCodes.Video.FailSetTime,
+                        callback: () => {
+                            const video = GetVideoById(videoId);
+                            return video.setVideoJumpToTime(time);
+                        },
+                    });
+                    return result;
+                }
+                VideoAPI.JumpToTime = JumpToTime;
             })(VideoAPI = Patterns.VideoAPI || (Patterns.VideoAPI = {}));
         })(Patterns = OSUI.Patterns || (OSUI.Patterns = {}));
     })(OSUI = OutSystems.OSUI || (OutSystems.OSUI = {}));

--- a/src/scripts/OSFramework/OSUI/Pattern/Video/IVideo.ts
+++ b/src/scripts/OSFramework/OSUI/Pattern/Video/IVideo.ts
@@ -17,6 +17,14 @@ namespace OSFramework.OSUI.Patterns.Video {
 		getVideoState: string;
 
 		/**
+		 *  Function that will trigger the set current video time method
+		 *
+		 * @param {number} time value in seconds
+		 * @memberof IVideo
+		 */
+		setVideoJumpToTime(time: number): void;
+
+		/**
 		 * Function that will trigger the pause video method
 		 *
 		 * @memberof IVideo

--- a/src/scripts/OSFramework/OSUI/Pattern/Video/Video.ts
+++ b/src/scripts/OSFramework/OSUI/Pattern/Video/Video.ts
@@ -406,6 +406,16 @@ namespace OSFramework.OSUI.Patterns.Video {
 		}
 
 		/**
+		 * uMethod to set current time
+		 *
+		 * @param {number} time value in seconds
+		 * @memberof Video
+		 */
+		public setVideoJumpToTime(time: number): void {
+			this._videoElement.currentTime = time;
+		}
+
+		/**
 		 * Method to pause video
 		 *
 		 * @memberof OSFramework.Patterns.Video.Video

--- a/src/scripts/OSFramework/OSUI/Pattern/Video/Video.ts
+++ b/src/scripts/OSFramework/OSUI/Pattern/Video/Video.ts
@@ -406,7 +406,7 @@ namespace OSFramework.OSUI.Patterns.Video {
 		}
 
 		/**
-		 * uMethod to set current time
+		 * Method to set current time
 		 *
 		 * @param {number} time value in seconds
 		 * @memberof Video

--- a/src/scripts/OutSystems/OSUI/ErrorCodes.ts
+++ b/src/scripts/OutSystems/OSUI/ErrorCodes.ts
@@ -328,6 +328,7 @@ namespace OutSystems.OSUI.ErrorCodes {
 		FailGetState: 'OSUI-API-31004',
 		FailPause: 'OSUI-API-31005',
 		FailPlay: 'OSUI-API-31006',
+		FailSetTime: 'OSUI-API-31007',
 	};
 
 	// Error Codes used in Legacy Client Action

--- a/src/scripts/OutSystems/OSUI/Patterns/VideoAPI.ts
+++ b/src/scripts/OutSystems/OSUI/Patterns/VideoAPI.ts
@@ -189,4 +189,17 @@ namespace OutSystems.OSUI.Patterns.VideoAPI {
 
 		return result;
 	}
+
+	export function JumpToTime(videoId: string, time: number): string {
+		const result = OutSystems.OSUI.Utils.CreateApiResponse({
+			errorCode: ErrorCodes.Video.FailSetTime,
+			callback: () => {
+				const video = GetVideoById(videoId);
+
+				return video.setVideoJumpToTime(time);
+			},
+		});
+
+		return result;
+	}
 }

--- a/src/scripts/OutSystems/OSUI/Patterns/VideoAPI.ts
+++ b/src/scripts/OutSystems/OSUI/Patterns/VideoAPI.ts
@@ -171,8 +171,8 @@ namespace OutSystems.OSUI.Patterns.VideoAPI {
 	}
 
 	/**
-	 *
 	 * Function that play video on a given video
+	 *
 	 * @export
 	 * @param {string} videoId
 	 * @return {*}  {string}
@@ -190,6 +190,14 @@ namespace OutSystems.OSUI.Patterns.VideoAPI {
 		return result;
 	}
 
+	/**
+	 * Function that jump to a specific time on a given video
+	 *
+	 * @export
+	 * @param {string} videoId
+	 * @param {number} time
+	 * @return {*}  {string}
+	 */
 	export function JumpToTime(videoId: string, time: number): string {
 		const result = OutSystems.OSUI.Utils.CreateApiResponse({
 			errorCode: ErrorCodes.Video.FailSetTime,

--- a/src/scripts/OutSystems/OSUI/Patterns/VideoAPI.ts
+++ b/src/scripts/OutSystems/OSUI/Patterns/VideoAPI.ts
@@ -204,7 +204,7 @@ namespace OutSystems.OSUI.Patterns.VideoAPI {
 			callback: () => {
 				const video = GetVideoById(videoId);
 
-				return video.setVideoJumpToTime(time);
+				video.setVideoJumpToTime(time);
 			},
 		});
 


### PR DESCRIPTION
This PR is for adding the new feature to Video to jump to a specific time of a video.

### What was done
- A new client action called VideoJumpToTime was added to give the ability to jump to a specific time of a given video.
![image](https://github.com/OutSystems/outsystems-ui/assets/25321845/f260dca5-29f9-492c-ad98-7c52b078d7ce)

### Test Steps
**Test Case 1**
1. Go to Sample Page
2. Click on Jump To Time Video Button
3. Expected: The video will change the seconds to 6 and the Infor box will have "Code = 200 ; Message = Success; VideoJumpToTime value is equal to VideoCurrentTime: True; CurrentTime: 6"

**Test Case 2**
1. Go to Sample Page
2. Click on Jump To Time Video - Error Button
3. Expected: The video action error will be triggered

### Checklist
-   [X] tested locally
-   [X] documented the code
-   [X] clean all warnings and errors of eslint
-   [ ] requires changes in OutSystems (if so, provide a module with changes)
-   [ ] requires new sample page in OutSystems (if so, provide a module with changes)
