### PR TITLE
ROU-4462: Abstraction to focus on the trigger when we close a component (sidebar, notification, etc) 

### DIFF
--- a/dist/OutSystemsUI.css
+++ b/dist/OutSystemsUI.css
@@ -506,7 +506,6 @@ a{
 a, a:visited{
   color:var(--color-primary);
   -webkit-transition:all 180ms linear;
-  -o-transition:all 180ms linear;
   transition:all 180ms linear;
 }
 a:hover, a:focus{
@@ -1104,7 +1103,6 @@ body,
   position:fixed;
   top:0;
   -webkit-transition:opacity 130ms ease-in;
-  -o-transition:opacity 130ms ease-in;
   transition:opacity 130ms ease-in;
   width:100vw;
   will-change:opacity;
@@ -1117,7 +1115,6 @@ body,
   opacity:1;
   pointer-events:auto;
   -webkit-transition:opacity 330ms ease-out;
-  -o-transition:opacity 330ms ease-out;
   transition:opacity 330ms ease-out;
 }
 .layout .app-menu-content{
@@ -1175,7 +1172,6 @@ body,
           transform:translateX(0) translateZ(0);
   -webkit-transition:-webkit-transform 130ms ease-in;
   transition:-webkit-transform 130ms ease-in;
-  -o-transition:transform 130ms ease-in;
   transition:transform 130ms ease-in;
   transition:transform 130ms ease-in, -webkit-transform 130ms ease-in;
   width:var(--side-menu-size);
@@ -1188,7 +1184,6 @@ body,
           transform:translateX(var(--side-menu-size)) translateZ(0);
   -webkit-transition:-webkit-transform 330ms ease-out;
   transition:-webkit-transform 330ms ease-out;
-  -o-transition:transform 330ms ease-out;
   transition:transform 330ms ease-out;
   transition:transform 330ms ease-out, -webkit-transform 330ms ease-out;
 }
@@ -1229,7 +1224,6 @@ body,
   -webkit-transform:translateX(0) translateZ(0);
           transform:translateX(0) translateZ(0);
   -webkit-transition:all 330ms ease-out;
-  -o-transition:all 330ms ease-out;
   transition:all 330ms ease-out;
 }
 /*! 3.6. Layout Native - Menu */
@@ -1312,7 +1306,6 @@ body,
           transform:translateX(0) translateZ(0);
   -webkit-transition:-webkit-transform 130ms ease-in;
   transition:-webkit-transform 130ms ease-in;
-  -o-transition:transform 130ms ease-in;
   transition:transform 130ms ease-in;
   transition:transform 130ms ease-in, -webkit-transform 130ms ease-in;
   width:var(--side-menu-size);
@@ -1324,7 +1317,6 @@ body,
           transform:translateX(var(--side-menu-size)) translateZ(0);
   -webkit-transition:-webkit-transform 330ms ease-out;
   transition:-webkit-transform 330ms ease-out;
-  -o-transition:transform 330ms ease-out;
   transition:transform 330ms ease-out;
   transition:transform 330ms ease-out, -webkit-transform 330ms ease-out;
 }
@@ -1355,7 +1347,6 @@ body,
       -ms-transform:none;
           transform:none;
   -webkit-transition:none;
-  -o-transition:none;
   transition:none;
 }
 .is-rtl.desktop .aside-expandable.menu-visible .main{
@@ -1365,7 +1356,6 @@ body,
 .is-rtl.tablet .app-menu-content, .is-rtl.phone .app-menu-content{
   right:calc(-1 * var(--side-menu-size));
   -webkit-transition:all 330ms ease-out;
-  -o-transition:all 330ms ease-out;
   transition:all 330ms ease-out;
 }
 .is-rtl:not(.portrait) .layout-side.layout-native.aside-visible .app-menu-content{
@@ -1379,7 +1369,6 @@ body,
   -webkit-transform:translateX(0) translateZ(0);
           transform:translateX(0) translateZ(0);
   -webkit-transition:all 330ms ease-out;
-  -o-transition:all 330ms ease-out;
   transition:all 330ms ease-out;
 }
 /*! 3.8. Menu - Header Logo */
@@ -1802,7 +1791,6 @@ body .app-menu-content .app-menu-links{
   color:var(--color-neutral-9);
   font-size:var(--font-size-s);
   -webkit-transition:all 180ms linear;
-  -o-transition:all 180ms linear;
   transition:all 180ms linear;
 }
 .form-control[data-input]:hover, .form-control[data-textarea]:hover{
@@ -1902,7 +1890,6 @@ body .app-menu-content .app-menu-links{
   height:30px;
   opacity:1;
   -webkit-transition:all 180ms linear;
-  -o-transition:all 180ms linear;
   transition:all 180ms linear;
   width:48px;
 }
@@ -1918,7 +1905,6 @@ body .app-menu-content .app-menu-links{
   -webkit-transform:translateX(4px) translateZ(0);
           transform:translateX(4px) translateZ(0);
   -webkit-transition:all 180ms linear;
-  -o-transition:all 180ms linear;
   transition:all 180ms linear;
   width:24px;
 }
@@ -1976,7 +1962,6 @@ body .app-menu-content .app-menu-links{
   height:22px;
   opacity:1;
   -webkit-transition:all 180ms linear;
-  -o-transition:all 180ms linear;
   transition:all 180ms linear;
   width:22px;
 }
@@ -2060,7 +2045,6 @@ body .app-menu-content .app-menu-links{
       -ms-transform:rotate(-45deg) translateY(0) translateX(0);
           transform:rotate(-45deg) translateY(0) translateX(0);
   -webkit-transition:all 300ms ease-in-out;
-  -o-transition:all 300ms ease-in-out;
   transition:all 300ms ease-in-out;
   width:8px;
 }
@@ -2127,8 +2111,7 @@ body .app-menu-content .app-menu-links{
 }
 .dropdown-container .dropdown-popup-row span{
   overflow:hidden;
-  -o-text-overflow:ellipsis;
-     text-overflow:ellipsis;
+  text-overflow:ellipsis;
   white-space:nowrap;
 }
 .dropdown-container .scrollable-list-with-scroll{
@@ -2242,7 +2225,6 @@ select.dropdown-display[disabled]{
   margin:0;
   padding:var(--space-none) var(--space-base);
   -webkit-transition:all 100ms linear;
-  -o-transition:all 100ms linear;
   transition:all 100ms linear;
 }
 .btn:hover:active{
@@ -3030,7 +3012,6 @@ div.feedback-message-warning{
   height:24px;
   position:relative;
   -webkit-transition:all 180ms linear;
-  -o-transition:all 180ms linear;
   transition:all 180ms linear;
   width:24px;
 }
@@ -3048,7 +3029,6 @@ div.feedback-message-warning{
   display:flex;
   height:100%;
   -webkit-transition:all 180ms linear;
-  -o-transition:all 180ms linear;
   transition:all 180ms linear;
   width:100%;
 }
@@ -3376,7 +3356,6 @@ div.feedback-message-warning{
 .flatpickr-months .flatpickr-prev-month svg path,
 .flatpickr-months .flatpickr-next-month svg path{
   -webkit-transition:fill 0.1s;
-  -o-transition:fill 0.1s;
   transition:fill 0.1s;
   fill:inherit;
 }
@@ -4099,7 +4078,6 @@ span.flatpickr-weekday{
   -webkit-transition:transform 0.3s;
   -webkit-transition:-webkit-transform 0.3s;
   transition:-webkit-transform 0.3s;
-  -o-transition:transform 0.3s;
   transition:transform 0.3s;
   transition:transform 0.3s, -webkit-transform 0.3s;
 }
@@ -4539,7 +4517,6 @@ span.flatpickr-weekday{
   position:relative;
   -webkit-transition:-webkit-transform 0.2s linear;
   transition:-webkit-transform 0.2s linear;
-  -o-transition:transform 0.2s linear;
   transition:transform 0.2s linear;
   transition:transform 0.2s linear, -webkit-transform 0.2s linear;
   width:8px;
@@ -4740,8 +4717,7 @@ span.flatpickr-weekday{
   line-height:20px;
   max-width:100%;
   overflow:hidden;
-  -o-text-overflow:ellipsis;
-     text-overflow:ellipsis;
+  text-overflow:ellipsis;
   white-space:nowrap;
 }
 .vscomp-arrow{
@@ -4936,8 +4912,7 @@ span.flatpickr-weekday{
 }
 .vscomp-option-text{
   overflow:hidden;
-  -o-text-overflow:ellipsis;
-     text-overflow:ellipsis;
+  text-overflow:ellipsis;
   white-space:nowrap;
   -webkit-user-select:none;
   -moz-user-select:none;
@@ -4947,8 +4922,7 @@ span.flatpickr-weekday{
 }
 .vscomp-option-description{
   overflow:hidden;
-  -o-text-overflow:ellipsis;
-     text-overflow:ellipsis;
+  text-overflow:ellipsis;
   white-space:nowrap;
   color:#666;
   font-size:13px;
@@ -5065,7 +5039,6 @@ span.flatpickr-weekday{
 }
 .vscomp-wrapper .checkbox-icon::after{
   -webkit-transition-duration:0.2s;
-       -o-transition-duration:0.2s;
           transition-duration:0.2s;
   border:2px solid #888;
   content:"";
@@ -5217,7 +5190,6 @@ span.flatpickr-weekday{
 }
 .vscomp-wrapper.keep-always-open .vscomp-dropbox{
   -webkit-transition-duration:0s;
-       -o-transition-duration:0s;
           transition-duration:0s;
   border:1px solid #ddd;
   -webkit-box-shadow:none;
@@ -5250,14 +5222,12 @@ span.flatpickr-weekday{
   height:auto;
   min-height:28px;
   overflow:auto;
-  -o-text-overflow:unset;
-     text-overflow:unset;
+  text-overflow:unset;
   white-space:normal;
 }
 .vscomp-wrapper.show-value-as-tags .vscomp-value-tag{
   overflow:hidden;
-  -o-text-overflow:ellipsis;
-     text-overflow:ellipsis;
+  text-overflow:ellipsis;
   white-space:nowrap;
   -webkit-box-align:center;
       -ms-flex-align:center;
@@ -5278,8 +5248,7 @@ span.flatpickr-weekday{
 }
 .vscomp-wrapper.show-value-as-tags .vscomp-value-tag-content{
   overflow:hidden;
-  -o-text-overflow:ellipsis;
-     text-overflow:ellipsis;
+  text-overflow:ellipsis;
   white-space:nowrap;
   width:calc(100% - 20px);
 }
@@ -5786,7 +5755,6 @@ span.flatpickr-weekday{
   -webkit-transform:translateX(100%) translateZ(0);
           transform:translateX(100%) translateZ(0);
   -webkit-transition:all 190ms ease-in;
-  -o-transition:all 190ms ease-in;
   transition:all 190ms ease-in;
   width:100%;
   will-change:transform;
@@ -5796,7 +5764,6 @@ span.flatpickr-weekday{
   -webkit-transform:translateX(0) translateZ(0);
           transform:translateX(0) translateZ(0);
   -webkit-transition:all 330ms ease-out;
-  -o-transition:all 330ms ease-out;
   transition:all 330ms ease-out;
 }
 .phone .split-screen-wrapper .split-right{
@@ -5922,7 +5889,6 @@ span.flatpickr-weekday{
   border-color:var(--color-primary);
   opacity:1;
   -webkit-transition:opacity 300ms ease-in;
-  -o-transition:opacity 300ms ease-in;
   transition:opacity 300ms ease-in;
 }
 .osui-accordion-item--is-disabled{
@@ -5950,8 +5916,7 @@ span.flatpickr-weekday{
   width:100%;
 }
 .osui-accordion-item__title__placeholder{
-  -o-text-overflow:ellipsis;
-     text-overflow:ellipsis;
+  text-overflow:ellipsis;
   width:100%;
 }
 .osui-accordion-item__title--is-left{
@@ -5979,7 +5944,6 @@ span.flatpickr-weekday{
       -ms-flex-pack:center;
           justify-content:center;
   -webkit-transition:all 300ms ease-in-out;
-  -o-transition:all 300ms ease-in-out;
   transition:all 300ms ease-in-out;
   width:16px;
 }
@@ -5992,7 +5956,6 @@ span.flatpickr-weekday{
   height:100%;
   -webkit-transition:-webkit-transform 300ms ease-in-out;
   transition:-webkit-transform 300ms ease-in-out;
-  -o-transition:transform 300ms ease-in-out;
   transition:transform 300ms ease-in-out;
   transition:transform 300ms ease-in-out, -webkit-transform 300ms ease-in-out;
   width:2px;
@@ -6031,7 +5994,6 @@ span.flatpickr-weekday{
 }
 .osui-accordion-item__content--is-animating{
   -webkit-transition:all 300ms ease-in-out;
-  -o-transition:all 300ms ease-in-out;
   transition:all 300ms ease-in-out;
 }
 .osui-accordion-item__content [data-block*=AnimatedLabel]:first-child .animated-label{
@@ -6216,7 +6178,6 @@ span.flatpickr-weekday{
 }
 .card-background-color:after{
   background:-webkit-gradient(linear, left top, left bottom, from(rgba(0, 0, 0, 0)), to(rgb(0, 0, 0)));
-  background:-o-linear-gradient(top, rgba(0, 0, 0, 0) 0%, rgb(0, 0, 0) 100%);
   background:linear-gradient(180deg, rgba(0, 0, 0, 0) 0%, rgb(0, 0, 0) 100%);
   content:"";
   height:100%;
@@ -6265,8 +6226,7 @@ span.flatpickr-weekday{
 .card-detail-text{
   color:var(--color-neutral-7);
   overflow:hidden;
-  -o-text-overflow:ellipsis;
-     text-overflow:ellipsis;
+  text-overflow:ellipsis;
 }
 .is-rtl .card-detail-left{
   padding-left:var(--space-base);
@@ -6460,7 +6420,6 @@ span.flatpickr-weekday{
   -webkit-transform-style:preserve-3d;
           transform-style:preserve-3d;
   -webkit-transition:all 630ms cubic-bezier(0.03, 0.01, 0.67, 1.97);
-  -o-transition:all 630ms cubic-bezier(0.03, 0.01, 0.67, 1.97);
   transition:all 630ms cubic-bezier(0.03, 0.01, 0.67, 1.97);
 }
 .osui-flip-content__container--flip-self{
@@ -6718,8 +6677,7 @@ span.flatpickr-weekday{
 }
 .list-item-content-title, .list-item-content-text{
   overflow:hidden;
-  -o-text-overflow:ellipsis;
-     text-overflow:ellipsis;
+  text-overflow:ellipsis;
   white-space:nowrap;
 }
 .list-item-content-title{
@@ -6893,7 +6851,6 @@ span.flatpickr-weekday{
   width:-moz-fit-content;
   width:fit-content;
   -webkit-transition:opacity 250ms;
-  -o-transition:opacity 250ms;
   transition:opacity 250ms;
 }
 .osui-tooltip__balloon-wrapper__balloon{
@@ -7215,32 +7172,26 @@ span.flatpickr-weekday{
 }
 .osui-tooltip__balloon-wrapper--is-opening.left{
   -webkit-transition:left 250ms;
-  -o-transition:left 250ms;
   transition:left 250ms;
 }
 .osui-tooltip__balloon-wrapper--is-opening.right{
   -webkit-transition:right 250ms;
-  -o-transition:right 250ms;
   transition:right 250ms;
 }
 .osui-tooltip__balloon-wrapper--is-opening.center{
   -webkit-transition:top 250ms;
-  -o-transition:top 250ms;
   transition:top 250ms;
 }
 .osui-tooltip__balloon-wrapper--is-opening.top, .osui-tooltip__balloon-wrapper--is-opening.top-left, .osui-tooltip__balloon-wrapper--is-opening.top-right{
   -webkit-transition:top 250ms;
-  -o-transition:top 250ms;
   transition:top 250ms;
 }
 .osui-tooltip__balloon-wrapper--is-opening.bottom, .osui-tooltip__balloon-wrapper--is-opening.bottom-left, .osui-tooltip__balloon-wrapper--is-opening.bottom-right{
   -webkit-transition:top 250ms;
-  -o-transition:top 250ms;
   transition:top 250ms;
 }
 .osui-tooltip__balloon-wrapper--is-opening .osui-tooltip__balloon-wrapper__balloon{
   -webkit-transition:opacity 250ms;
-  -o-transition:opacity 250ms;
   transition:opacity 250ms;
 }
 .osui-tooltip__balloon-wrapper--is-open{
@@ -7469,7 +7420,6 @@ span.flatpickr-weekday{
   position:absolute;
   top:0;
   -webkit-transition:opacity 0.3s cubic-bezier(0, 0, 0.3, 1);
-  -o-transition:opacity 0.3s cubic-bezier(0, 0, 0.3, 1);
   transition:opacity 0.3s cubic-bezier(0, 0, 0.3, 1);
   width:100%;
   will-change:opacity;
@@ -7490,12 +7440,10 @@ span.flatpickr-weekday{
 }
 .action-sheet-container--visible.action-sheet-container--animatable .action-sheet{
   -webkit-transition:all 330ms ease-out;
-  -o-transition:all 330ms ease-out;
   transition:all 330ms ease-out;
 }
 .action-sheet-container--animatable .action-sheet{
   -webkit-transition:all 130ms ease-in;
-  -o-transition:all 130ms ease-in;
   transition:all 130ms ease-in;
 }
 .action-sheet-buttons{
@@ -7545,7 +7493,6 @@ span.flatpickr-weekday{
           animation-fill-mode:both;
   display:inline-block;
   -webkit-transition-timing-function:ease-out;
-       -o-transition-timing-function:ease-out;
           transition-timing-function:ease-out;
   visibility:hidden;
   width:100%;
@@ -7638,7 +7585,6 @@ span.flatpickr-weekday{
   position:absolute;
   top:8px;
   -webkit-transition:all 300ms ease;
-  -o-transition:all 300ms ease;
   transition:all 300ms ease;
   z-index:var(--layer-global-screen);
 }
@@ -7659,7 +7605,6 @@ span.flatpickr-weekday{
   border-radius:var(--border-radius-none);
   padding:var(--space-none);
   -webkit-transition:all 100ms ease-in-out;
-  -o-transition:all 100ms ease-in-out;
   transition:all 100ms ease-in-out;
 }
 .animated-label-input .form-control[data-input]:focus, .animated-label-input .form-control[data-textarea]:focus{
@@ -7750,7 +7695,6 @@ span.flatpickr-weekday{
   opacity:1;
   pointer-events:all;
   -webkit-transition:opacity 300ms ease-in;
-  -o-transition:opacity 300ms ease-in;
   transition:opacity 300ms ease-in;
 }
 .osui-balloon:not(.osui-balloon--is-open) *{
@@ -7843,7 +7787,6 @@ span.flatpickr-weekday{
   text-align:center;
   -webkit-transition:-webkit-transform 350ms var(--osui-bottom-sheet-transition-function);
   transition:-webkit-transform 350ms var(--osui-bottom-sheet-transition-function);
-  -o-transition:transform 350ms var(--osui-bottom-sheet-transition-function);
   transition:transform 350ms var(--osui-bottom-sheet-transition-function);
   transition:transform 350ms var(--osui-bottom-sheet-transition-function), -webkit-transform 350ms var(--osui-bottom-sheet-transition-function);
   -webkit-transform:translateY(100%);
@@ -7906,13 +7849,11 @@ span.flatpickr-weekday{
 .osui-bottom-sheet:not(.osui-bottom-sheet--is-open){
   -webkit-transition:-webkit-transform 200ms ease-out;
   transition:-webkit-transform 200ms ease-out;
-  -o-transition:transform 200ms ease-out;
   transition:transform 200ms ease-out;
   transition:transform 200ms ease-out, -webkit-transform 200ms ease-out;
 }
 .osui-bottom-sheet:not(.osui-bottom-sheet--is-open) + .osui-bottom-sheet-overlay{
   -webkit-transition:opacity 200ms ease-out;
-  -o-transition:opacity 200ms ease-out;
   transition:opacity 200ms ease-out;
 }
 .osui-bottom-sheet-overlay{
@@ -7924,7 +7865,6 @@ span.flatpickr-weekday{
   position:fixed;
   top:0;
   -webkit-transition:opacity 350ms ease-in;
-  -o-transition:opacity 350ms ease-in;
   transition:opacity 350ms ease-in;
   width:100vw;
   z-index:calc(var(--layer-below) + var(--osui-bottom-sheet-layer));
@@ -7959,7 +7899,6 @@ span.flatpickr-weekday{
           transform:translateY(-2px);
   -webkit-transition:opacity 200ms ease, -webkit-transform 200ms var(--osui-bottom-sheet-transition-function);
   transition:opacity 200ms ease, -webkit-transform 200ms var(--osui-bottom-sheet-transition-function);
-  -o-transition:opacity 200ms ease, transform 200ms var(--osui-bottom-sheet-transition-function);
   transition:opacity 200ms ease, transform 200ms var(--osui-bottom-sheet-transition-function);
   transition:opacity 200ms ease, transform 200ms var(--osui-bottom-sheet-transition-function), -webkit-transform 200ms var(--osui-bottom-sheet-transition-function);
   top:0;
@@ -8007,7 +7946,6 @@ span.flatpickr-weekday{
   height:40px;
   opacity:1;
   -webkit-transition:opacity 150ms linear;
-  -o-transition:opacity 150ms linear;
   transition:opacity 150ms linear;
   width:40px;
   will-change:opacity;
@@ -8462,7 +8400,6 @@ span.flatpickr-weekday{
 .safari input.flatpickr-input,
 .safari input.flatpickr-input + input{
   -webkit-transition:none;
-  -o-transition:none;
   transition:none;
 }
 .phone .flatpickr-current-month .flatpickr-monthDropdown-months,
@@ -8825,7 +8762,6 @@ html[data-uieditorversion^="1"] .osui-datepicker-calendar-ss-preview.has-today-b
   margin-right:var(--space-s);
   overflow:visible;
   -webkit-transition:background-color 0.25s ease;
-  -o-transition:background-color 0.25s ease;
   transition:background-color 0.25s ease;
   width:16px;
 }
@@ -8836,7 +8772,6 @@ html[data-uieditorversion^="1"] .osui-datepicker-calendar-ss-preview.has-today-b
   height:85%;
   opacity:0;
   -webkit-transition:opacity 0.25s ease;
-  -o-transition:opacity 0.25s ease;
   transition:opacity 0.25s ease;
   width:40%;
 }
@@ -8873,7 +8808,6 @@ html[data-uieditorversion^="1"] .osui-datepicker-calendar-ss-preview.has-today-b
   padding:var(--space-xs) var(--space-xl) var(--space-xs) var(--space-base);
   position:relative;
   -webkit-transition:height, border-color 0.25s ease;
-  -o-transition:height, border-color 0.25s ease;
   transition:height, border-color 0.25s ease;
   vertical-align:middle;
   width:100%;
@@ -8892,7 +8826,6 @@ html[data-uieditorversion^="1"] .osui-datepicker-calendar-ss-preview.has-today-b
       -ms-transform-origin:center;
           transform-origin:center;
   -webkit-transition:all 0.25s ease;
-  -o-transition:all 0.25s ease;
   transition:all 0.25s ease;
 }
 .vscomp-toggle-button:hover{
@@ -9002,7 +8935,6 @@ html[data-uieditorversion^="1"] .osui-datepicker-calendar-ss-preview.has-today-b
       align-content:center;
   background-color:var(--color-neutral-0);
   -webkit-transition:background-color 0.25s ease;
-  -o-transition:background-color 0.25s ease;
   transition:background-color 0.25s ease;
 }
 .vscomp-option.focused, .vscomp-option.selected{
@@ -9218,10 +9150,8 @@ body.vscomp-popup-active .vscomp-wrapper{
   -webkit-transform:translateY(0px) translateZ(0) scale(1);
           transform:translateY(0px) translateZ(0) scale(1);
   -webkit-transition:all 180ms ease-out;
-  -o-transition:all 180ms ease-out;
   transition:all 180ms ease-out;
   -webkit-transition-delay:calc(var(--delay) * 40ms);
-       -o-transition-delay:calc(var(--delay) * 40ms);
           transition-delay:calc(var(--delay) * 40ms);
 }
 .floating-actions-wrapper.is--open .floating-actions-item-button{
@@ -9276,7 +9206,6 @@ body.vscomp-popup-active .vscomp-wrapper{
   -webkit-transform:translateY(--space-base) translateZ(0);
           transform:translateY(--space-base) translateZ(0);
   -webkit-transition:all 100ms ease-in;
-  -o-transition:all 100ms ease-in;
   transition:all 100ms ease-in;
 }
 .floating-actions-item{
@@ -9306,11 +9235,9 @@ body.vscomp-popup-active .vscomp-wrapper{
           transform:translateZ(0) scale(0.3);
   -webkit-transition:-webkit-transform 180ms ease-out;
   transition:-webkit-transform 180ms ease-out;
-  -o-transition:transform 180ms ease-out;
   transition:transform 180ms ease-out;
   transition:transform 180ms ease-out, -webkit-transform 180ms ease-out;
   -webkit-transition-delay:calc(var(--delay) * 40ms);
-       -o-transition-delay:calc(var(--delay) * 40ms);
           transition-delay:calc(var(--delay) * 40ms);
   width:40px;
 }
@@ -9346,7 +9273,6 @@ body.vscomp-popup-active .vscomp-wrapper{
       -ms-transform-origin:center center;
           transform-origin:center center;
   -webkit-transition:all 180ms linear;
-  -o-transition:all 180ms linear;
   transition:all 180ms linear;
   width:56px;
 }
@@ -9364,7 +9290,6 @@ body.vscomp-popup-active .vscomp-wrapper{
   right:0;
   top:0;
   -webkit-transition:opacity 180ms ease-out;
-  -o-transition:opacity 180ms ease-out;
   transition:opacity 180ms ease-out;
   width:100vw;
   z-index:var(--osui-floating-actions-layer);
@@ -9658,7 +9583,6 @@ body.vscomp-popup-active .vscomp-wrapper{
   position:fixed;
   -webkit-transition:opacity 300ms ease-out, -webkit-transform 300ms ease-out;
   transition:opacity 300ms ease-out, -webkit-transform 300ms ease-out;
-  -o-transition:transform 300ms ease-out, opacity 300ms ease-out;
   transition:transform 300ms ease-out, opacity 300ms ease-out;
   transition:transform 300ms ease-out, opacity 300ms ease-out, -webkit-transform 300ms ease-out;
   -webkit-user-select:none;
@@ -9845,7 +9769,6 @@ body.vscomp-popup-active .vscomp-wrapper{
   height:var(--range-slider-handle-size);
   -webkit-transition:-webkit-transform 150ms ease-out;
   transition:-webkit-transform 150ms ease-out;
-  -o-transition:transform 150ms ease-out;
   transition:transform 150ms ease-out;
   transition:transform 150ms ease-out, -webkit-transform 150ms ease-out;
   width:var(--range-slider-handle-size);
@@ -10180,7 +10103,6 @@ body.vscomp-popup-active .vscomp-wrapper{
   right:13px;
   top:50%;
   -webkit-transition:all 300ms ease;
-  -o-transition:all 300ms ease;
   transition:all 300ms ease;
   width:16px;
 }
@@ -10195,7 +10117,6 @@ body.vscomp-popup-active .vscomp-wrapper{
       -ms-transform:rotate(-45deg);
           transform:rotate(-45deg);
   -webkit-transition:all 300ms ease;
-  -o-transition:all 300ms ease;
   transition:all 300ms ease;
   width:3px;
 }
@@ -10208,14 +10129,12 @@ body.vscomp-popup-active .vscomp-wrapper{
       -ms-transform:translate(0, calc(-100% - var(--os-safe-area-top)));
           transform:translate(0, calc(-100% - var(--os-safe-area-top)));
   -webkit-transition:all 300ms ease;
-  -o-transition:all 300ms ease;
   transition:all 300ms ease;
 }
 .layout-native .header-right .search-input input[data-input], .layout-native .header-right .search-input input[data-input]:empty{
   height:34px;
   padding-left:var(--space-xl);
   -webkit-transition:none;
-  -o-transition:none;
   transition:none;
 }
 .layout-native .header-right .search-input input[data-input]:focus{
@@ -10258,7 +10177,6 @@ body.vscomp-popup-active .vscomp-wrapper{
   position:fixed;
   top:0;
   -webkit-transition:all 130ms ease-in;
-  -o-transition:all 130ms ease-in;
   transition:all 130ms ease-in;
   width:var(--sidebar-width);
   will-change:transform;
@@ -10336,7 +10254,6 @@ body.vscomp-popup-active .vscomp-wrapper{
   position:fixed;
   top:0;
   -webkit-transition:opacity 130ms ease-in;
-  -o-transition:opacity 130ms ease-in;
   transition:opacity 130ms ease-in;
   width:200vw;
   will-change:opacity;
@@ -10359,7 +10276,6 @@ body.vscomp-popup-active .vscomp-wrapper{
           transform:none;
   -webkit-transition:-webkit-transform 330ms ease-out;
   transition:-webkit-transform 330ms ease-out;
-  -o-transition:transform 330ms ease-out;
   transition:transform 330ms ease-out;
   transition:transform 330ms ease-out, -webkit-transform 330ms ease-out;
   will-change:transform;
@@ -10462,7 +10378,6 @@ body.vscomp-popup-active .vscomp-wrapper{
 }
 .stackedcards--animatable{
   -webkit-transition:all 400ms ease;
-  -o-transition:all 400ms ease;
   transition:all 400ms ease;
 }
 .stackedcards .init{
@@ -10769,8 +10684,7 @@ html[data-uieditorversion^="1"] .osui-timepicker__dropdown-ss-preview.time12h, h
 .bottom-bar-item-text{
   font-size:10px;
   overflow:hidden;
-  -o-text-overflow:ellipsis;
-     text-overflow:ellipsis;
+  text-overflow:ellipsis;
   white-space:nowrap;
   word-wrap:break-word;
 }
@@ -11154,7 +11068,6 @@ html[data-uieditorversion^="1"] .osui-timepicker__dropdown-ss-preview.time12h, h
   display:flex;
   padding:var(--space-none) var(--space-s);
   -webkit-transition:all 150ms linear;
-  -o-transition:all 150ms linear;
   transition:all 150ms linear;
 }
 .osui-submenu__header__icon{
@@ -11166,7 +11079,6 @@ html[data-uieditorversion^="1"] .osui-timepicker__dropdown-ss-preview.time12h, h
       -ms-transform:rotate(-45deg);
           transform:rotate(-45deg);
   -webkit-transition:all 150ms linear;
-  -o-transition:all 150ms linear;
   transition:all 150ms linear;
 }
 .osui-submenu__header__icon:before{
@@ -11178,7 +11090,6 @@ html[data-uieditorversion^="1"] .osui-timepicker__dropdown-ss-preview.time12h, h
   content:"";
   height:6px;
   -webkit-transition:all 150ms linear;
-  -o-transition:all 150ms linear;
   transition:all 150ms linear;
   width:6px;
 }
@@ -11193,7 +11104,6 @@ html[data-uieditorversion^="1"] .osui-timepicker__dropdown-ss-preview.time12h, h
   height:100%;
   position:relative;
   -webkit-transition:all 150ms linear;
-  -o-transition:all 150ms linear;
   transition:all 150ms linear;
   -servicestudio-min-width:100px;
   -servicestudio-margin-left:calc(var(--space-s) * -1);
@@ -11235,7 +11145,6 @@ html[data-uieditorversion^="1"] .osui-timepicker__dropdown-ss-preview.time12h, h
       -ms-transform:translateY(-8px);
           transform:translateY(-8px);
   -webkit-transition:all 130ms ease-out;
-  -o-transition:all 130ms ease-out;
   transition:all 130ms ease-out;
   z-index:var(--layer-global-elevated);
 }
@@ -11581,7 +11490,6 @@ html[data-uieditorversion^="1"] .osui-timepicker__dropdown-ss-preview.time12h, h
   position:absolute;
   -webkit-transition:-webkit-transform 200ms linear;
   transition:-webkit-transform 200ms linear;
-  -o-transition:transform 200ms linear;
   transition:transform 200ms linear;
   transition:transform 200ms linear, -webkit-transform 200ms linear;
   -webkit-transform-origin:0 0;
@@ -12141,12 +12049,10 @@ html[data-uieditorversion^="1"] .wizard-wrapper-item{
 }
 .osui-progress-bar__container.animate-entrance .osui-progress-bar__value:before{
   -webkit-transition-delay:0.5s;
-       -o-transition-delay:0.5s;
           transition-delay:0.5s;
 }
 .osui-progress-bar__container.animate-entrance .osui-progress-bar__value:before, .osui-progress-bar__container.animate-progress-change .osui-progress-bar__value:before{
   -webkit-transition-duration:0.35s;
-       -o-transition-duration:0.35s;
           transition-duration:0.35s;
 }
 .osui-progress-bar__value{
@@ -12255,17 +12161,14 @@ html[data-uieditorversion^="1"] .wizard-wrapper-item{
   stroke-dashoffset:var(--stroke-dashoffset);
   stroke-linecap:var(--shape);
   -webkit-transition:stroke-dashoffset 0;
-  -o-transition:stroke-dashoffset 0;
   transition:stroke-dashoffset 0;
 }
 .osui-progress-circle__container__progress-path.animate-entrance, .osui-progress-circle__container__progress-path.animate-progress-change{
   -webkit-transition-duration:0.35s;
-       -o-transition-duration:0.35s;
           transition-duration:0.35s;
 }
 .osui-progress-circle__container__progress-path.animate-entrance{
   -webkit-transition-delay:0.5s;
-       -o-transition-delay:0.5s;
           transition-delay:0.5s;
 }
 .osui-progress-circle__container__trail-path{
@@ -12345,7 +12248,6 @@ html[data-uieditorversion^="1"] .wizard-wrapper-item{
   position:absolute;
   top:0;
   -webkit-transition:opacity linear 150ms;
-  -o-transition:opacity linear 150ms;
   transition:opacity linear 150ms;
 }
 .rating-item-filled, .rating-item-half, .rating-item-empty{
@@ -12485,7 +12387,6 @@ html[data-uieditorversion^="1"] .wizard-wrapper-item{
   display:-ms-inline-flexbox;
   display:inline-flex;
   -webkit-transition:none;
-  -o-transition:none;
   transition:none;
   vertical-align:middle;
   white-space:nowrap;
@@ -12618,14 +12519,12 @@ html[data-uieditorversion^="1"] .wizard-wrapper-item{
 }
 .pull-to-refresh .genericon{
   -webkit-transition:all 0.25s ease;
-  -o-transition:all 0.25s ease;
   transition:all 0.25s ease;
 }
 .ptr-loading .content,
 .ptr-loading .pull-to-refresh, .ptr-reset .content,
 .ptr-reset .pull-to-refresh{
   -webkit-transition:all 0.25s ease;
-  -o-transition:all 0.25s ease;
   transition:all 0.25s ease;
 }
 .ptr-loading .pull-to-refresh .genericon, .ptr-reset .pull-to-refresh .genericon{
@@ -12725,7 +12624,6 @@ html[data-uieditorversion^="1"] .wizard-wrapper-item{
   top:0;
   -webkit-transition:-webkit-transform 200ms ease-in-out;
   transition:-webkit-transform 200ms ease-in-out;
-  -o-transition:transform 200ms ease-in-out;
   transition:transform 200ms ease-in-out;
   transition:transform 200ms ease-in-out, -webkit-transform 200ms ease-in-out;
 }
@@ -12737,8 +12635,7 @@ html[data-uieditorversion^="1"] .wizard-wrapper-item{
 }
 .osui-dropdown-serverside__selected-values > *:first-child{
   overflow:hidden;
-  -o-text-overflow:ellipsis;
-     text-overflow:ellipsis;
+  text-overflow:ellipsis;
   white-space:nowrap;
   width:100%;
 }
@@ -12759,7 +12656,6 @@ html[data-uieditorversion^="1"] .wizard-wrapper-item{
   padding:var(--space-none) var(--space-base);
   position:relative;
   -webkit-transition:border 250ms ease-in-out;
-  -o-transition:border 250ms ease-in-out;
   transition:border 250ms ease-in-out;
   width:100%;
 }
@@ -12785,7 +12681,6 @@ html[data-uieditorversion^="1"] .wizard-wrapper-item{
   overflow:hidden;
   position:absolute;
   -webkit-transition:opacity 300ms ease;
-  -o-transition:opacity 300ms ease;
   transition:opacity 300ms ease;
   width:100%;
   z-index:var(--layer-global-elevated);
@@ -12816,7 +12711,6 @@ html[data-uieditorversion^="1"] .wizard-wrapper-item{
           transform:translateY(calc(-1 * var(--osui-dropdown-ss-thresholdanimateval)));
   -webkit-transition:opacity 250ms ease, -webkit-transform 300ms ease-in-out;
   transition:opacity 250ms ease, -webkit-transform 300ms ease-in-out;
-  -o-transition:opacity 250ms ease, transform 300ms ease-in-out;
   transition:opacity 250ms ease, transform 300ms ease-in-out;
   transition:opacity 250ms ease, transform 300ms ease-in-out, -webkit-transform 300ms ease-in-out;
 }
@@ -12916,7 +12810,6 @@ html[data-uieditorversion^="1"] .wizard-wrapper-item{
       -ms-transform:translateY(0);
           transform:translateY(0);
   -webkit-transition:opacity 250ms ease;
-  -o-transition:opacity 250ms ease;
   transition:opacity 250ms ease;
 }
 .osui-dropdown-serverside__balloon--is-top .osui-dropdown-serverside__balloon-content{
@@ -13053,7 +12946,6 @@ body:has(.popup-dialog):has(.osui-dropdown-serverside--is-opened) .osui-dropdown
   overflow:hidden;
   top:0;
   -webkit-transition:opacity 250ms ease;
-  -o-transition:opacity 250ms ease;
   transition:opacity 250ms ease;
   z-index:var(--layer-global-instant-interaction);
 }
@@ -13104,7 +12996,6 @@ body:has(.popup-dialog):has(.osui-dropdown-serverside--is-opened) .osui-dropdown
   padding:var(--space-s) var(--space-base);
   position:relative;
   -webkit-transition:background 250ms ease;
-  -o-transition:background 250ms ease;
   transition:background 250ms ease;
   width:100%;
   z-index:var(--layer-global-screen);
@@ -13132,8 +13023,7 @@ body:has(.popup-dialog):has(.osui-dropdown-serverside--is-opened) .osui-dropdown
 }
 .osui-dropdown-serverside-item__content > *:first-child{
   overflow:hidden;
-  -o-text-overflow:ellipsis;
-     text-overflow:ellipsis;
+  text-overflow:ellipsis;
   white-space:nowrap;
   width:100%;
 }
@@ -13202,7 +13092,6 @@ body:has(.popup-dialog):has(.osui-dropdown-serverside--is-opened) .osui-dropdown
   font-size:24px;
   font-weight:400;
   -webkit-transition:all 300ms ease-in-out;
-  -o-transition:all 300ms ease-in-out;
   transition:all 300ms ease-in-out;
 }
 .section-expandable .section-expandable-icon:after{
@@ -13228,7 +13117,6 @@ body:has(.popup-dialog):has(.osui-dropdown-serverside--is-opened) .osui-dropdown
 }
 .section-expandable .section-expandable-content-animating, .section-expandable .section-expandable-content.is--animating{
   -webkit-transition:all 300ms ease-in-out;
-  -o-transition:all 300ms ease-in-out;
   transition:all 300ms ease-in-out;
 }
 .section-expandable .section-expandable-content.no-padding{
@@ -13330,7 +13218,6 @@ button.OSFillParent{
   overflow:hidden;
   position:relative;
   -webkit-transition:all 400ms ease;
-  -o-transition:all 400ms ease;
   transition:all 400ms ease;
   will-change:transform;
 }
@@ -13374,7 +13261,6 @@ button.OSFillParent{
 }
 .carousel--animatable{
   -webkit-transition:all 250ms linear;
-  -o-transition:all 250ms linear;
   transition:all 250ms linear;
   will-change:transform;
 }
@@ -13460,7 +13346,6 @@ button.OSFillParent{
       -ms-transform:translateY(-25px);
           transform:translateY(-25px);
   -webkit-transition:opacity 150ms linear;
-  -o-transition:opacity 150ms linear;
   transition:opacity 150ms linear;
   width:40px;
   will-change:opacity;
@@ -13501,7 +13386,6 @@ button.OSFillParent{
 .carousel-is-moving .hide-on-drag{
   opacity:0;
   -webkit-transition:opacity 250ms ease;
-  -o-transition:opacity 250ms ease;
   transition:opacity 250ms ease;
 }
 .carousel .list.list-group{
@@ -14014,7 +13898,6 @@ input.OSFillParent.calendar-input{
   line-height:calc(var(--font-size-base) * 2);
   padding-left:var(--space-base);
   -webkit-transition:all 180ms linear;
-  -o-transition:all 180ms linear;
   transition:all 180ms linear;
   vertical-align:top;
   width:100%;
@@ -14178,7 +14061,6 @@ input.OSFillParent.calendar-input{
   height:40px;
   padding:var(--space-none) var(--space-base);
   -webkit-transition:all 180ms linear;
-  -o-transition:all 180ms linear;
   transition:all 180ms linear;
 }
 .section-expandable-content .choices__list--dropdown.is-active{
@@ -14263,7 +14145,6 @@ input.OSFillParent.calendar-input{
       -ms-transform-origin:center;
           transform-origin:center;
   -webkit-transition:all 300ms ease;
-  -o-transition:all 300ms ease;
   transition:all 300ms ease;
 }
 .choices[data-type*=select-one].is-open:after{
@@ -14305,8 +14186,7 @@ input.OSFillParent.calendar-input{
   color:var(--color-neutral-10);
   overflow:hidden;
   padding-right:var(--space-base);
-  -o-text-overflow:ellipsis;
-     text-overflow:ellipsis;
+  text-overflow:ellipsis;
   white-space:nowrap;
   width:99%;
 }
@@ -14466,7 +14346,6 @@ input.OSFillParent.calendar-input{
 .flip-content-container{
   position:relative;
   -webkit-transition:all 630ms cubic-bezier(0.03, 0.01, 0.67, 1.97);
-  -o-transition:all 630ms cubic-bezier(0.03, 0.01, 0.67, 1.97);
   transition:all 630ms cubic-bezier(0.03, 0.01, 0.67, 1.97);
   -webkit-transform-style:preserve-3d;
   transform-style:preserve-3d;
@@ -14616,12 +14495,10 @@ input.OSFillParent.calendar-input{
 }
 .notification--visible.notification--animatable{
   -webkit-transition:all 330ms ease-out;
-  -o-transition:all 330ms ease-out;
   transition:all 330ms ease-out;
 }
 .notification--animatable{
   -webkit-transition:all 130ms ease-in;
-  -o-transition:all 130ms ease-in;
   transition:all 130ms ease-in;
 }
 .layout-native .notification{
@@ -14680,7 +14557,6 @@ input.OSFillParent.calendar-input{
       -ms-transform-origin:left;
           transform-origin:left;
   -webkit-transition:all 750ms ease-out;
-  -o-transition:all 750ms ease-out;
   transition:all 750ms ease-out;
   will-change:width;
 }
@@ -14824,7 +14700,6 @@ input.OSFillParent.calendar-input{
       -ms-transform:translateX(102%);
           transform:translateX(102%);
   -webkit-transition:all 130ms ease-in;
-  -o-transition:all 130ms ease-in;
   transition:all 130ms ease-in;
   width:500px;
   will-change:transform;
@@ -14861,7 +14736,6 @@ input.OSFillParent.calendar-input{
       -ms-transform:none;
           transform:none;
   -webkit-transition:all 330ms ease-out;
-  -o-transition:all 330ms ease-out;
   transition:all 330ms ease-out;
   will-change:transform;
 }
@@ -14958,7 +14832,6 @@ input.OSFillParent.calendar-input{
   display:flex;
   padding:var(--space-none) var(--space-s);
   -webkit-transition:all 150ms linear;
-  -o-transition:all 150ms linear;
   transition:all 150ms linear;
 }
 .submenu-icon{
@@ -14970,7 +14843,6 @@ input.OSFillParent.calendar-input{
       -ms-transform:rotate(-45deg);
           transform:rotate(-45deg);
   -webkit-transition:all 150ms linear;
-  -o-transition:all 150ms linear;
   transition:all 150ms linear;
 }
 .submenu-icon:before{
@@ -14982,7 +14854,6 @@ input.OSFillParent.calendar-input{
   content:"";
   height:6px;
   -webkit-transition:all 150ms linear;
-  -o-transition:all 150ms linear;
   transition:all 150ms linear;
   width:6px;
 }
@@ -14997,7 +14868,6 @@ input.OSFillParent.calendar-input{
   height:100%;
   position:relative;
   -webkit-transition:all 150ms linear;
-  -o-transition:all 150ms linear;
   transition:all 150ms linear;
 }
 .submenu-item a{
@@ -15034,7 +14904,6 @@ input.OSFillParent.calendar-input{
       -ms-transform:translateY(-8px);
           transform:translateY(-8px);
   -webkit-transition:all 130ms ease-out;
-  -o-transition:all 130ms ease-out;
   transition:all 130ms ease-out;
   z-index:var(--layer-global-elevated);
 }
@@ -15310,7 +15179,6 @@ input.OSFillParent.calendar-input{
   margin-left:var(--space-l);
   padding:var(--space-base) var(--space-xs);
   -webkit-transition:border 150ms linear;
-  -o-transition:border 150ms linear;
   transition:border 150ms linear;
   white-space:nowrap;
 }
@@ -15367,7 +15235,6 @@ input.OSFillParent.calendar-input{
 .layout-native .tabs-content-wrapper{
   -webkit-transition:-webkit-transform 230ms ease-in-out;
   transition:-webkit-transform 230ms ease-in-out;
-  -o-transition:transform 230ms ease-in-out;
   transition:transform 230ms ease-in-out;
   transition:transform 230ms ease-in-out, -webkit-transform 230ms ease-in-out;
 }
@@ -16447,8 +16314,7 @@ input.OSFillParent.calendar-input{
 }
 .text-ellipsis{
   overflow:hidden;
-  -o-text-overflow:ellipsis;
-     text-overflow:ellipsis;
+  text-overflow:ellipsis;
   white-space:nowrap;
 }
 /*! 7.9. Border Size */
@@ -17631,7 +17497,6 @@ img.thumbnail{
 /*! 7.24. Miscellaneous */
 .no-transition{
   -webkit-transition:none !important;
-  -o-transition:none !important;
   transition:none !important;
 }
 .no-transform{
@@ -17689,7 +17554,6 @@ img.thumbnail{
 .fade-leave.fade-leave-active{
   -webkit-transition:opacity 400ms ease-in-out, -webkit-transform 400ms ease-in-out;
   transition:opacity 400ms ease-in-out, -webkit-transform 400ms ease-in-out;
-  -o-transition:transform 400ms ease-in-out, opacity 400ms ease-in-out;
   transition:transform 400ms ease-in-out, opacity 400ms ease-in-out;
   transition:transform 400ms ease-in-out, opacity 400ms ease-in-out, -webkit-transform 400ms ease-in-out;
 }
@@ -17705,7 +17569,6 @@ img.thumbnail{
 .fade-leave.fade-leave-active .content{
   -webkit-transition:opacity 400ms ease-in-out, -webkit-transform 400ms ease-in-out;
   transition:opacity 400ms ease-in-out, -webkit-transform 400ms ease-in-out;
-  -o-transition:transform 400ms ease-in-out, opacity 400ms ease-in-out;
   transition:transform 400ms ease-in-out, opacity 400ms ease-in-out;
   transition:transform 400ms ease-in-out, opacity 400ms ease-in-out, -webkit-transform 400ms ease-in-out;
 }
@@ -17782,7 +17645,6 @@ img.thumbnail{
 .fade-enter.fade-enter-active .header{
   -webkit-transition:opacity 400ms ease-in-out, -webkit-transform 400ms ease-in-out;
   transition:opacity 400ms ease-in-out, -webkit-transform 400ms ease-in-out;
-  -o-transition:transform 400ms ease-in-out, opacity 400ms ease-in-out;
   transition:transform 400ms ease-in-out, opacity 400ms ease-in-out;
   transition:transform 400ms ease-in-out, opacity 400ms ease-in-out, -webkit-transform 400ms ease-in-out;
 }
@@ -17793,7 +17655,6 @@ img.thumbnail{
 .fade-leave.fade-leave-active{
   opacity:0;
   -webkit-transition:all 400ms ease-in-out;
-  -o-transition:all 400ms ease-in-out;
   transition:all 400ms ease-in-out;
 }
 .fade-leave.fade-leave-active .header{
@@ -17801,7 +17662,6 @@ img.thumbnail{
   -webkit-transform:translateY(-200px) translateZ(0);
           transform:translateY(-200px) translateZ(0);
   -webkit-transition:none;
-  -o-transition:none;
   transition:none;
 }
 .fade-leave.screen-container{

--- a/dist/OutSystemsUI.d.ts
+++ b/dist/OutSystemsUI.d.ts
@@ -525,6 +525,14 @@ declare namespace OSFramework.OSUI.Behaviors {
     export {};
 }
 declare namespace OSFramework.OSUI.Behaviors {
+    class FocusManager {
+        private _lastFocusedElem;
+        constructor();
+        returnFocusToElement(): void;
+        storeLastFocusedElement(): void;
+    }
+}
+declare namespace OSFramework.OSUI.Behaviors {
     type FocusTrapParams = {
         focusBottomCallback: GlobalCallbacks.Generic;
         focusTargetElement: HTMLElement;
@@ -871,14 +879,14 @@ declare namespace OSFramework.OSUI.Feature.Balloon {
         private _eventOnKeypress;
         private _floatingInstance;
         private _floatingOptions;
+        private _focusManagerInstance;
         private _focusTrapInstance;
-        private _focusableActiveElement;
         private _isOpenedByApi;
         private _onToggleEvent;
         isOpen: boolean;
         constructor(featurePattern: PT, featureElem: HTMLElement, options: BalloonOptions);
         private _bodyClickCallback;
-        private _handleFocusTrap;
+        private _handleFocusBehavior;
         private _onkeypressCallback;
         private _removeEventListeners;
         private _setA11YProperties;
@@ -1511,8 +1519,8 @@ declare namespace OSFramework.OSUI.Patterns.BottomSheet {
         private _bottomSheetHeaderElem;
         private _eventOnContentScroll;
         private _eventOnKeypress;
+        private _focusManagerInstance;
         private _focusTrapInstance;
-        private _focusableActiveElement;
         private _gestureEventInstance;
         private _hasGestureEvents;
         private _isOpen;
@@ -1529,7 +1537,7 @@ declare namespace OSFramework.OSUI.Patterns.BottomSheet {
         get gestureEventInstance(): Event.GestureEvent.DragEvent;
         get hasGestureEvents(): boolean;
         constructor(uniqueId: string, configs: JSON);
-        private _handleFocusTrap;
+        private _handleFocusBehavior;
         private _handleGestureEvents;
         private _handleShape;
         private _onContentScrollCallback;
@@ -2350,8 +2358,8 @@ declare namespace OSFramework.OSUI.Patterns.Notification {
         private _eventOnClick;
         private _eventOnKeypress;
         private _eventType;
+        private _focusManagerInstance;
         private _focusTrapInstance;
-        private _focusableActiveElement;
         private _gestureEventInstance;
         private _hasGestureEvents;
         private _isOpen;
@@ -2360,7 +2368,7 @@ declare namespace OSFramework.OSUI.Patterns.Notification {
         constructor(uniqueId: string, configs: JSON);
         private _autoCloseNotification;
         private _clickCallback;
-        private _handleFocusTrap;
+        private _handleFocusBehavior;
         private _handleGestureEvents;
         private _hideNotification;
         private _keypressCallback;
@@ -3009,6 +3017,7 @@ declare namespace OSFramework.OSUI.Patterns.Sidebar {
         private _eventOverlayClick;
         private _eventOverlayMouseDown;
         private _eventSidebarKeypress;
+        private _focusManagerInstance;
         private _focusTrapInstance;
         private _gestureEventInstance;
         private _hasGestureEvents;
@@ -3017,7 +3026,7 @@ declare namespace OSFramework.OSUI.Patterns.Sidebar {
         private _platformEventOnToggle;
         constructor(uniqueId: string, configs: JSON);
         private _closeSidebar;
-        private _handleFocusTrap;
+        private _handleFocusBehavior;
         private _handleGestureEvents;
         private _onGestureEnd;
         private _onGestureMove;

--- a/dist/OutSystemsUI.d.ts
+++ b/dist/OutSystemsUI.d.ts
@@ -528,7 +528,7 @@ declare namespace OSFramework.OSUI.Behaviors {
     class FocusManager {
         private _lastFocusedElem;
         constructor();
-        returnFocusToElement(): void;
+        setFocusToStoredElement(): void;
         storeLastFocusedElement(): void;
     }
 }

--- a/dist/OutSystemsUI.js
+++ b/dist/OutSystemsUI.js
@@ -806,6 +806,37 @@ var OSFramework;
     (function (OSUI) {
         var Behaviors;
         (function (Behaviors) {
+            class FocusManager {
+                constructor() {
+                }
+                returnFocusToElement() {
+                    if (this._lastFocusedElem === undefined ||
+                        !document.body.contains(this._lastFocusedElem) ||
+                        this._lastFocusedElem.hasAttribute(OSUI.GlobalEnum.HTMLAttributes.Disabled) ||
+                        this._lastFocusedElem.tabIndex < 0) {
+                        document.querySelector(OSFramework.OSUI.Constants.FocusableElems).focus();
+                    }
+                    else {
+                        this._lastFocusedElem.focus();
+                    }
+                }
+                storeLastFocusedElement() {
+                    if (document.activeElement !== undefined &&
+                        document.activeElement !== null &&
+                        document.activeElement !== document.body)
+                        this._lastFocusedElem = document.activeElement;
+                }
+            }
+            Behaviors.FocusManager = FocusManager;
+        })(Behaviors = OSUI.Behaviors || (OSUI.Behaviors = {}));
+    })(OSUI = OSFramework.OSUI || (OSFramework.OSUI = {}));
+})(OSFramework || (OSFramework = {}));
+var OSFramework;
+(function (OSFramework) {
+    var OSUI;
+    (function (OSUI) {
+        var Behaviors;
+        (function (Behaviors) {
             class FocusTrap {
                 constructor(opts) {
                     this._hasBeenPassThoughFirstOne = false;
@@ -1812,11 +1843,12 @@ var OSFramework;
                             e.stopPropagation();
                         }
                     }
-                    _handleFocusTrap() {
+                    _handleFocusBehavior() {
                         const opts = {
                             focusTargetElement: this._floatingOptions.AnchorElem.parentElement,
                         };
                         this._focusTrapInstance = new OSUI.Behaviors.FocusTrap(opts);
+                        this._focusManagerInstance = new OSUI.Behaviors.FocusManager();
                     }
                     _onkeypressCallback(e) {
                         const isEscapedPressed = e.key === OSUI.GlobalEnum.Keycodes.Escape;
@@ -1867,7 +1899,7 @@ var OSFramework;
                         }
                         this._setA11YProperties();
                         if (this.isOpen) {
-                            this._focusableActiveElement = document.activeElement;
+                            this._focusManagerInstance.storeLastFocusedElement();
                             this._focusTrapInstance.enableForA11y();
                             this.setFloatingBehaviour();
                             OSUI.Helper.AsyncInvocation(() => {
@@ -1880,7 +1912,7 @@ var OSFramework;
                             OSUI.Helper.AsyncInvocation(() => {
                                 this.featureElem.blur();
                                 if (isBodyClick === false) {
-                                    this._focusableActiveElement.focus();
+                                    this._focusManagerInstance.returnFocusToElement();
                                 }
                             });
                         }
@@ -1899,7 +1931,7 @@ var OSFramework;
                         this._setCallbacks();
                         this._setEventListeners();
                         this.setFloatingConfigs();
-                        this._handleFocusTrap();
+                        this._handleFocusBehavior();
                         this._setA11YProperties();
                         this.setBalloonShape();
                     }
@@ -4389,11 +4421,12 @@ var OSFramework;
                             },
                         };
                     }
-                    _handleFocusTrap() {
+                    _handleFocusBehavior() {
                         const opts = {
                             focusTargetElement: this._parentSelf,
                         };
                         this._focusTrapInstance = new OSUI.Behaviors.FocusTrap(opts);
+                        this._focusManagerInstance = new OSUI.Behaviors.FocusManager();
                     }
                     _handleGestureEvents() {
                         if (!OSUI.Helper.DeviceInfo.IsDesktop) {
@@ -4444,7 +4477,7 @@ var OSFramework;
                         this.setEventListeners();
                         this.setA11YProperties();
                         if (isOpen) {
-                            this._focusableActiveElement = document.activeElement;
+                            this._focusManagerInstance.storeLastFocusedElement();
                             this._focusTrapInstance.enableForA11y();
                             this.selfElement.focus();
                         }
@@ -4452,7 +4485,7 @@ var OSFramework;
                             this._focusTrapInstance.disableForA11y();
                             OSUI.Helper.AsyncInvocation(() => {
                                 this.selfElement.blur();
-                                this._focusableActiveElement.focus();
+                                this._focusManagerInstance.returnFocusToElement();
                             });
                         }
                         this._triggerOnToggleEvent();
@@ -4516,7 +4549,7 @@ var OSFramework;
                     build() {
                         super.build();
                         this.setHtmlElements();
-                        this._handleFocusTrap();
+                        this._handleFocusBehavior();
                         this.setInitialOptions();
                         this.setCallbacks();
                         this.setA11YProperties();
@@ -6831,11 +6864,12 @@ var OSFramework;
                         e.preventDefault();
                         this.hide();
                     }
-                    _handleFocusTrap() {
+                    _handleFocusBehavior() {
                         const opts = {
                             focusTargetElement: this._parentSelf,
                         };
                         this._focusTrapInstance = new OSUI.Behaviors.FocusTrap(opts);
+                        this._focusManagerInstance = new OSUI.Behaviors.FocusManager();
                     }
                     _handleGestureEvents() {
                         if (OSUI.Helper.DeviceInfo.IsNative) {
@@ -6850,7 +6884,7 @@ var OSFramework;
                         this._triggerOnToggleEvent(this._isOpen);
                         this._updateA11yProperties();
                         this.selfElement.blur();
-                        this._focusableActiveElement.focus();
+                        this._focusManagerInstance.returnFocusToElement();
                         if (OSUI.Helper.DeviceInfo.IsNative === false && this.configs.InteractToClose) {
                             this.selfElement.removeEventListener(this._eventType, this._eventOnClick);
                             this.selfElement.removeEventListener(OSUI.GlobalEnum.HTMLEvent.keyDown, this._eventOnKeypress);
@@ -6867,7 +6901,7 @@ var OSFramework;
                         this.selfElement.removeEventListener(OSUI.GlobalEnum.HTMLEvent.keyDown, this._eventOnKeypress);
                     }
                     _showNotification() {
-                        this._focusableActiveElement = document.activeElement;
+                        this._focusManagerInstance.storeLastFocusedElement();
                         this._isOpen = true;
                         this._focusTrapInstance.enableForA11y();
                         OSUI.Helper.Dom.Styles.AddClass(this.selfElement, Notification_1.Enum.CssClass.PatternIsOpen);
@@ -6969,7 +7003,7 @@ var OSFramework;
                         OSUI.Helper.AsyncInvocation(this.setInitialStates.bind(this));
                         this.setCallbacks();
                         this.setHtmlElements();
-                        this._handleFocusTrap();
+                        this._handleFocusBehavior();
                         this.setA11YProperties();
                         this._handleGestureEvents();
                         this.finishBuild();
@@ -8992,12 +9026,14 @@ var OSFramework;
                                 OSUI.Event.DOMEvents.Listeners.GlobalListenerManager.Instance.removeHandler(OSUI.Event.DOMEvents.Listeners.Type.BodyOnClick, this._eventOverlayClick);
                             }
                         }
+                        this._focusManagerInstance.returnFocusToElement();
                     }
-                    _handleFocusTrap() {
+                    _handleFocusBehavior() {
                         const opts = {
                             focusTargetElement: this._parentSelf,
                         };
                         this._focusTrapInstance = new OSUI.Behaviors.FocusTrap(opts);
+                        this._focusManagerInstance = new OSUI.Behaviors.FocusManager();
                         if (this._isOpen === false) {
                             OSUI.Helper.A11Y.SetElementsTabIndex(false, this._focusTrapInstance.focusableElements);
                         }
@@ -9029,6 +9065,7 @@ var OSFramework;
                         OSUI.Helper.A11Y.TabIndexTrue(this.selfElement);
                         OSUI.Helper.A11Y.AriaHiddenFalse(this.selfElement);
                         this._focusTrapInstance.enableForA11y();
+                        this._focusManagerInstance.storeLastFocusedElement();
                         if (this.isBuilt) {
                             this._isOpen = true;
                             this._triggerOnToggleEvent();
@@ -9153,7 +9190,7 @@ var OSFramework;
                         super.build();
                         this.setCallbacks();
                         this.setHtmlElements();
-                        this._handleFocusTrap();
+                        this._handleFocusBehavior();
                         this._setInitialCssClasses();
                         this.setA11YProperties();
                         this._handleGestureEvents();

--- a/dist/OutSystemsUI.js
+++ b/dist/OutSystemsUI.js
@@ -809,7 +809,7 @@ var OSFramework;
             class FocusManager {
                 constructor() {
                 }
-                returnFocusToElement() {
+                setFocusToStoredElement() {
                     if (this._lastFocusedElem === undefined ||
                         !document.body.contains(this._lastFocusedElem) ||
                         this._lastFocusedElem.hasAttribute(OSUI.GlobalEnum.HTMLAttributes.Disabled) ||
@@ -1912,7 +1912,7 @@ var OSFramework;
                             OSUI.Helper.AsyncInvocation(() => {
                                 this.featureElem.blur();
                                 if (isBodyClick === false) {
-                                    this._focusManagerInstance.returnFocusToElement();
+                                    this._focusManagerInstance.setFocusToStoredElement();
                                 }
                             });
                         }
@@ -4485,7 +4485,7 @@ var OSFramework;
                             this._focusTrapInstance.disableForA11y();
                             OSUI.Helper.AsyncInvocation(() => {
                                 this.selfElement.blur();
-                                this._focusManagerInstance.returnFocusToElement();
+                                this._focusManagerInstance.setFocusToStoredElement();
                             });
                         }
                         this._triggerOnToggleEvent();
@@ -6884,7 +6884,7 @@ var OSFramework;
                         this._triggerOnToggleEvent(this._isOpen);
                         this._updateA11yProperties();
                         this.selfElement.blur();
-                        this._focusManagerInstance.returnFocusToElement();
+                        this._focusManagerInstance.setFocusToStoredElement();
                         if (OSUI.Helper.DeviceInfo.IsNative === false && this.configs.InteractToClose) {
                             this.selfElement.removeEventListener(this._eventType, this._eventOnClick);
                             this.selfElement.removeEventListener(OSUI.GlobalEnum.HTMLEvent.keyDown, this._eventOnKeypress);
@@ -9026,7 +9026,7 @@ var OSFramework;
                                 OSUI.Event.DOMEvents.Listeners.GlobalListenerManager.Instance.removeHandler(OSUI.Event.DOMEvents.Listeners.Type.BodyOnClick, this._eventOverlayClick);
                             }
                         }
-                        this._focusManagerInstance.returnFocusToElement();
+                        this._focusManagerInstance.setFocusToStoredElement();
                     }
                     _handleFocusBehavior() {
                         const opts = {

--- a/src/scripts/OSFramework/OSUI/Behaviors/FocusManager.ts
+++ b/src/scripts/OSFramework/OSUI/Behaviors/FocusManager.ts
@@ -20,7 +20,7 @@ namespace OSFramework.OSUI.Behaviors {
 		 * @return {*}  {void}
 		 * @memberof OSFramework.Behaviors.FocusManager
 		 */
-		public returnFocusToElement(): void {
+		public setFocusToStoredElement(): void {
 			// If no element was set as the last focused element or it is not focusable anymore,
 			// return the focus to the first focusable element in the page.
 			if (

--- a/src/scripts/OSFramework/OSUI/Behaviors/FocusManager.ts
+++ b/src/scripts/OSFramework/OSUI/Behaviors/FocusManager.ts
@@ -1,0 +1,57 @@
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+namespace OSFramework.OSUI.Behaviors {
+	/**
+	 * Class to manage focus of overlay components
+	 *
+	 * @export
+	 * @class FocusManager
+	 */
+	export class FocusManager {
+		// Store the last focused element
+		private _lastFocusedElem: HTMLElement;
+
+		constructor() {
+			// do nothing.
+		}
+
+		/**
+		 * Method to return the focus to the previous focused element
+		 *
+		 * @return {*}  {void}
+		 * @memberof OSFramework.Behaviors.FocusManager
+		 */
+		public returnFocusToElement(): void {
+			// If no element was set as the last focused element or it is not focusable anymore,
+			// return the focus to the first focusable element in the page.
+			if (
+				this._lastFocusedElem === undefined ||
+				!document.body.contains(this._lastFocusedElem) ||
+				this._lastFocusedElem.hasAttribute(GlobalEnum.HTMLAttributes.Disabled) ||
+				this._lastFocusedElem.tabIndex < 0
+			) {
+				(document.querySelector(OSFramework.OSUI.Constants.FocusableElems) as HTMLElement).focus();
+			}
+			// Otherwise, return the focus to the stored element.
+			else {
+				this._lastFocusedElem.focus();
+			}
+		}
+
+		/**
+		 * Method to store the last focused element if any
+		 *
+		 * @return {*}  {void}
+		 * @memberof OSFramework.Behaviors.FocusManager
+		 */
+		public storeLastFocusedElement(): void {
+			// In case there is an element focused, i.e., the activeElement is not the body, null or undefined,
+			// Store it as the last focused element
+			if (
+				document.activeElement !== undefined &&
+				document.activeElement !== null &&
+				document.activeElement !== document.body
+			)
+				this._lastFocusedElem = document.activeElement as HTMLElement;
+		}
+	}
+}

--- a/src/scripts/OSFramework/OSUI/Feature/Balloon/Balloon.ts
+++ b/src/scripts/OSFramework/OSUI/Feature/Balloon/Balloon.ts
@@ -26,9 +26,10 @@ namespace OSFramework.OSUI.Feature.Balloon {
 		private _floatingInstance: Utils.FloatingPosition.FloatingPosition;
 		// Store the Floating Util options
 		private _floatingOptions: Utils.FloatingPosition.FloatingPositionConfig;
+		// Store focus manager instance
+		private _focusManagerInstance: Behaviors.FocusManager;
 		// FocusTrap Properties
 		private _focusTrapInstance: Behaviors.FocusTrap;
-		private _focusableActiveElement: HTMLElement;
 		// Flag used to deal with onBodyClick and open api concurrency methods!
 		private _isOpenedByApi = false;
 		// Store the onTogle custom event
@@ -53,12 +54,14 @@ namespace OSFramework.OSUI.Feature.Balloon {
 		}
 
 		// Add Focus Trap to the Pattern
-		private _handleFocusTrap(): void {
+		private _handleFocusBehavior(): void {
 			const opts = {
 				focusTargetElement: this._floatingOptions.AnchorElem.parentElement,
 			} as Behaviors.FocusTrapParams;
 
 			this._focusTrapInstance = new Behaviors.FocusTrap(opts);
+
+			this._focusManagerInstance = new Behaviors.FocusManager();
 		}
 
 		// Call methods to open or close, based on e.key and behaviour applied
@@ -154,7 +157,7 @@ namespace OSFramework.OSUI.Feature.Balloon {
 
 			if (this.isOpen) {
 				// Handle focus trap logic
-				this._focusableActiveElement = document.activeElement as HTMLElement;
+				this._focusManagerInstance.storeLastFocusedElement();
 				this._focusTrapInstance.enableForA11y();
 
 				// Set Floating Util
@@ -173,7 +176,7 @@ namespace OSFramework.OSUI.Feature.Balloon {
 				Helper.AsyncInvocation(() => {
 					this.featureElem.blur();
 					if (isBodyClick === false) {
-						this._focusableActiveElement.focus();
+						this._focusManagerInstance.returnFocusToElement();
 					}
 				});
 			}
@@ -204,7 +207,7 @@ namespace OSFramework.OSUI.Feature.Balloon {
 			this._setCallbacks();
 			this._setEventListeners();
 			this.setFloatingConfigs();
-			this._handleFocusTrap();
+			this._handleFocusBehavior();
 			this._setA11YProperties();
 			this.setBalloonShape();
 		}

--- a/src/scripts/OSFramework/OSUI/Feature/Balloon/Balloon.ts
+++ b/src/scripts/OSFramework/OSUI/Feature/Balloon/Balloon.ts
@@ -176,7 +176,7 @@ namespace OSFramework.OSUI.Feature.Balloon {
 				Helper.AsyncInvocation(() => {
 					this.featureElem.blur();
 					if (isBodyClick === false) {
-						this._focusManagerInstance.returnFocusToElement();
+						this._focusManagerInstance.setFocusToStoredElement();
 					}
 				});
 			}

--- a/src/scripts/OSFramework/OSUI/Pattern/BottomSheet/BottomSheet.ts
+++ b/src/scripts/OSFramework/OSUI/Pattern/BottomSheet/BottomSheet.ts
@@ -17,9 +17,10 @@ namespace OSFramework.OSUI.Patterns.BottomSheet {
 		// Listener callbacks
 		private _eventOnContentScroll: GlobalCallbacks.Generic;
 		private _eventOnKeypress: GlobalCallbacks.Generic;
+		// Store focus manager instance
+		private _focusManagerInstance: Behaviors.FocusManager;
 		// FocusTrap Properties
 		private _focusTrapInstance: Behaviors.FocusTrap;
-		private _focusableActiveElement: HTMLElement;
 		// Store gesture events instance
 		private _gestureEventInstance: Event.GestureEvent.DragEvent;
 		// Store if the pattern has gesture events added
@@ -73,12 +74,14 @@ namespace OSFramework.OSUI.Patterns.BottomSheet {
 		 * @private
 		 * @memberof BottomSheet
 		 */
-		private _handleFocusTrap(): void {
+		private _handleFocusBehavior(): void {
 			const opts = {
 				focusTargetElement: this._parentSelf,
 			} as Behaviors.FocusTrapParams;
 
 			this._focusTrapInstance = new Behaviors.FocusTrap(opts);
+
+			this._focusManagerInstance = new Behaviors.FocusManager();
 		}
 
 		/**
@@ -227,7 +230,7 @@ namespace OSFramework.OSUI.Patterns.BottomSheet {
 
 			// Handle focus trap logic
 			if (isOpen) {
-				this._focusableActiveElement = document.activeElement as HTMLElement;
+				this._focusManagerInstance.storeLastFocusedElement();
 				this._focusTrapInstance.enableForA11y();
 				// Focus on element when pattern is open
 				this.selfElement.focus();
@@ -237,7 +240,7 @@ namespace OSFramework.OSUI.Patterns.BottomSheet {
 				// Focus on last element clicked. Async to avoid conflict with closing animation
 				Helper.AsyncInvocation(() => {
 					this.selfElement.blur();
-					this._focusableActiveElement.focus();
+					this._focusManagerInstance.returnFocusToElement();
 				});
 			}
 
@@ -398,7 +401,7 @@ namespace OSFramework.OSUI.Patterns.BottomSheet {
 		public build(): void {
 			super.build();
 			this.setHtmlElements();
-			this._handleFocusTrap();
+			this._handleFocusBehavior();
 			this.setInitialOptions();
 			this.setCallbacks();
 			this.setA11YProperties();

--- a/src/scripts/OSFramework/OSUI/Pattern/BottomSheet/BottomSheet.ts
+++ b/src/scripts/OSFramework/OSUI/Pattern/BottomSheet/BottomSheet.ts
@@ -240,7 +240,7 @@ namespace OSFramework.OSUI.Patterns.BottomSheet {
 				// Focus on last element clicked. Async to avoid conflict with closing animation
 				Helper.AsyncInvocation(() => {
 					this.selfElement.blur();
-					this._focusManagerInstance.returnFocusToElement();
+					this._focusManagerInstance.setFocusToStoredElement();
 				});
 			}
 

--- a/src/scripts/OSFramework/OSUI/Pattern/Notification/Notification.ts
+++ b/src/scripts/OSFramework/OSUI/Pattern/Notification/Notification.ts
@@ -13,10 +13,10 @@ namespace OSFramework.OSUI.Patterns.Notification {
 		private _eventOnKeypress: GlobalCallbacks.Generic;
 		// Define the event to be applied based on device
 		private _eventType: string;
+		// Store focus manager instance
+		private _focusManagerInstance: Behaviors.FocusManager;
 		// Store focus trap instance
 		private _focusTrapInstance: Behaviors.FocusTrap;
-		// Store the active element focused
-		private _focusableActiveElement: HTMLElement;
 		// Store gesture events instance
 		private _gestureEventInstance: Event.GestureEvent.SwipeEvent;
 		// Store if the pattern has gesture events added
@@ -70,12 +70,14 @@ namespace OSFramework.OSUI.Patterns.Notification {
 		 * @private
 		 * @memberof Notification
 		 */
-		private _handleFocusTrap(): void {
+		private _handleFocusBehavior(): void {
 			const opts = {
 				focusTargetElement: this._parentSelf,
 			} as Behaviors.FocusTrapParams;
 
 			this._focusTrapInstance = new Behaviors.FocusTrap(opts);
+
+			this._focusManagerInstance = new Behaviors.FocusManager();
 		}
 
 		/**
@@ -124,7 +126,7 @@ namespace OSFramework.OSUI.Patterns.Notification {
 			this.selfElement.blur();
 
 			// Focus on last element clicked
-			this._focusableActiveElement.focus();
+			this._focusManagerInstance.returnFocusToElement();
 
 			// Remove listeners to toggle Notification
 			if (Helper.DeviceInfo.IsNative === false && this.configs.InteractToClose) {
@@ -167,7 +169,7 @@ namespace OSFramework.OSUI.Patterns.Notification {
 		 * @memberof Notification
 		 */
 		private _showNotification(): void {
-			this._focusableActiveElement = document.activeElement as HTMLElement;
+			this._focusManagerInstance.storeLastFocusedElement();
 			this._isOpen = true;
 
 			// Add the A11Y states to focus trap
@@ -410,7 +412,7 @@ namespace OSFramework.OSUI.Patterns.Notification {
 
 			this.setHtmlElements();
 
-			this._handleFocusTrap();
+			this._handleFocusBehavior();
 
 			this.setA11YProperties();
 

--- a/src/scripts/OSFramework/OSUI/Pattern/Notification/Notification.ts
+++ b/src/scripts/OSFramework/OSUI/Pattern/Notification/Notification.ts
@@ -126,7 +126,7 @@ namespace OSFramework.OSUI.Patterns.Notification {
 			this.selfElement.blur();
 
 			// Focus on last element clicked
-			this._focusManagerInstance.returnFocusToElement();
+			this._focusManagerInstance.setFocusToStoredElement();
 
 			// Remove listeners to toggle Notification
 			if (Helper.DeviceInfo.IsNative === false && this.configs.InteractToClose) {

--- a/src/scripts/OSFramework/OSUI/Pattern/Sidebar/Sidebar.ts
+++ b/src/scripts/OSFramework/OSUI/Pattern/Sidebar/Sidebar.ts
@@ -23,6 +23,8 @@ namespace OSFramework.OSUI.Patterns.Sidebar {
 		private _eventOverlayMouseDown: GlobalCallbacks.Generic;
 		// Store the keypress event with bind(this)
 		private _eventSidebarKeypress: GlobalCallbacks.Generic;
+		// Store focus manager instance
+		private _focusManagerInstance: Behaviors.FocusManager;
 		// Store focus trap instance
 		private _focusTrapInstance: Behaviors.FocusTrap;
 		// Store gesture events instance
@@ -76,6 +78,7 @@ namespace OSFramework.OSUI.Patterns.Sidebar {
 					);
 				}
 			}
+			this._focusManagerInstance.returnFocusToElement();
 		}
 
 		/**
@@ -84,12 +87,14 @@ namespace OSFramework.OSUI.Patterns.Sidebar {
 		 * @private
 		 * @memberof Sidebar
 		 */
-		private _handleFocusTrap(): void {
+		private _handleFocusBehavior(): void {
 			const opts = {
 				focusTargetElement: this._parentSelf,
 			} as Behaviors.FocusTrapParams;
 
 			this._focusTrapInstance = new Behaviors.FocusTrap(opts);
+
+			this._focusManagerInstance = new Behaviors.FocusManager();
 
 			// Disable tabIndex to the inner focusable elements if its start closed!
 			if (this._isOpen === false) {
@@ -189,6 +194,8 @@ namespace OSFramework.OSUI.Patterns.Sidebar {
 
 			// Add the A11Y states to focus trap
 			this._focusTrapInstance.enableForA11y();
+
+			this._focusManagerInstance.storeLastFocusedElement();
 
 			if (this.isBuilt) {
 				//let's only change the property and trigger the OS event IF the pattern is already built.
@@ -470,7 +477,7 @@ namespace OSFramework.OSUI.Patterns.Sidebar {
 
 			this.setHtmlElements();
 
-			this._handleFocusTrap();
+			this._handleFocusBehavior();
 
 			this._setInitialCssClasses();
 

--- a/src/scripts/OSFramework/OSUI/Pattern/Sidebar/Sidebar.ts
+++ b/src/scripts/OSFramework/OSUI/Pattern/Sidebar/Sidebar.ts
@@ -78,7 +78,7 @@ namespace OSFramework.OSUI.Patterns.Sidebar {
 					);
 				}
 			}
-			this._focusManagerInstance.returnFocusToElement();
+			this._focusManagerInstance.setFocusToStoredElement();
 		}
 
 		/**


### PR DESCRIPTION
This PR is for create the abstraction to focus on the trigger when we close a component (sidebar, notification, balloon and bottom sheet) 

### What was happening
- When we close the notification, stay focused on the notification element. The element is hidden but the screen reader keeps focused on the element.
- When the sidebar is closed, it does not return focus to the previous focusable element
- When a component starts opening, the focus was set to the body when closed.

### What was done
- Created the FocusManager class to be instantiated in overlay components to manage the focus when closing the component.
   - The FocusManager.storeLastFocusedElement stores the element activeElement reference
   - The FocusManager.returnFocusToElement return the focus to the stored element. If the element does not exist on the page, is not focusable or is disabled, the focus is set to the first focusable element in the page.

### Test Steps
1. Go to a page with a notification that starts opening
2. Check that when the notification is closed, the focus goes to the first focusable element on the page

1. Go to a page with button to open the notification
2. Click on the button.
3. Check that when the notification is closed, the focus returns to the button.

### Checklist

-   [x] tested locally
-   [x] documented the code
-   [x] clean all warnings and errors of eslint
-   [ ] requires changes in OutSystems (if so, provide a module with changes)
-   [ ] requires new sample page in OutSystems (if so, provide a module with changes)
