### PR TITLE
[ROU-4493]: DatePicker - Fixed issue when InitialDate = MinDate

### DIFF
--- a/src/scripts/Providers/OSUI/Datepicker/Flatpickr/AbstractFlatpickrConfig.ts
+++ b/src/scripts/Providers/OSUI/Datepicker/Flatpickr/AbstractFlatpickrConfig.ts
@@ -169,7 +169,7 @@ namespace Providers.OSUI.Datepicker.Flatpickr {
 			} else if (this._isUsingDateTime) {
 				return _finalDate;
 			} else {
-				return OSFramework.OSUI.Helper.Dates.NormalizeDateTime(_finalDate);
+				return OSFramework.OSUI.Helper.Dates.NormalizeDateTime(_finalDate, date === this.MaxDate);
 			}
 		}
 


### PR DESCRIPTION
This PR is for fix an issue at DatePicker when Initial and Min date were the same that was blocking the ability on selecting the MinDate.