### PR TITLE
ROU-4482: Fixed SS preview of input on time-related pickers

### DIFF
--- a/src/scripts/OSFramework/OSUI/Pattern/DatePicker/scss/_datepicker.scss
+++ b/src/scripts/OSFramework/OSUI/Pattern/DatePicker/scss/_datepicker.scss
@@ -27,6 +27,10 @@
 		// Hide the platform input which is set as hidden by the library and we're change it into the expected type, however we do not want it visible since library will add a clone to better deal with the selected dates.
 		&:first-of-type {
 			display: none !important;
+			// Make the platform input visible in Service Studio
+			& {
+				-servicestudio-display: inline-flex !important;
+			}
 		}
 
 		// Disable states for Datepicker

--- a/src/scripts/OSFramework/OSUI/Pattern/MonthPicker/scss/_monthpicker.scss
+++ b/src/scripts/OSFramework/OSUI/Pattern/MonthPicker/scss/_monthpicker.scss
@@ -49,6 +49,10 @@
 		// Hide the platform input which is set as hidden by the library and we're change it into the expected type, however we do not want it visible since library will add a clone to better deal with the selected dates.
 		&:first-of-type {
 			display: none !important;
+			// Make the platform input visible in Service Studio
+			& {
+				-servicestudio-display: inline-flex !important;
+			}
 		}
 
 		// Disable states for Datepicker

--- a/src/scripts/OSFramework/OSUI/Pattern/TimePicker/scss/_timepicker.scss
+++ b/src/scripts/OSFramework/OSUI/Pattern/TimePicker/scss/_timepicker.scss
@@ -50,7 +50,7 @@
 		// Service Studio Preview
 		& {
 			-servicestudio-background-color: transparent;
-			-servicestudio-background-position: top center;
+			-servicestudio-background-position: top left;
 			-servicestudio-background-repeat: no-repeat;
 			-servicestudio-background-size: contain;
 			-servicestudio-border-radius: var(--border-radius-soft);

--- a/src/scripts/OSFramework/OSUI/Pattern/TimePicker/scss/_timepicker.scss
+++ b/src/scripts/OSFramework/OSUI/Pattern/TimePicker/scss/_timepicker.scss
@@ -27,6 +27,10 @@
 		// Hide the platform input which is set as hidden by the library and we're change it into the expected type, however we do not want it visible since library will add a clone to better deal with the selected dates.
 		&:first-of-type {
 			display: none !important;
+			// Make the platform input visible in Service Studio
+			& {
+				-servicestudio-display: inline-flex !important;
+			}
 		}
 
 		// Disable states for Datepicker


### PR DESCRIPTION
This PR is to fix the Service Studio preview of input on time-related pickers

### What was happening

- The platform input was not visible in design time.

### What was done

- Added a CSS _-servicestudio-_ rule to make it visible in the Service Studio

### Test Steps

1. Open the module containing all pickers.
2. Check that the input is now visible in the Design time
3. Open the page in runtime and check that everything is working as before

### Screenshots

- Before:
![image](https://github.com/OutSystems/outsystems-ui/assets/29493222/709001fe-e006-4648-b5bb-ad901173fa9f)

- After the fix:
![image](https://github.com/OutSystems/outsystems-ui/assets/29493222/78b3e9f7-4bfc-4be5-8378-b9d4c39c2bfb)


### Checklist

-   [X] tested locally
-   [X] documented the code
-   [X] clean all warnings and errors of eslint
-   [ ] requires changes in OutSystems (if so, provide a module with changes)
-   [ ] requires new sample page in OutSystems (if so, provide a module with changes)
