### PR TITLE
ROU-4533: Issue on Dropdown Server Side disabled using Enter and focus

### DIFF
--- a/dist/OutSystemsUI.d.ts
+++ b/dist/OutSystemsUI.d.ts
@@ -31,6 +31,7 @@ declare namespace OSFramework.OSUI.Constants {
         };
         Role: {
             Alert: string;
+            AlertDialog: string;
             AttrName: string;
             Button: string;
             Complementary: string;
@@ -5382,6 +5383,7 @@ declare namespace Providers.OSUI.Dropdown.VirtualSelect {
         constructor(uniqueId: string, configs: C);
         private _addErrorMessage;
         private _manageAttributes;
+        private _manageDisableStatus;
         private _onMouseUp;
         private _onSelectedOption;
         private _onWindowResize;

--- a/dist/OutSystemsUI.js
+++ b/dist/OutSystemsUI.js
@@ -73,6 +73,7 @@ var OSFramework;
                 },
                 Role: {
                     Alert: 'alert',
+                    AlertDialog: 'alertdialog',
                     AttrName: 'role',
                     Button: 'button',
                     Complementary: 'complementary',
@@ -5837,6 +5838,7 @@ var OSFramework;
                             OSUI.Helper.Dom.Attribute.Set(this.selfElement, OSUI.GlobalEnum.HTMLAttributes.Disabled, '');
                             OSUI.Helper.Dom.Attribute.Set(this._balloonWrapperElement, OSUI.GlobalEnum.HTMLAttributes.Disabled, '');
                             OSUI.Helper.Dom.Styles.AddClass(this.selfElement, ServerSide.Enum.CssClass.IsDisabled);
+                            OSUI.Helper.A11Y.TabIndexFalse(this._selectValuesWrapper);
                         }
                         dispose() {
                             this._unsetObserver();
@@ -5850,6 +5852,7 @@ var OSFramework;
                             OSUI.Helper.Dom.Attribute.Remove(this.selfElement, OSUI.GlobalEnum.HTMLAttributes.Disabled);
                             OSUI.Helper.Dom.Attribute.Remove(this._balloonWrapperElement, OSUI.GlobalEnum.HTMLAttributes.Disabled);
                             OSUI.Helper.Dom.Styles.RemoveClass(this.selfElement, ServerSide.Enum.CssClass.IsDisabled);
+                            OSUI.Helper.A11Y.TabIndexTrue(this._selectValuesWrapper);
                         }
                         getSelectedValues() {
                             return this._hasNoImplementation();
@@ -6868,7 +6871,7 @@ var OSFramework;
                         this._isOpen = this.configs.StartsOpen;
                     }
                     _autoCloseNotification() {
-                        setTimeout(() => {
+                        OSUI.Helper.ApplySetTimeOut(() => {
                             if (this._isOpen) {
                                 this.hide();
                             }
@@ -6975,7 +6978,7 @@ var OSFramework;
                         }
                     }
                     setA11YProperties() {
-                        OSUI.Helper.Dom.Attribute.Set(this.selfElement, OSUI.Constants.A11YAttributes.Role.AttrName, OSUI.Constants.A11YAttributes.Role.Alert);
+                        OSUI.Helper.Dom.Attribute.Set(this.selfElement, OSUI.Constants.A11YAttributes.Role.AttrName, OSUI.Constants.A11YAttributes.Role.AlertDialog);
                         this._updateA11yProperties();
                     }
                     setCallbacks() {
@@ -18717,6 +18720,14 @@ var Providers;
                     _manageAttributes() {
                         this.setA11YProperties();
                     }
+                    _manageDisableStatus() {
+                        if (this.configs.IsDisabled) {
+                            this.provider.$ele.disable();
+                        }
+                        else {
+                            this.provider.$ele.enable();
+                        }
+                    }
                     _onMouseUp(event) {
                         event.preventDefault();
                     }
@@ -18807,6 +18818,8 @@ var Providers;
                         if (this.isBuilt) {
                             switch (propertyName) {
                                 case OSFramework.OSUI.Patterns.Dropdown.Enum.Properties.IsDisabled:
+                                    this._manageDisableStatus();
+                                    break;
                                 case VirtualSelect.Enum.Properties.NoOptionsText:
                                 case VirtualSelect.Enum.Properties.NoResultsText:
                                 case VirtualSelect.Enum.Properties.OptionsList:

--- a/src/scripts/OSFramework/OSUI/Pattern/Dropdown/ServerSide/DropdownServerSide.ts
+++ b/src/scripts/OSFramework/OSUI/Pattern/Dropdown/ServerSide/DropdownServerSide.ts
@@ -1137,6 +1137,8 @@ namespace OSFramework.OSUI.Patterns.Dropdown.ServerSide {
 			Helper.Dom.Attribute.Set(this._balloonWrapperElement, GlobalEnum.HTMLAttributes.Disabled, '');
 			// Assign IsDisabled class
 			Helper.Dom.Styles.AddClass(this.selfElement, Enum.CssClass.IsDisabled);
+			// Assign tabindex value on values wrapper
+			Helper.A11Y.TabIndexFalse(this._selectValuesWrapper);
 		}
 
 		/**
@@ -1164,6 +1166,8 @@ namespace OSFramework.OSUI.Patterns.Dropdown.ServerSide {
 			Helper.Dom.Attribute.Remove(this._balloonWrapperElement, GlobalEnum.HTMLAttributes.Disabled);
 			// Remove IsDisabled class
 			Helper.Dom.Styles.RemoveClass(this.selfElement, Enum.CssClass.IsDisabled);
+			// Assign tabindex value on values wrapper
+			Helper.A11Y.TabIndexTrue(this._selectValuesWrapper);
 		}
 
 		/**


### PR DESCRIPTION
This PR is for changing the tabindex value based on disable state on Dropdown.


### What was happening
- When the DropdownServerSide has the disabled state applied, it's possible to focus on Dropdown using the keyboard.
![image](https://github.com/OutSystems/outsystems-ui/assets/25321845/53ccd697-bb8f-4860-b2e5-0755b8856bce)

### What was done
- Changed the tabindex value based on disable state.
![2023-09-06 14 49 18](https://github.com/OutSystems/outsystems-ui/assets/25321845/0b9fe2b8-becd-48d3-be16-daa6eede3367)

### Test Steps
**Test case 1**
1. Go to sample page
2. Enable the A11Y feature on header switch
3. Click on isDisabled checkbox
4. Click on Apply Button
5. Navigate using tab key 
Expected: The DropdownServerSide can't be selectable or clicked

**Test case 2**
1. Go to sample page
2. Enable the A11Y feature on header switch
3. isDisabled checkbox must be unchecked
4. Click on Apply Button
5. Navigate using tab key 
Expected: The DropdownServerSide can be selectable or clicked

### Checklist
-   [X] tested locally
-   [X] documented the code
-   [X] clean all warnings and errors of eslint
-   [ ] requires changes in OutSystems (if so, provide a module with changes)
-   [ ] requires new sample page in OutSystems (if so, provide a module with changes)
