### PR TITLE
ROU-4348: Add aria-label to the ProgressBar/Circle when empty content

### DIFF
--- a/dist/OutSystemsUI.d.ts
+++ b/dist/OutSystemsUI.d.ts
@@ -2487,7 +2487,7 @@ declare namespace OSFramework.OSUI.Patterns.OverflowMenu {
 declare namespace OSFramework.OSUI.Patterns.Progress {
     abstract class AbstractProgress<C extends ProgressConfiguration> extends AbstractPattern<C> implements IProgress {
         private _eventAnimateEntranceEnd;
-        protected contentElemId: string;
+        protected contentElem: HTMLElement;
         protected gradientLength: number;
         protected progressElem: HTMLElement;
         protected progressType: ProgressEnum.ProgressTypes;
@@ -2529,6 +2529,9 @@ declare namespace OSFramework.OSUI.Patterns.Progress {
     }
 }
 declare namespace OSFramework.OSUI.Patterns.Progress.ProgressEnum {
+    enum AriaLabel {
+        Progress = "progress"
+    }
     enum CssClass {
         AddInitialAnimation = "animate-entrance",
         AnimateProgressChange = "animate-progress-change",

--- a/dist/OutSystemsUI.js
+++ b/dist/OutSystemsUI.js
@@ -7392,7 +7392,6 @@ var OSFramework;
                 class AbstractProgress extends Patterns.AbstractPattern {
                     constructor(uniqueId, configs) {
                         super(uniqueId, configs);
-                        this.contentElemId = '';
                     }
                     _animateEntranceEnd() {
                         this.progressElem.removeEventListener(OSUI.GlobalEnum.HTMLEvent.TransitionEnd, this._eventAnimateEntranceEnd);
@@ -7421,6 +7420,7 @@ var OSFramework;
                     }
                     unsetHtmlElements() {
                         this.progressElem = undefined;
+                        this.contentElem = undefined;
                     }
                     updatedProgressValue() {
                         if (this.configs.Progress < Progress.ProgressEnum.Properties.MinProgressValue) {
@@ -7488,6 +7488,10 @@ var OSFramework;
             (function (Progress) {
                 var ProgressEnum;
                 (function (ProgressEnum) {
+                    let AriaLabel;
+                    (function (AriaLabel) {
+                        AriaLabel["Progress"] = "progress";
+                    })(AriaLabel = ProgressEnum.AriaLabel || (ProgressEnum.AriaLabel = {}));
                     let CssClass;
                     (function (CssClass) {
                         CssClass["AddInitialAnimation"] = "animate-entrance";
@@ -7611,7 +7615,10 @@ var OSFramework;
                             this.updatedProgressValue();
                         }
                         setA11YProperties() {
-                            OSUI.Helper.A11Y.AriaLabelledBy(this.selfElement, this.contentElemId);
+                            if (this.contentElem.innerHTML)
+                                OSUI.Helper.A11Y.AriaLabelledBy(this.selfElement, this.contentElem.id);
+                            else
+                                OSUI.Helper.A11Y.AriaLabel(this.selfElement, Progress.ProgressEnum.AriaLabel.Progress);
                         }
                         setCallbacks() {
                             super.setCallbacks();
@@ -7623,7 +7630,7 @@ var OSFramework;
                         }
                         setHtmlElements() {
                             this.progressElem = this.selfElement.querySelector(OSUI.Constants.Dot + Progress.ProgressEnum.CssClass.Container);
-                            this.contentElemId = this.selfElement.querySelector(OSUI.Constants.Dot + Progress.ProgressEnum.CssClass.ProgressBarContent).id;
+                            this.contentElem = this.selfElement.querySelector(OSUI.Constants.Dot + Progress.ProgressEnum.CssClass.ProgressBarContent);
                         }
                         unsetCallbacks() {
                             super.unsetCallbacks();
@@ -7890,7 +7897,10 @@ var OSFramework;
                             }
                         }
                         setA11YProperties() {
-                            OSUI.Helper.A11Y.AriaLabelledBy(this.selfElement, this.contentElemId);
+                            if (this.contentElem.innerHTML)
+                                OSUI.Helper.A11Y.AriaLabelledBy(this.selfElement, this.contentElem.id);
+                            else
+                                OSUI.Helper.A11Y.AriaLabel(this.selfElement, Progress.ProgressEnum.AriaLabel.Progress);
                         }
                         setCallbacks() {
                             super.setCallbacks();
@@ -7904,7 +7914,7 @@ var OSFramework;
                         setHtmlElements() {
                             this._blockParent = document.getElementById(this.widgetId).parentElement;
                             this.progressElem = this.selfElement.querySelector(OSUI.Constants.Dot + Circle_1.Enum.CssClass.Progress);
-                            this.contentElemId = this.selfElement.querySelector(OSUI.Constants.Dot + Progress.ProgressEnum.CssClass.ProgressCircleContent).id;
+                            this.contentElem = this.selfElement.querySelector(OSUI.Constants.Dot + Progress.ProgressEnum.CssClass.ProgressCircleContent);
                             if (this.isBuilt) {
                                 this._gradientElem = this.progressElem.parentElement.querySelector('defs');
                             }

--- a/src/scripts/OSFramework/OSUI/Pattern/Progress/AbstractProgress.ts
+++ b/src/scripts/OSFramework/OSUI/Pattern/Progress/AbstractProgress.ts
@@ -5,7 +5,7 @@ namespace OSFramework.OSUI.Patterns.Progress {
 		implements IProgress
 	{
 		private _eventAnimateEntranceEnd: GlobalCallbacks.Generic;
-		protected contentElemId = Constants.EmptyString;
+		protected contentElem: HTMLElement;
 		protected gradientLength: number;
 		protected progressElem: HTMLElement;
 		protected progressType: ProgressEnum.ProgressTypes;
@@ -102,7 +102,7 @@ namespace OSFramework.OSUI.Patterns.Progress {
 		 */
 		protected unsetHtmlElements(): void {
 			this.progressElem = undefined;
-			this.contentElemId = Constants.EmptyString;
+			this.contentElem = undefined;
 		}
 
 		/**

--- a/src/scripts/OSFramework/OSUI/Pattern/Progress/Bar/ProgressBar.ts
+++ b/src/scripts/OSFramework/OSUI/Pattern/Progress/Bar/ProgressBar.ts
@@ -95,7 +95,8 @@ namespace OSFramework.OSUI.Patterns.Progress.Bar {
 		 * @memberof OSFramework.Patterns.Progress.Bar.Bar
 		 */
 		protected setA11YProperties(): void {
-			Helper.A11Y.AriaLabelledBy(this.selfElement, this.contentElemId);
+			if (this.contentElem.innerHTML) Helper.A11Y.AriaLabelledBy(this.selfElement, this.contentElem.id);
+			else Helper.A11Y.AriaLabel(this.selfElement, ProgressEnum.AriaLabel.Progress);
 		}
 
 		/**
@@ -133,10 +134,10 @@ namespace OSFramework.OSUI.Patterns.Progress.Bar {
 		protected setHtmlElements(): void {
 			// Set the html references that will be used to manage the cssClasses and atribute properties
 			this.progressElem = this.selfElement.querySelector(Constants.Dot + ProgressEnum.CssClass.Container);
-			// Set Progress Circle content element id
-			this.contentElemId = this.selfElement.querySelector(
+			// Set Progress Circle content element
+			this.contentElem = this.selfElement.querySelector(
 				OSUI.Constants.Dot + Progress.ProgressEnum.CssClass.ProgressBarContent
-			).id;
+			);
 		}
 
 		/**

--- a/src/scripts/OSFramework/OSUI/Pattern/Progress/Circle/ProgressCircle.ts
+++ b/src/scripts/OSFramework/OSUI/Pattern/Progress/Circle/ProgressCircle.ts
@@ -249,7 +249,8 @@ namespace OSFramework.OSUI.Patterns.Progress.Circle {
 		 * @memberof OSFramework.Patterns.Progress.Circle.Circle
 		 */
 		protected setA11YProperties(): void {
-			Helper.A11Y.AriaLabelledBy(this.selfElement, this.contentElemId);
+			if (this.contentElem.innerHTML) Helper.A11Y.AriaLabelledBy(this.selfElement, this.contentElem.id);
+			else Helper.A11Y.AriaLabel(this.selfElement, ProgressEnum.AriaLabel.Progress);
 		}
 
 		/**
@@ -290,9 +291,9 @@ namespace OSFramework.OSUI.Patterns.Progress.Circle {
 			// Set the html reference that will be used to do all the needed calcs
 			this.progressElem = this.selfElement.querySelector(Constants.Dot + Enum.CssClass.Progress);
 			// Set Progress Bar content element id
-			this.contentElemId = this.selfElement.querySelector(
+			this.contentElem = this.selfElement.querySelector(
 				OSUI.Constants.Dot + Progress.ProgressEnum.CssClass.ProgressCircleContent
-			).id;
+			);
 			// Set the <defs> element when using a svg gradient. Only after built, as the gradient is only available through Client Action
 			if (this.isBuilt) {
 				this._gradientElem = this.progressElem.parentElement.querySelector('defs');

--- a/src/scripts/OSFramework/OSUI/Pattern/Progress/ProgressEnum.ts
+++ b/src/scripts/OSFramework/OSUI/Pattern/Progress/ProgressEnum.ts
@@ -1,6 +1,12 @@
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 namespace OSFramework.OSUI.Patterns.Progress.ProgressEnum {
 	/**
+	 * Progress Enum AriaLabel
+	 */
+	export enum AriaLabel {
+		Progress = 'progress',
+	}
+	/**
 	 * Progress Enum Common classes
 	 */
 	export enum CssClass {


### PR DESCRIPTION
This PR is for add aria-label to the ProgressBar/Circle when empty content

### What was happening
- Accessibility checkers were indicating an issue when the element referenced in aria-labelledby attribute is not readable.

### What was done
- When the content placeholder contains any element, we replace the aria-label attribute from Progress Bar and Circle with the aria-labelledby referencing the Content id, otherwise, we keep the aria-label attribute.
- If the content inside the Content placeholders is not readable, it is the responsibility of the user to make it accessible.

### Test Steps
1. Go to a page with a Progress Bar or Progress Circle
2. Enable the screen reader
3. Check that the screen reader reads the Progress Bar/Circle percentage, content, and the role "progressbar".

### Checklist

-   [x] tested locally
-   [x] documented the code
-   [x] clean all warnings and errors of eslint
-   [ ] requires changes in OutSystems (if so, provide a module with changes)
-   [ ] requires new sample page in OutSystems (if so, provide a module with changes)
