### PR TITLE
ROU-4504: add BottomSheet a11y improvements

### DIFF
--- a/dist/OutSystemsUI.js
+++ b/dist/OutSystemsUI.js
@@ -4461,9 +4461,17 @@ var OSFramework;
                         this._animateOnDragInstance.onDragStart(true, OSUI.GlobalEnum.Direction.Down, x, y, true, this.selfElement.clientHeight.toString());
                     }
                     _onkeypressCallback(e) {
-                        const isEscapedPressed = e.key === OSUI.GlobalEnum.Keycodes.Escape;
-                        if (isEscapedPressed && this._isOpen) {
-                            this.close();
+                        var _a, _b;
+                        switch (e.key) {
+                            case OSUI.GlobalEnum.Keycodes.Escape:
+                                this.close();
+                                break;
+                            case OSUI.GlobalEnum.Keycodes.End:
+                                (_a = this._focusTrapInstance.focusableElements[this._focusTrapInstance.focusableElements.length - 1]) === null || _a === void 0 ? void 0 : _a.focus();
+                                break;
+                            case OSUI.GlobalEnum.Keycodes.Home:
+                                (_b = this._focusTrapInstance.focusableElements[0]) === null || _b === void 0 ? void 0 : _b.focus();
+                                break;
                         }
                     }
                     _toggleBottomSheet(isOpen) {

--- a/dist/OutSystemsUI.js
+++ b/dist/OutSystemsUI.js
@@ -4522,7 +4522,7 @@ var OSFramework;
                     }
                     setA11YProperties() {
                         if (!this.isBuilt) {
-                            OSUI.Helper.Dom.Attribute.Set(this.selfElement, OSUI.Constants.A11YAttributes.Role.Complementary, true);
+                            OSUI.Helper.A11Y.RoleComplementary(this.selfElement);
                         }
                         OSUI.Helper.Dom.Attribute.Set(this.selfElement, OSUI.Constants.A11YAttributes.Aria.Hidden, (!this._isOpen).toString());
                         OSUI.Helper.Dom.Attribute.Set(this.selfElement, OSUI.Constants.A11YAttributes.TabIndex, this._isOpen

--- a/src/scripts/OSFramework/OSUI/Pattern/BottomSheet/BottomSheet.ts
+++ b/src/scripts/OSFramework/OSUI/Pattern/BottomSheet/BottomSheet.ts
@@ -304,7 +304,7 @@ namespace OSFramework.OSUI.Patterns.BottomSheet {
 		 */
 		protected setA11YProperties(): void {
 			if (!this.isBuilt) {
-				Helper.Dom.Attribute.Set(this.selfElement, Constants.A11YAttributes.Role.Complementary, true);
+				Helper.A11Y.RoleComplementary(this.selfElement);
 			}
 
 			Helper.Dom.Attribute.Set(

--- a/src/scripts/OSFramework/OSUI/Pattern/BottomSheet/BottomSheet.ts
+++ b/src/scripts/OSFramework/OSUI/Pattern/BottomSheet/BottomSheet.ts
@@ -191,12 +191,22 @@ namespace OSFramework.OSUI.Patterns.BottomSheet {
 		 * @memberof BottomSheet
 		 */
 		private _onkeypressCallback(e: KeyboardEvent): void {
-			const isEscapedPressed = e.key === GlobalEnum.Keycodes.Escape;
-
-			// Close the BottomSheet when pressing Esc
-			if (isEscapedPressed && this._isOpen) {
-				this.close();
+			switch (e.key) {
+				case GlobalEnum.Keycodes.Escape:
+					// Close the BottomSheet when pressing Esc
+					this.close();
+					break;
+			
+				case GlobalEnum.Keycodes.End:
+					// Focus on last focusable item
+					this._focusTrapInstance.focusableElements[this._focusTrapInstance.focusableElements.length - 1]?.focus();
+					break;
+				case GlobalEnum.Keycodes.Home:
+					// Focus on first focusable items (in this case, its the bottom sheet itself)
+					this._focusTrapInstance.focusableElements[0]?.focus();
+					break;
 			}
+
 		}
 
 		/**


### PR DESCRIPTION
This PR is for adding accessibility improvements to the BottomSheet

- Correct role is now applied
- Home/End keys support was added

### Checklist

-   [x] tested locally
-   [x] documented the code
-   [x] clean all warnings and errors of eslint
-   [x] requires changes in OutSystems (if so, provide a module with changes)
-   [ ] requires new sample page in OutSystems (if so, provide a module with changes)
