### PR TITLE
Video: Change the time type to be applied on VideoJumpTime

### DIFF
--- a/dist/OutSystemsUI.d.ts
+++ b/dist/OutSystemsUI.d.ts
@@ -3692,11 +3692,15 @@ declare namespace OSFramework.OSUI.Patterns.Video.Enum {
         Width = "width",
         Muted = "muted"
     }
+    enum VideoTime {
+        Hour = 60,
+        Minute = 60
+    }
 }
 declare namespace OSFramework.OSUI.Patterns.Video {
     interface IVideo extends Interface.IPattern {
         getVideoState: string;
-        setVideoJumpToTime(time: number): void;
+        setVideoJumpToTime(time: string): void;
         setVideoPause(): void;
         setVideoPlay(): void;
     }
@@ -3705,6 +3709,7 @@ declare namespace OSFramework.OSUI.Patterns.Video {
     class Video extends AbstractPattern<VideoConfig> implements IVideo {
         private _platformEventOnStateChanged;
         private _videoElement;
+        private _videoJumpTime;
         private _videoSourceElement;
         private _videoState;
         constructor(uniqueId: string, configs: JSON);
@@ -3729,7 +3734,7 @@ declare namespace OSFramework.OSUI.Patterns.Video {
         dispose(): void;
         get getVideoState(): string;
         registerCallback(eventName: string, callback: GlobalCallbacks.OSGeneric): void;
-        setVideoJumpToTime(time: number): void;
+        setVideoJumpToTime(time: string): void;
         setVideoPause(): void;
         setVideoPlay(): void;
     }
@@ -4476,7 +4481,7 @@ declare namespace OutSystems.OSUI.Patterns.VideoAPI {
     function GetState(videoId: string): string;
     function Pause(videoId: string): string;
     function Play(videoId: string): string;
-    function JumpToTime(videoId: string, time: number): string;
+    function JumpToTime(videoId: string, time: string): string;
 }
 declare namespace OutSystems.OSUI.Utils.Accessibility {
     function SetAccessibilityRole(widgetId: string, role: string): string;

--- a/dist/OutSystemsUI.d.ts
+++ b/dist/OutSystemsUI.d.ts
@@ -471,6 +471,10 @@ declare namespace OSFramework.OSUI.GlobalEnum {
         ParserError = "parsererror",
         SVG = "svg"
     }
+    enum Time {
+        HourInSeconds = 3600,
+        MinuteInSeconds = 60
+    }
 }
 declare namespace OSFramework.OSUI.Behaviors {
     type SpringAnimationProperties = {
@@ -1096,6 +1100,7 @@ declare namespace OSFramework.OSUI.Helper {
 }
 declare namespace OSFramework.OSUI.Helper {
     abstract class Times {
+        static ConvertInSeconds(time: Date): number;
         static IsNull(time: string): boolean;
     }
 }
@@ -3692,15 +3697,11 @@ declare namespace OSFramework.OSUI.Patterns.Video.Enum {
         Width = "width",
         Muted = "muted"
     }
-    enum VideoTime {
-        Hour = 60,
-        Minute = 60
-    }
 }
 declare namespace OSFramework.OSUI.Patterns.Video {
     interface IVideo extends Interface.IPattern {
         getVideoState: string;
-        setVideoJumpToTime(time: string): void;
+        setVideoJumpToTime(currentTime: number): void;
         setVideoPause(): void;
         setVideoPlay(): void;
     }
@@ -3734,7 +3735,7 @@ declare namespace OSFramework.OSUI.Patterns.Video {
         dispose(): void;
         get getVideoState(): string;
         registerCallback(eventName: string, callback: GlobalCallbacks.OSGeneric): void;
-        setVideoJumpToTime(time: string): void;
+        setVideoJumpToTime(currentTime: number): void;
         setVideoPause(): void;
         setVideoPlay(): void;
     }
@@ -4481,7 +4482,7 @@ declare namespace OutSystems.OSUI.Patterns.VideoAPI {
     function GetState(videoId: string): string;
     function Pause(videoId: string): string;
     function Play(videoId: string): string;
-    function JumpToTime(videoId: string, time: string): string;
+    function JumpToTime(videoId: string, currentTime: number): string;
 }
 declare namespace OutSystems.OSUI.Utils.Accessibility {
     function SetAccessibilityRole(widgetId: string, role: string): string;

--- a/dist/OutSystemsUI.js
+++ b/dist/OutSystemsUI.js
@@ -567,6 +567,11 @@ var OSFramework;
                 SVGHelperConstants["ParserError"] = "parsererror";
                 SVGHelperConstants["SVG"] = "svg";
             })(SVGHelperConstants = GlobalEnum.SVGHelperConstants || (GlobalEnum.SVGHelperConstants = {}));
+            let Time;
+            (function (Time) {
+                Time[Time["HourInSeconds"] = 3600] = "HourInSeconds";
+                Time[Time["MinuteInSeconds"] = 60] = "MinuteInSeconds";
+            })(Time = GlobalEnum.Time || (GlobalEnum.Time = {}));
         })(GlobalEnum = OSUI.GlobalEnum || (OSUI.GlobalEnum = {}));
     })(OSUI = OSFramework.OSUI || (OSFramework.OSUI = {}));
 })(OSFramework || (OSFramework = {}));
@@ -3076,6 +3081,11 @@ var OSFramework;
         var Helper;
         (function (Helper) {
             class Times {
+                static ConvertInSeconds(time) {
+                    return (time.getHours() * OSUI.GlobalEnum.Time.HourInSeconds +
+                        time.getMinutes() * OSUI.GlobalEnum.Time.MinuteInSeconds +
+                        time.getSeconds());
+                }
                 static IsNull(time) {
                     if (isNaN(Date.parse(time))) {
                         if (typeof time === OSUI.Constants.JavaScriptTypes.String) {
@@ -11505,11 +11515,6 @@ var OSFramework;
                         VideoAttributes["Width"] = "width";
                         VideoAttributes["Muted"] = "muted";
                     })(VideoAttributes = Enum.VideoAttributes || (Enum.VideoAttributes = {}));
-                    let VideoTime;
-                    (function (VideoTime) {
-                        VideoTime[VideoTime["Hour"] = 60] = "Hour";
-                        VideoTime[VideoTime["Minute"] = 60] = "Minute";
-                    })(VideoTime = Enum.VideoTime || (Enum.VideoTime = {}));
                 })(Enum = Video.Enum || (Video.Enum = {}));
             })(Video = Patterns.Video || (Patterns.Video = {}));
         })(Patterns = OSUI.Patterns || (OSUI.Patterns = {}));
@@ -11696,12 +11701,8 @@ var OSFramework;
                                 super.registerCallback(eventName, callback);
                         }
                     }
-                    setVideoJumpToTime(time) {
-                        const jumpToTime = time.split(':');
-                        const timeInSeconds = +jumpToTime[0] * Video_1.Enum.VideoTime.Hour * Video_1.Enum.VideoTime.Minute +
-                            +jumpToTime[1] * Video_1.Enum.VideoTime.Minute +
-                            +jumpToTime[2];
-                        this._videoElement.currentTime = timeInSeconds;
+                    setVideoJumpToTime(currentTime) {
+                        this._videoElement.currentTime = currentTime;
                     }
                     setVideoPause() {
                         this._videoElement.pause();
@@ -15419,12 +15420,12 @@ var OutSystems;
                     return result;
                 }
                 VideoAPI.Play = Play;
-                function JumpToTime(videoId, time) {
+                function JumpToTime(videoId, currentTime) {
                     const result = OutSystems.OSUI.Utils.CreateApiResponse({
                         errorCode: OSUI.ErrorCodes.Video.FailSetTime,
                         callback: () => {
                             const video = GetVideoById(videoId);
-                            video.setVideoJumpToTime(time);
+                            video.setVideoJumpToTime(currentTime);
                         },
                     });
                     return result;

--- a/dist/OutSystemsUI.js
+++ b/dist/OutSystemsUI.js
@@ -11505,6 +11505,11 @@ var OSFramework;
                         VideoAttributes["Width"] = "width";
                         VideoAttributes["Muted"] = "muted";
                     })(VideoAttributes = Enum.VideoAttributes || (Enum.VideoAttributes = {}));
+                    let VideoTime;
+                    (function (VideoTime) {
+                        VideoTime[VideoTime["Hour"] = 60] = "Hour";
+                        VideoTime[VideoTime["Minute"] = 60] = "Minute";
+                    })(VideoTime = Enum.VideoTime || (Enum.VideoTime = {}));
                 })(Enum = Video.Enum || (Video.Enum = {}));
             })(Video = Patterns.Video || (Patterns.Video = {}));
         })(Patterns = OSUI.Patterns || (OSUI.Patterns = {}));
@@ -11692,7 +11697,11 @@ var OSFramework;
                         }
                     }
                     setVideoJumpToTime(time) {
-                        this._videoElement.currentTime = time;
+                        const jumpToTime = time.split(':');
+                        const timeInSeconds = +jumpToTime[0] * Video_1.Enum.VideoTime.Hour * Video_1.Enum.VideoTime.Minute +
+                            +jumpToTime[1] * Video_1.Enum.VideoTime.Minute +
+                            +jumpToTime[2];
+                        this._videoElement.currentTime = timeInSeconds;
                     }
                     setVideoPause() {
                         this._videoElement.pause();
@@ -15415,7 +15424,7 @@ var OutSystems;
                         errorCode: OSUI.ErrorCodes.Video.FailSetTime,
                         callback: () => {
                             const video = GetVideoById(videoId);
-                            return video.setVideoJumpToTime(time);
+                            video.setVideoJumpToTime(time);
                         },
                     });
                     return result;
@@ -19160,7 +19169,7 @@ var Providers;
                                     }
                                 }
                                 else {
-                                    if (this.StartingSelection[0].value !== '') {
+                                    if (this.StartingSelection[0].value !== OSFramework.OSUI.Constants.EmptyString) {
                                         selectedKeyvalues.push(this.StartingSelection[0].value);
                                     }
                                 }

--- a/src/scripts/OSFramework/OSUI/GlobalEnum.ts
+++ b/src/scripts/OSFramework/OSUI/GlobalEnum.ts
@@ -427,4 +427,9 @@ namespace OSFramework.OSUI.GlobalEnum {
 		ParserError = 'parsererror',
 		SVG = 'svg',
 	}
+
+	export enum Time {
+		HourInSeconds = 3600,
+		MinuteInSeconds = 60,
+	}
 }

--- a/src/scripts/OSFramework/OSUI/Helper/Times.ts
+++ b/src/scripts/OSFramework/OSUI/Helper/Times.ts
@@ -2,6 +2,25 @@
 namespace OSFramework.OSUI.Helper {
 	export abstract class Times {
 		/**
+		 * Function used to convert a time in seconds
+		 *
+		 * @static
+		 * @param {string} time
+		 * @return {*}  {number}
+		 * @memberof Times
+		 */
+		public static ConvertInSeconds(time: Date): number {
+			// Convert the time provided into seconds
+			return (
+				// To get the total seconds of hours and minutes, the hour needs to be multiplied for the number of minutes
+				// and the minutes needs to multiply for the number of seconds
+				time.getHours() * GlobalEnum.Time.HourInSeconds +
+				time.getMinutes() * GlobalEnum.Time.MinuteInSeconds +
+				time.getSeconds()
+			);
+		}
+
+		/**
 		 * Function used to check if a given time is an OutSystems nullDate
 		 *
 		 * @export

--- a/src/scripts/OSFramework/OSUI/Pattern/Video/Enum.ts
+++ b/src/scripts/OSFramework/OSUI/Pattern/Video/Enum.ts
@@ -58,4 +58,9 @@ namespace OSFramework.OSUI.Patterns.Video.Enum {
 		Width = 'width',
 		Muted = 'muted',
 	}
+
+	export enum VideoTime {
+		Hour = 60, // 60 minutes
+		Minute = 60, // 60 seconds
+	}
 }

--- a/src/scripts/OSFramework/OSUI/Pattern/Video/Enum.ts
+++ b/src/scripts/OSFramework/OSUI/Pattern/Video/Enum.ts
@@ -58,9 +58,4 @@ namespace OSFramework.OSUI.Patterns.Video.Enum {
 		Width = 'width',
 		Muted = 'muted',
 	}
-
-	export enum VideoTime {
-		Hour = 60, // 60 minutes
-		Minute = 60, // 60 seconds
-	}
 }

--- a/src/scripts/OSFramework/OSUI/Pattern/Video/IVideo.ts
+++ b/src/scripts/OSFramework/OSUI/Pattern/Video/IVideo.ts
@@ -19,10 +19,10 @@ namespace OSFramework.OSUI.Patterns.Video {
 		/**
 		 *  Function that will trigger the set current video time method
 		 *
-		 * @param {number} time value in seconds
+		 * @param {number} currentTime value in seconds
 		 * @memberof IVideo
 		 */
-		setVideoJumpToTime(time: string): void;
+		setVideoJumpToTime(currentTime: number): void;
 
 		/**
 		 * Function that will trigger the pause video method

--- a/src/scripts/OSFramework/OSUI/Pattern/Video/IVideo.ts
+++ b/src/scripts/OSFramework/OSUI/Pattern/Video/IVideo.ts
@@ -22,7 +22,7 @@ namespace OSFramework.OSUI.Patterns.Video {
 		 * @param {number} time value in seconds
 		 * @memberof IVideo
 		 */
-		setVideoJumpToTime(time: number): void;
+		setVideoJumpToTime(time: string): void;
 
 		/**
 		 * Function that will trigger the pause video method

--- a/src/scripts/OSFramework/OSUI/Pattern/Video/Video.ts
+++ b/src/scripts/OSFramework/OSUI/Pattern/Video/Video.ts
@@ -13,6 +13,8 @@ namespace OSFramework.OSUI.Patterns.Video {
 		private _platformEventOnStateChanged: Callbacks.OSOnStateChangedEvent;
 		// Store the video element
 		private _videoElement: HTMLVideoElement;
+		// Store the value for video to jump into a specific time
+		private _videoJumpTime: number;
 		// Store the source element
 		private _videoSourceElement: HTMLSourceElement;
 		// Store the current video state
@@ -411,8 +413,14 @@ namespace OSFramework.OSUI.Patterns.Video {
 		 * @param {number} time value in seconds
 		 * @memberof Video
 		 */
-		public setVideoJumpToTime(time: number): void {
-			this._videoElement.currentTime = time;
+		public setVideoJumpToTime(time: string): void {
+			const jumpToTime = time.split(':');
+			// Convert the time provided into seconds
+			const timeInSeconds =
+				+jumpToTime[0] * Enum.VideoTime.Hour * Enum.VideoTime.Minute +
+				+jumpToTime[1] * Enum.VideoTime.Minute +
+				+jumpToTime[2];
+			this._videoElement.currentTime = timeInSeconds;
 		}
 
 		/**

--- a/src/scripts/OSFramework/OSUI/Pattern/Video/Video.ts
+++ b/src/scripts/OSFramework/OSUI/Pattern/Video/Video.ts
@@ -410,17 +410,11 @@ namespace OSFramework.OSUI.Patterns.Video {
 		/**
 		 * Method to set current time
 		 *
-		 * @param {number} time value in seconds
+		 * @param {number} currentTime value in seconds
 		 * @memberof Video
 		 */
-		public setVideoJumpToTime(time: string): void {
-			const jumpToTime = time.split(':');
-			// Convert the time provided into seconds
-			const timeInSeconds =
-				+jumpToTime[0] * Enum.VideoTime.Hour * Enum.VideoTime.Minute +
-				+jumpToTime[1] * Enum.VideoTime.Minute +
-				+jumpToTime[2];
-			this._videoElement.currentTime = timeInSeconds;
+		public setVideoJumpToTime(currentTime: number): void {
+			this._videoElement.currentTime = currentTime;
 		}
 
 		/**

--- a/src/scripts/OutSystems/OSUI/Patterns/VideoAPI.ts
+++ b/src/scripts/OutSystems/OSUI/Patterns/VideoAPI.ts
@@ -198,7 +198,7 @@ namespace OutSystems.OSUI.Patterns.VideoAPI {
 	 * @param {number} time
 	 * @return {*}  {string}
 	 */
-	export function JumpToTime(videoId: string, time: number): string {
+	export function JumpToTime(videoId: string, time: string): string {
 		const result = OutSystems.OSUI.Utils.CreateApiResponse({
 			errorCode: ErrorCodes.Video.FailSetTime,
 			callback: () => {

--- a/src/scripts/OutSystems/OSUI/Patterns/VideoAPI.ts
+++ b/src/scripts/OutSystems/OSUI/Patterns/VideoAPI.ts
@@ -195,16 +195,16 @@ namespace OutSystems.OSUI.Patterns.VideoAPI {
 	 *
 	 * @export
 	 * @param {string} videoId
-	 * @param {number} time
+	 * @param {number} currentTime
 	 * @return {*}  {string}
 	 */
-	export function JumpToTime(videoId: string, time: string): string {
+	export function JumpToTime(videoId: string, currentTime: number): string {
 		const result = OutSystems.OSUI.Utils.CreateApiResponse({
 			errorCode: ErrorCodes.Video.FailSetTime,
 			callback: () => {
 				const video = GetVideoById(videoId);
 
-				video.setVideoJumpToTime(time);
+				video.setVideoJumpToTime(currentTime);
 			},
 		});
 


### PR DESCRIPTION
This PR is for changing the behavior of applying time in VideoJumpToTime. Now the the time is defined as time and we convert the value into seconds to apply on video.

### What was done
- Now the the time is defined as time and we convert the value into seconds to apply on video.

### Checklist
-   [X] tested locally
-   [X] documented the code
-   [X] clean all warnings and errors of eslint
-   [ ] requires changes in OutSystems (if so, provide a module with changes)
-   [ ] requires new sample page in OutSystems (if so, provide a module with changes)
