### PR TITLE
Date, Time and Month pickers fixed issue

### DIFF
--- a/src/scripts/OSFramework/OSUI/Pattern/DatePicker/scss/_datepicker.scss
+++ b/src/scripts/OSFramework/OSUI/Pattern/DatePicker/scss/_datepicker.scss
@@ -24,21 +24,24 @@
 			}
 		}
 
-		// Hide the platform input which is set as hidden by the library and we're change it into the expected type, however we do not want it visible since library will add a clone to better deal with the selected dates.
-		&:first-of-type {
-			display: none !important;
-			// Make the platform input visible in Service Studio
-			& {
-				-servicestudio-display: inline-flex !important;
-			}
-		}
-
 		// Disable states for Datepicker
 		&.flatpickr-input[disabled] + input {
 			background-color: var(--color-neutral-2);
 			border: var(--border-size-s) solid var(--color-neutral-4);
 			color: var(--color-neutral-6);
 			pointer-events: none;
+		}
+	}
+
+	// Hide the platform input which is set as hidden by the library and we're change it into the expected type, however we do not want it visible since library will add a clone to better deal with the selected dates.
+	& > span > input {
+		&:first-of-type {
+			display: none !important;
+
+			// Make the platform input visible in Service Studio
+			& {
+				-servicestudio-display: inline-flex !important;
+			}
 		}
 	}
 

--- a/src/scripts/OSFramework/OSUI/Pattern/MonthPicker/scss/_monthpicker.scss
+++ b/src/scripts/OSFramework/OSUI/Pattern/MonthPicker/scss/_monthpicker.scss
@@ -46,21 +46,24 @@
 	}
 
 	input {
-		// Hide the platform input which is set as hidden by the library and we're change it into the expected type, however we do not want it visible since library will add a clone to better deal with the selected dates.
-		&:first-of-type {
-			display: none !important;
-			// Make the platform input visible in Service Studio
-			& {
-				-servicestudio-display: inline-flex !important;
-			}
-		}
-
 		// Disable states for Datepicker
 		&[disabled] + input {
 			background-color: var(--color-neutral-2);
 			border: var(--border-size-s) solid var(--color-neutral-4);
 			color: var(--color-neutral-6);
 			pointer-events: none;
+		}
+	}
+
+	// Hide the platform input which is set as hidden by the library and we're change it into the expected type, however we do not want it visible since library will add a clone to better deal with the selected dates.
+	& > span > input {
+		&:first-of-type {
+			display: none !important;
+
+			// Make the platform input visible in Service Studio
+			& {
+				-servicestudio-display: inline-flex !important;
+			}
 		}
 	}
 }

--- a/src/scripts/OSFramework/OSUI/Pattern/TimePicker/scss/_timepicker.scss
+++ b/src/scripts/OSFramework/OSUI/Pattern/TimePicker/scss/_timepicker.scss
@@ -24,21 +24,24 @@
 			}
 		}
 
-		// Hide the platform input which is set as hidden by the library and we're change it into the expected type, however we do not want it visible since library will add a clone to better deal with the selected dates.
-		&:first-of-type {
-			display: none !important;
-			// Make the platform input visible in Service Studio
-			& {
-				-servicestudio-display: inline-flex !important;
-			}
-		}
-
 		// Disable states for Datepicker
 		&.flatpickr-input[disabled] + input {
 			background-color: var(--color-neutral-2);
 			border: var(--border-size-s) solid var(--color-neutral-4);
 			color: var(--color-neutral-6);
 			pointer-events: none;
+		}
+	}
+
+	// Hide the platform input which is set as hidden by the library and we're change it into the expected type, however we do not want it visible since library will add a clone to better deal with the selected dates.
+	& > span > input {
+		&:first-of-type {
+			display: none !important;
+
+			// Make the platform input visible in Service Studio
+			& {
+				-servicestudio-display: inline-flex !important;
+			}
 		}
 	}
 


### PR DESCRIPTION
This PR is for fixing an issue at DatePicker, DatePickerRange, TimePicker and MonthPicker when inline = true.
This is a provider attribute that has been set through Extensibility feature and since calendar will be placed at the same context of the input, the selector will also hide all the first-of-type inputs inside it.