### PR TITLE
ROU-4372: Tabs A11y improvements

### DIFF
--- a/dist/OutSystemsUI.css
+++ b/dist/OutSystemsUI.css
@@ -1,6 +1,6 @@
 @charset "UTF-8";
 /*!
-OutSystems UI 2.17.0
+OutSystems UI 2.18.0
 Website:
  • https://www.outsystems.com/outsystems-ui
 GitHub:
@@ -4967,7 +4967,9 @@ span.flatpickr-weekday{
   padding:0 5px 0 15px;
 }
 .vscomp-search-label,
-.vscomp-live-region{
+.vscomp-live-region,
+.vscomp-dropbox-container-top,
+.vscomp-dropbox-container-bottom{
   border:0;
   clip:rect(0 0 0 0);
   height:1px;

--- a/dist/OutSystemsUI.d.ts
+++ b/dist/OutSystemsUI.d.ts
@@ -80,7 +80,7 @@ declare namespace OSFramework.OSUI.Constants {
     const AccessibilityHideElementClass = "wcag-hide-text";
     const IsRTLClass = "is-rtl";
     const NoTransition = "no-transition";
-    const OSUIVersion = "2.17.0";
+    const OSUIVersion = "2.18.0";
     const ZeroValue = 0;
 }
 declare namespace OSFramework.OSUI.ErrorCodes {
@@ -342,8 +342,10 @@ declare namespace OSFramework.OSUI.GlobalEnum {
         ArrowLeft = "ArrowLeft",
         ArrowRight = "ArrowRight",
         ArrowUp = "ArrowUp",
+        End = "End",
         Enter = "Enter",
         Escape = "Escape",
+        Home = "Home",
         Shift = "Shift",
         ShiftTab = "ShiftTab",
         Space = " ",
@@ -5370,7 +5372,6 @@ declare namespace Providers.OSUI.Dropdown.VirtualSelect {
         constructor(uniqueId: string, configs: C);
         private _addErrorMessage;
         private _manageAttributes;
-        private _manageDisableStatus;
         private _onMouseUp;
         private _onSelectedOption;
         private _onWindowResize;

--- a/dist/OutSystemsUI.d.ts
+++ b/dist/OutSystemsUI.d.ts
@@ -37,6 +37,7 @@ declare namespace OSFramework.OSUI.Constants {
             Listbox: string;
             MenuItem: string;
             Option: string;
+            Presentation: string;
             Progressbar: string;
             Region: string;
             Search: string;
@@ -1083,6 +1084,7 @@ declare namespace OSFramework.OSUI.Helper {
         static RoleListbox(element: HTMLElement): void;
         static RoleMenuItem(element: HTMLElement): void;
         static RoleOption(element: HTMLElement): void;
+        static RolePresentation(element: HTMLElement): void;
         static RoleProgressBar(element: HTMLElement): void;
         static RoleRegion(element: HTMLElement): void;
         static RoleSearch(element: HTMLElement): void;

--- a/dist/OutSystemsUI.js
+++ b/dist/OutSystemsUI.js
@@ -1,5 +1,5 @@
 /*!
-OutSystems UI 2.17.0
+OutSystems UI 2.18.0
 Website:
  • https://www.outsystems.com/outsystems-ui
 GitHub:
@@ -135,7 +135,7 @@ var OSFramework;
             Constants.AccessibilityHideElementClass = 'wcag-hide-text';
             Constants.IsRTLClass = 'is-rtl';
             Constants.NoTransition = 'no-transition';
-            Constants.OSUIVersion = '2.17.0';
+            Constants.OSUIVersion = '2.18.0';
             Constants.ZeroValue = 0;
         })(Constants = OSUI.Constants || (OSUI.Constants = {}));
     })(OSUI = OSFramework.OSUI || (OSFramework.OSUI = {}));
@@ -421,8 +421,10 @@ var OSFramework;
                 Keycodes["ArrowLeft"] = "ArrowLeft";
                 Keycodes["ArrowRight"] = "ArrowRight";
                 Keycodes["ArrowUp"] = "ArrowUp";
+                Keycodes["End"] = "End";
                 Keycodes["Enter"] = "Enter";
                 Keycodes["Escape"] = "Escape";
+                Keycodes["Home"] = "Home";
                 Keycodes["Shift"] = "Shift";
                 Keycodes["ShiftTab"] = "ShiftTab";
                 Keycodes["Space"] = " ";
@@ -10023,6 +10025,14 @@ var OSFramework;
                                 }
                                 this.changeTab(targetHeaderItemIndex, undefined, true);
                                 break;
+                            case OSUI.GlobalEnum.Keycodes.End:
+                                targetHeaderItemIndex = this.getChildItems(Tabs_1.Enum.ChildTypes.TabsHeaderItem).length - 1;
+                                this.changeTab(targetHeaderItemIndex, undefined, true);
+                                break;
+                            case OSUI.GlobalEnum.Keycodes.Home:
+                                targetHeaderItemIndex = 0;
+                                this.changeTab(targetHeaderItemIndex, undefined, true);
+                                break;
                         }
                         const targetHeaderItem = this.getChildByIndex(targetHeaderItemIndex, Tabs_1.Enum.ChildTypes.TabsHeaderItem);
                         if (targetHeaderItem) {
@@ -10622,7 +10632,7 @@ var OSFramework;
                     }
                     setA11YProperties(isUpdate = true) {
                         if (isUpdate === false) {
-                            OSUI.Helper.A11Y.RoleTab(this.selfElement);
+                            OSUI.Helper.A11Y.RoleTab(this.selfElement.parentElement);
                         }
                         if (this._isActive) {
                             OSUI.Helper.A11Y.TabIndexTrue(this.selfElement);
@@ -18644,16 +18654,7 @@ var Providers;
                         }
                     }
                     _manageAttributes() {
-                        this._manageDisableStatus();
                         this.setA11YProperties();
-                    }
-                    _manageDisableStatus() {
-                        if (this.configs.IsDisabled) {
-                            OSFramework.OSUI.Helper.Dom.Attribute.Set(this.selfElement, OSFramework.OSUI.GlobalEnum.HTMLAttributes.Disabled, '');
-                        }
-                        else {
-                            OSFramework.OSUI.Helper.Dom.Attribute.Remove(this.selfElement, OSFramework.OSUI.GlobalEnum.HTMLAttributes.Disabled);
-                        }
                     }
                     _onMouseUp(event) {
                         event.preventDefault();
@@ -18745,8 +18746,6 @@ var Providers;
                         if (this.isBuilt) {
                             switch (propertyName) {
                                 case OSFramework.OSUI.Patterns.Dropdown.Enum.Properties.IsDisabled:
-                                    this._manageDisableStatus();
-                                    break;
                                 case VirtualSelect.Enum.Properties.NoOptionsText:
                                 case VirtualSelect.Enum.Properties.NoResultsText:
                                 case VirtualSelect.Enum.Properties.OptionsList:
@@ -18768,9 +18767,9 @@ var Providers;
                         OSFramework.OSUI.Helper.AsyncInvocation(this.virtualselectConfigs.close.bind(this.virtualselectConfigs));
                     }
                     disable() {
-                        if (this.configs.IsDisabled === false) {
+                        if (this.configs.IsDisabled === false && this.provider !== undefined) {
                             this.configs.IsDisabled = true;
-                            this._manageDisableStatus();
+                            this.provider.$ele.disable();
                         }
                     }
                     dispose() {
@@ -18789,9 +18788,9 @@ var Providers;
                         super.dispose();
                     }
                     enable() {
-                        if (this.configs.IsDisabled) {
+                        if (this.configs.IsDisabled && this.provider !== undefined) {
                             this.configs.IsDisabled = false;
-                            this._manageDisableStatus();
+                            this.provider.$ele.enable();
                         }
                     }
                     getSelectedValues() {
@@ -18971,6 +18970,7 @@ var Providers;
                         this._groupedOptionsList = groupedOptionsList;
                         this._providerOptions = {
                             ele: this.ElementId,
+                            disabled: this.IsDisabled,
                             dropboxWrapper: OSFramework.OSUI.GlobalEnum.HTMLElement.Body,
                             hasOptionDescription: hasDescription,
                             hideClearButton: false,

--- a/dist/OutSystemsUI.js
+++ b/dist/OutSystemsUI.js
@@ -79,6 +79,7 @@ var OSFramework;
                     Listbox: 'listbox',
                     MenuItem: 'menuitem',
                     Option: 'option',
+                    Presentation: 'presentation',
                     Progressbar: 'progressbar',
                     Region: 'region',
                     Search: 'search',
@@ -2986,6 +2987,9 @@ var OSFramework;
                 }
                 static RoleOption(element) {
                     Helper.Dom.Attribute.Set(element, OSUI.Constants.A11YAttributes.Role.AttrName, OSUI.Constants.A11YAttributes.Role.Option);
+                }
+                static RolePresentation(element) {
+                    Helper.Dom.Attribute.Set(element, OSUI.Constants.A11YAttributes.Role.AttrName, OSUI.Constants.A11YAttributes.Role.Presentation);
                 }
                 static RoleProgressBar(element) {
                     Helper.Dom.Attribute.Set(element, OSUI.Constants.A11YAttributes.Role.AttrName, OSUI.Constants.A11YAttributes.Role.Progressbar);
@@ -10632,7 +10636,8 @@ var OSFramework;
                     }
                     setA11YProperties(isUpdate = true) {
                         if (isUpdate === false) {
-                            OSUI.Helper.A11Y.RoleTab(this.selfElement.parentElement);
+                            OSUI.Helper.A11Y.RoleTab(this.selfElement);
+                            OSUI.Helper.A11Y.RolePresentation(this.selfElement.parentElement);
                         }
                         if (this._isActive) {
                             OSUI.Helper.A11Y.TabIndexTrue(this.selfElement);

--- a/src/scripts/OSFramework/OSUI/Constants.ts
+++ b/src/scripts/OSFramework/OSUI/Constants.ts
@@ -33,6 +33,7 @@ namespace OSFramework.OSUI.Constants {
 			Listbox: 'listbox',
 			MenuItem: 'menuitem',
 			Option: 'option',
+			Presentation: 'presentation',
 			Progressbar: 'progressbar',
 			Region: 'region',
 			Search: 'search',

--- a/src/scripts/OSFramework/OSUI/GlobalEnum.ts
+++ b/src/scripts/OSFramework/OSUI/GlobalEnum.ts
@@ -250,8 +250,10 @@ namespace OSFramework.OSUI.GlobalEnum {
 		ArrowLeft = 'ArrowLeft',
 		ArrowRight = 'ArrowRight',
 		ArrowUp = 'ArrowUp',
+		End = 'End',
 		Enter = 'Enter',
 		Escape = 'Escape',
+		Home = 'Home',
 		Shift = 'Shift',
 		ShiftTab = 'ShiftTab', // Do not exist as a keyboard key, but used to manage this behaviour
 		Space = ' ',

--- a/src/scripts/OSFramework/OSUI/Helper/ManageAccessibility.ts
+++ b/src/scripts/OSFramework/OSUI/Helper/ManageAccessibility.ts
@@ -396,6 +396,17 @@ namespace OSFramework.OSUI.Helper {
 		}
 
 		/**
+		 * Method that will set the presentation role
+		 *
+		 * @static
+		 * @param {HTMLElement} element
+		 * @memberof A11Y
+		 */
+		public static RolePresentation(element: HTMLElement): void {
+			Dom.Attribute.Set(element, Constants.A11YAttributes.Role.AttrName, Constants.A11YAttributes.Role.Presentation);
+		}
+
+		/**
 		 * Method that will set the progressbar role
 		 *
 		 * @param {HTMLElement} element Target element to receive the role atributte

--- a/src/scripts/OSFramework/OSUI/Pattern/Tabs/Tabs.ts
+++ b/src/scripts/OSFramework/OSUI/Pattern/Tabs/Tabs.ts
@@ -278,6 +278,18 @@ namespace OSFramework.OSUI.Patterns.Tabs {
 
 					this.changeTab(targetHeaderItemIndex, undefined, true);
 					break;
+				case GlobalEnum.Keycodes.End:
+					targetHeaderItemIndex = this.getChildItems(Enum.ChildTypes.TabsHeaderItem).length - 1;
+
+					this.changeTab(targetHeaderItemIndex, undefined, true);
+
+					break;
+				case GlobalEnum.Keycodes.Home:
+					targetHeaderItemIndex = 0;
+
+					this.changeTab(targetHeaderItemIndex, undefined, true);
+
+					break;
 			}
 
 			const targetHeaderItem = this.getChildByIndex(targetHeaderItemIndex, Enum.ChildTypes.TabsHeaderItem);

--- a/src/scripts/OSFramework/OSUI/Pattern/TabsHeaderItem/TabsHeaderItem.ts
+++ b/src/scripts/OSFramework/OSUI/Pattern/TabsHeaderItem/TabsHeaderItem.ts
@@ -61,7 +61,7 @@ namespace OSFramework.OSUI.Patterns.TabsHeaderItem {
 		protected setA11YProperties(isUpdate = true): void {
 			// Static attribute to be added when the item is created
 			if (isUpdate === false) {
-				Helper.A11Y.RoleTab(this.selfElement);
+				Helper.A11Y.RoleTab(this.selfElement.parentElement);
 			}
 
 			// Dynamic values that need to be changed when toggling the active state

--- a/src/scripts/OSFramework/OSUI/Pattern/TabsHeaderItem/TabsHeaderItem.ts
+++ b/src/scripts/OSFramework/OSUI/Pattern/TabsHeaderItem/TabsHeaderItem.ts
@@ -61,7 +61,8 @@ namespace OSFramework.OSUI.Patterns.TabsHeaderItem {
 		protected setA11YProperties(isUpdate = true): void {
 			// Static attribute to be added when the item is created
 			if (isUpdate === false) {
-				Helper.A11Y.RoleTab(this.selfElement.parentElement);
+				Helper.A11Y.RoleTab(this.selfElement);
+				Helper.A11Y.RolePresentation(this.selfElement.parentElement);
 			}
 
 			// Dynamic values that need to be changed when toggling the active state

--- a/src/scss/OutSystemsUI.scss
+++ b/src/scss/OutSystemsUI.scss
@@ -17,7 +17,7 @@ PS: This comment will not be visible at the compiled version!
 =============================================================================== */
 
 /*!
-OutSystems UI 2.17.0
+OutSystems UI 2.18.0
 Website:
  • https://www.outsystems.com/outsystems-ui
 GitHub:


### PR DESCRIPTION
This PR is for adding improvements for the Tabs accessibility compliance.

- Added role="presentation" to each wrapper of the tabdsHeaderItem element
- Added keypress event for Home and End keys, to go to first and last element, respectively

### Checklist

-   [ ] tested locally
-   [ ] documented the code
-   [ ] clean all warnings and errors of eslint
-   [ ] requires changes in OutSystems (if so, provide a module with changes)
-   [ ] requires new sample page in OutSystems (if so, provide a module with changes)
