### PR TITLE
ROU-4510: Added alternate fix for the Tabs fix

### DIFF
--- a/dist/OutSystemsUI.css
+++ b/dist/OutSystemsUI.css
@@ -1,6 +1,6 @@
 @charset "UTF-8";
 /*!
-OutSystems UI 2.17.0
+OutSystems UI 2.18.0
 Website:
  • https://www.outsystems.com/outsystems-ui
 GitHub:
@@ -4967,7 +4967,9 @@ span.flatpickr-weekday{
   padding:0 5px 0 15px;
 }
 .vscomp-search-label,
-.vscomp-live-region{
+.vscomp-live-region,
+.vscomp-dropbox-container-top,
+.vscomp-dropbox-container-bottom{
   border:0;
   clip:rect(0 0 0 0);
   height:1px;
@@ -11705,9 +11707,6 @@ html[data-uieditorversion^="1"] .osui-timepicker__dropdown-ss-preview.time12h, h
 .osx.edge .section-expandable .osui-tabs__header__indicator{
   -webkit-perspective:1000px;
           perspective:1000px;
-}
-.desktop .osui-tabs__content-item:not(.osui-tabs--is-active) *{
-  visibility:hidden;
 }
 .osui-tabs__preview{
   display:none;

--- a/dist/OutSystemsUI.d.ts
+++ b/dist/OutSystemsUI.d.ts
@@ -80,7 +80,7 @@ declare namespace OSFramework.OSUI.Constants {
     const AccessibilityHideElementClass = "wcag-hide-text";
     const IsRTLClass = "is-rtl";
     const NoTransition = "no-transition";
-    const OSUIVersion = "2.17.0";
+    const OSUIVersion = "2.18.0";
     const ZeroValue = 0;
 }
 declare namespace OSFramework.OSUI.ErrorCodes {
@@ -3264,6 +3264,9 @@ declare namespace OSFramework.OSUI.Patterns.Tabs.Enum {
     enum ObserverOptions {
         RootMargin = "1px"
     }
+    enum ElementsBlockingOnChange {
+        Dropdown = ".pop-comp-active"
+    }
     enum ChildTypes {
         TabsContentItem = "TabsContentItem",
         TabsHeaderItem = "TabsHeaderItem"
@@ -5370,7 +5373,6 @@ declare namespace Providers.OSUI.Dropdown.VirtualSelect {
         constructor(uniqueId: string, configs: C);
         private _addErrorMessage;
         private _manageAttributes;
-        private _manageDisableStatus;
         private _onMouseUp;
         private _onSelectedOption;
         private _onWindowResize;

--- a/dist/OutSystemsUI.js
+++ b/dist/OutSystemsUI.js
@@ -1,5 +1,5 @@
 /*!
-OutSystems UI 2.17.0
+OutSystems UI 2.18.0
 Website:
  • https://www.outsystems.com/outsystems-ui
 GitHub:
@@ -135,7 +135,7 @@ var OSFramework;
             Constants.AccessibilityHideElementClass = 'wcag-hide-text';
             Constants.IsRTLClass = 'is-rtl';
             Constants.NoTransition = 'no-transition';
-            Constants.OSUIVersion = '2.17.0';
+            Constants.OSUIVersion = '2.18.0';
             Constants.ZeroValue = 0;
         })(Constants = OSUI.Constants || (OSUI.Constants = {}));
     })(OSUI = OSFramework.OSUI || (OSFramework.OSUI = {}));
@@ -9888,6 +9888,10 @@ var OSFramework;
                     (function (ObserverOptions) {
                         ObserverOptions["RootMargin"] = "1px";
                     })(ObserverOptions = Enum.ObserverOptions || (Enum.ObserverOptions = {}));
+                    let ElementsBlockingOnChange;
+                    (function (ElementsBlockingOnChange) {
+                        ElementsBlockingOnChange["Dropdown"] = ".pop-comp-active";
+                    })(ElementsBlockingOnChange = Enum.ElementsBlockingOnChange || (Enum.ElementsBlockingOnChange = {}));
                     let ChildTypes;
                     (function (ChildTypes) {
                         ChildTypes["TabsContentItem"] = "TabsContentItem";
@@ -10385,7 +10389,8 @@ var OSFramework;
                     }
                     changeTab(tabIndex = this.configs.StartingTab, tabsHeaderItem, triggerEvent = false, triggeredByObserver = false) {
                         if (this._activeTabHeaderElement === tabsHeaderItem ||
-                            (tabIndex === this.configs.StartingTab && this.isBuilt && tabsHeaderItem === undefined)) {
+                            (tabIndex === this.configs.StartingTab && this.isBuilt && tabsHeaderItem === undefined) ||
+                            this._activeTabContentElement.selfElement.querySelector(Tabs_1.Enum.ElementsBlockingOnChange.Dropdown)) {
                             return;
                         }
                         let newTabIndex;
@@ -18644,16 +18649,7 @@ var Providers;
                         }
                     }
                     _manageAttributes() {
-                        this._manageDisableStatus();
                         this.setA11YProperties();
-                    }
-                    _manageDisableStatus() {
-                        if (this.configs.IsDisabled) {
-                            OSFramework.OSUI.Helper.Dom.Attribute.Set(this.selfElement, OSFramework.OSUI.GlobalEnum.HTMLAttributes.Disabled, '');
-                        }
-                        else {
-                            OSFramework.OSUI.Helper.Dom.Attribute.Remove(this.selfElement, OSFramework.OSUI.GlobalEnum.HTMLAttributes.Disabled);
-                        }
                     }
                     _onMouseUp(event) {
                         event.preventDefault();
@@ -18745,8 +18741,6 @@ var Providers;
                         if (this.isBuilt) {
                             switch (propertyName) {
                                 case OSFramework.OSUI.Patterns.Dropdown.Enum.Properties.IsDisabled:
-                                    this._manageDisableStatus();
-                                    break;
                                 case VirtualSelect.Enum.Properties.NoOptionsText:
                                 case VirtualSelect.Enum.Properties.NoResultsText:
                                 case VirtualSelect.Enum.Properties.OptionsList:
@@ -18768,9 +18762,9 @@ var Providers;
                         OSFramework.OSUI.Helper.AsyncInvocation(this.virtualselectConfigs.close.bind(this.virtualselectConfigs));
                     }
                     disable() {
-                        if (this.configs.IsDisabled === false) {
+                        if (this.configs.IsDisabled === false && this.provider !== undefined) {
                             this.configs.IsDisabled = true;
-                            this._manageDisableStatus();
+                            this.provider.$ele.disable();
                         }
                     }
                     dispose() {
@@ -18789,9 +18783,9 @@ var Providers;
                         super.dispose();
                     }
                     enable() {
-                        if (this.configs.IsDisabled) {
+                        if (this.configs.IsDisabled && this.provider !== undefined) {
                             this.configs.IsDisabled = false;
-                            this._manageDisableStatus();
+                            this.provider.$ele.enable();
                         }
                     }
                     getSelectedValues() {
@@ -18971,6 +18965,7 @@ var Providers;
                         this._groupedOptionsList = groupedOptionsList;
                         this._providerOptions = {
                             ele: this.ElementId,
+                            disabled: this.IsDisabled,
                             dropboxWrapper: OSFramework.OSUI.GlobalEnum.HTMLElement.Body,
                             hasOptionDescription: hasDescription,
                             hideClearButton: false,

--- a/src/scripts/OSFramework/OSUI/Pattern/Tabs/Enum.ts
+++ b/src/scripts/OSFramework/OSUI/Pattern/Tabs/Enum.ts
@@ -72,6 +72,13 @@ namespace OSFramework.OSUI.Patterns.Tabs.Enum {
 	}
 
 	/**
+	 * Tabs Enum for Selectors of elements that can block OnChange event
+	 */
+	export enum ElementsBlockingOnChange {
+		Dropdown = '.pop-comp-active',
+	}
+
+	/**
 	 * Tabs Enum for Tabs child types
 	 */
 	export enum ChildTypes {

--- a/src/scripts/OSFramework/OSUI/Pattern/Tabs/Tabs.ts
+++ b/src/scripts/OSFramework/OSUI/Pattern/Tabs/Tabs.ts
@@ -1048,7 +1048,9 @@ namespace OSFramework.OSUI.Patterns.Tabs {
 			if (
 				this._activeTabHeaderElement === tabsHeaderItem ||
 				// to prevent triggering event if using client action SetActiveTab to set the already active item
-				(tabIndex === this.configs.StartingTab && this.isBuilt && tabsHeaderItem === undefined)
+				(tabIndex === this.configs.StartingTab && this.isBuilt && tabsHeaderItem === undefined) ||
+				// To prevent changing tab when a dropdown is currently open, which would cause UI issues
+				this._activeTabContentElement.selfElement.querySelector(Enum.ElementsBlockingOnChange.Dropdown)
 			) {
 				return;
 			}

--- a/src/scripts/OSFramework/OSUI/Pattern/Tabs/scss/_tabs.scss
+++ b/src/scripts/OSFramework/OSUI/Pattern/Tabs/scss/_tabs.scss
@@ -363,13 +363,6 @@
 	}
 }
 
-// Fix issue when patterns like Dropdown are open when the header click is triggered.
-.desktop {
-	.osui-tabs__content-item:not(.osui-tabs--is-active) * {
-		visibility: hidden;
-	} 
-}
-
 // Service Studio Preview Message
 .osui-tabs__preview {
 	display: none;

--- a/src/scss/OutSystemsUI.scss
+++ b/src/scss/OutSystemsUI.scss
@@ -17,7 +17,7 @@ PS: This comment will not be visible at the compiled version!
 =============================================================================== */
 
 /*!
-OutSystems UI 2.17.0
+OutSystems UI 2.18.0
 Website:
  • https://www.outsystems.com/outsystems-ui
 GitHub:


### PR DESCRIPTION
This PR is for reverting the previous PR for this ROU, as it was adding some layout shifting in some scenarios.

Now, instead of a CSS solution, we validating the existence of an active dropdown on the active content item, and prevent the OnChange in case there's one (making it mandatory for the dropdown to be closed first). 

This solution was implemented instead of the CSS one with :has(), due to lack of Firefox support.

### Checklist

-   [x] tested locally
-   [x] documented the code
-   [x] clean all warnings and errors of eslint
-   [ ] requires changes in OutSystems (if so, provide a module with changes)
-   [ ] requires new sample page in OutSystems (if so, provide a module with changes)
