### PR TITLE
Update Virtual Select v1.0.40

### DIFF
--- a/dist/OutSystemsUI.css
+++ b/dist/OutSystemsUI.css
@@ -793,7 +793,8 @@ body,
 }
 .phone .layout .main-content .layout.layout-native{
   -servicestudio-min-width:100vw;
-} /*! 3.2. Header */
+}
+/*! 3.2. Header */
 .header{
   background-color:var(--header-color);
   -webkit-box-shadow:0 1px 5px 0 rgba(21, 24, 26, 0.1);
@@ -4650,7 +4651,7 @@ span.flatpickr-weekday{
 }
 /*! 5.4. VirtualSelect */
 /*!
- * Virtual Select v1.0.39
+ * Virtual Select v1.0.40
  * https://sa-si-dev.github.io/virtual-select
  * Licensed under MIT (https://github.com/sa-si-dev/virtual-select/blob/master/LICENSE)
  */
@@ -8467,14 +8468,17 @@ span.flatpickr-weekday{
   display:none;
   -moz-appearance:none;
 }
-.osui-datepicker input:first-of-type{
-  display:none !important;
-}
 .osui-datepicker input.flatpickr-input[disabled] + input{
   background-color:var(--color-neutral-2);
   border:var(--border-size-s) solid var(--color-neutral-4);
   color:var(--color-neutral-6);
   pointer-events:none;
+}
+.osui-datepicker > span > input:first-of-type{
+  display:none !important;
+}
+.osui-datepicker > span > input:first-of-type{
+  -servicestudio-display:inline-flex !important;
 }
 .osui-datepicker-calendar-ss-preview{
   display:none;
@@ -9555,14 +9559,17 @@ body.vscomp-popup-active .vscomp-wrapper{
 .osui-monthpicker .not-valid + .flatpickr-mobile{
   border-color:var(--color-error);
 }
-.osui-monthpicker input:first-of-type{
-  display:none !important;
-}
 .osui-monthpicker input[disabled] + input{
   background-color:var(--color-neutral-2);
   border:var(--border-size-s) solid var(--color-neutral-4);
   color:var(--color-neutral-6);
   pointer-events:none;
+}
+.osui-monthpicker > span > input:first-of-type{
+  display:none !important;
+}
+.osui-monthpicker > span > input:first-of-type{
+  -servicestudio-display:inline-flex !important;
 }
 .form .osui-monthpicker-ss-preview{
   -servicestudio-margin-top:-22px;
@@ -10517,14 +10524,17 @@ body.vscomp-popup-active .vscomp-wrapper{
   display:none;
   -moz-appearance:none;
 }
-.osui-timepicker input:first-of-type{
-  display:none !important;
-}
 .osui-timepicker input.flatpickr-input[disabled] + input{
   background-color:var(--color-neutral-2);
   border:var(--border-size-s) solid var(--color-neutral-4);
   color:var(--color-neutral-6);
   pointer-events:none;
+}
+.osui-timepicker > span > input:first-of-type{
+  display:none !important;
+}
+.osui-timepicker > span > input:first-of-type{
+  -servicestudio-display:inline-flex !important;
 }
 .osui-timepicker__dropdown-ss-preview{
   display:none;
@@ -10532,7 +10542,7 @@ body.vscomp-popup-active .vscomp-wrapper{
 }
 .osui-timepicker__dropdown-ss-preview{
   -servicestudio-background-color:transparent;
-  -servicestudio-background-position:top center;
+  -servicestudio-background-position:top left;
   -servicestudio-background-repeat:no-repeat;
   -servicestudio-background-size:contain;
   -servicestudio-border-radius:var(--border-radius-soft);

--- a/dist/OutSystemsUI.d.ts
+++ b/dist/OutSystemsUI.d.ts
@@ -5432,7 +5432,7 @@ declare namespace Providers.OSUI.Dropdown.VirtualSelect {
 declare namespace Providers.OSUI.Dropdown.VirtualSelect.Enum {
     enum ProviderInfo {
         Name = "VirtualSelect",
-        Version = "1.0.39"
+        Version = "1.0.40"
     }
     enum CssClass {
         ErrorMessage = "osui-dropdown-error-message",

--- a/dist/OutSystemsUI.js
+++ b/dist/OutSystemsUI.js
@@ -17695,7 +17695,7 @@ var Providers;
                             return _finalDate;
                         }
                         else {
-                            return OSFramework.OSUI.Helper.Dates.NormalizeDateTime(_finalDate);
+                            return OSFramework.OSUI.Helper.Dates.NormalizeDateTime(_finalDate, date === this.MaxDate);
                         }
                     }
                     getProviderConfig() {
@@ -19034,7 +19034,7 @@ var Providers;
                     let ProviderInfo;
                     (function (ProviderInfo) {
                         ProviderInfo["Name"] = "VirtualSelect";
-                        ProviderInfo["Version"] = "1.0.39";
+                        ProviderInfo["Version"] = "1.0.40";
                     })(ProviderInfo = Enum.ProviderInfo || (Enum.ProviderInfo = {}));
                     let CssClass;
                     (function (CssClass) {

--- a/package.json
+++ b/package.json
@@ -65,6 +65,6 @@
 		"typedoc-plugin-merge-modules": "^4.0.1",
 		"typedoc-umlclass": "^0.7.0",
 		"typescript": "^4.5.0",
-		"virtual-select-plugin": "1.0.39"
+		"virtual-select-plugin": "1.0.40"
 	}
 }

--- a/src/scripts/Providers/OSUI/Dropdown/VirtualSelect/AbstractVirtualSelectEnum.ts
+++ b/src/scripts/Providers/OSUI/Dropdown/VirtualSelect/AbstractVirtualSelectEnum.ts
@@ -5,7 +5,7 @@ namespace Providers.OSUI.Dropdown.VirtualSelect.Enum {
 	 */
 	export enum ProviderInfo {
 		Name = 'VirtualSelect',
-		Version = '1.0.39',
+		Version = '1.0.40',
 	}
 
 	/**

--- a/src/scripts/Providers/OSUI/Dropdown/VirtualSelect/scss/_virtualselect_lib.scss
+++ b/src/scripts/Providers/OSUI/Dropdown/VirtualSelect/scss/_virtualselect_lib.scss
@@ -1,5 +1,5 @@
 /*!
- * Virtual Select v1.0.39
+ * Virtual Select v1.0.40
  * https://sa-si-dev.github.io/virtual-select
  * Licensed under MIT (https://github.com/sa-si-dev/virtual-select/blob/master/LICENSE)
  */
@@ -401,7 +401,10 @@
 }
 .vscomp-wrapper.focused .vscomp-toggle-button,
 .vscomp-wrapper:focus .vscomp-toggle-button {
-	box-shadow: 0 2px 2px 0 rgba(0, 0, 0, 0.14), 0 3px 1px -2px rgba(0, 0, 0, 0.12), 0 1px 5px 0 rgba(0, 0, 0, 0.2);
+	box-shadow:
+		0 2px 2px 0 rgba(0, 0, 0, 0.14),
+		0 3px 1px -2px rgba(0, 0, 0, 0.12),
+		0 1px 5px 0 rgba(0, 0, 0, 0.2);
 }
 .vscomp-wrapper.closed .vscomp-dropbox-container,
 .vscomp-wrapper.closed.vscomp-dropbox-wrapper {
@@ -454,7 +457,10 @@
 .vscomp-wrapper.keep-always-open.focused,
 .vscomp-wrapper.keep-always-open:focus,
 .vscomp-wrapper.keep-always-open:hover {
-	box-shadow: 0 2px 2px 0 rgba(0, 0, 0, 0.14), 0 3px 1px -2px rgba(0, 0, 0, 0.12), 0 1px 5px 0 rgba(0, 0, 0, 0.2);
+	box-shadow:
+		0 2px 2px 0 rgba(0, 0, 0, 0.14),
+		0 3px 1px -2px rgba(0, 0, 0, 0.12),
+		0 1px 5px 0 rgba(0, 0, 0, 0.2);
 }
 .vscomp-wrapper.server-searching .vscomp-options-list {
 	display: none;
@@ -613,7 +619,10 @@
 	opacity: 0;
 	color: #000;
 	background-color: #fff;
-	box-shadow: 0 2px 2px 0 rgba(0, 0, 0, 0.14), 0 3px 1px -2px rgba(0, 0, 0, 0.12), 0 1px 5px 0 rgba(0, 0, 0, 0.2);
+	box-shadow:
+		0 2px 2px 0 rgba(0, 0, 0, 0.14),
+		0 3px 1px -2px rgba(0, 0, 0, 0.12),
+		0 1px 5px 0 rgba(0, 0, 0, 0.2);
 	text-align: left;
 	flex-wrap: wrap;
 	z-index: 1;
@@ -634,7 +643,10 @@
 	width: 16px;
 	height: 16px;
 	background-color: #fff;
-	box-shadow: 0 2px 2px 0 rgba(0, 0, 0, 0.14), 0 3px 1px -2px rgba(0, 0, 0, 0.12), 0 1px 5px 0 rgba(0, 0, 0, 0.2);
+	box-shadow:
+		0 2px 2px 0 rgba(0, 0, 0, 0.14),
+		0 3px 1px -2px rgba(0, 0, 0, 0.12),
+		0 1px 5px 0 rgba(0, 0, 0, 0.2);
 	-webkit-transform-origin: left top;
 	transform-origin: left top;
 	-webkit-transform: rotate(45deg);


### PR DESCRIPTION
This PR is to update Virtual Select v1.0.40.

### What was done

- Now, Dropdown Search and Dropdown Tags will be using the latest version of their library provider (VirtualSelect v1.0.40).

### Test Steps

**Test Case 1 - Regression:**

1. Go to Tests_DropdownSearch
2. Run regression tests
4. Repeated the same tests on Tests_DropdownTags 

**Test Case 1 - Focus Issue with Starting Values:**

1. Go to Test_StartingValues_DropdownSearch
2. Check that the screen stays on the top and not focus on the bottom Dropdown
4. Repeated the same tests with a Test_StartingValues_DropdownTags 



### Checklist

-   [X] tested locally
-   [X] documented the code
-   [X] clean all warnings and errors of eslint
-   [X] requires changes in OutSystems
-   [ ] requires new sample page in OutSystems (if so, provide a module with changes)
