### PR TITLE
ROU-4540: Fix issue on Datepicker that show the hidden datepicker input

### DIFF
--- a/dist/OutSystemsUI.css
+++ b/dist/OutSystemsUI.css
@@ -8544,10 +8544,10 @@ span.flatpickr-weekday{
   color:var(--color-neutral-6);
   pointer-events:none;
 }
-.osui-datepicker > span > input:first-of-type{
-  display:none !important;
+.osui-datepicker span > input.flatpickr-input:first-of-type{
+  display:none;
 }
-.osui-datepicker > span > input:first-of-type{
+.osui-datepicker span > input.flatpickr-input:first-of-type{
   -servicestudio-display:inline-flex !important;
 }
 .osui-datepicker-calendar-ss-preview{
@@ -9647,10 +9647,10 @@ body.vscomp-popup-active .vscomp-wrapper{
   color:var(--color-neutral-6);
   pointer-events:none;
 }
-.osui-monthpicker > span > input:first-of-type{
-  display:none !important;
+.osui-monthpicker span > input.flatpickr-input:first-of-type{
+  display:none;
 }
-.osui-monthpicker > span > input:first-of-type{
+.osui-monthpicker span > input.flatpickr-input:first-of-type{
   -servicestudio-display:inline-flex !important;
 }
 .form .osui-monthpicker-ss-preview{
@@ -10622,10 +10622,10 @@ body.vscomp-popup-active .vscomp-wrapper{
   color:var(--color-neutral-6);
   pointer-events:none;
 }
-.osui-timepicker > span > input:first-of-type{
-  display:none !important;
+.osui-timepicker span > input.flatpickr-input:first-of-type{
+  display:none;
 }
-.osui-timepicker > span > input:first-of-type{
+.osui-timepicker span > input.flatpickr-input:first-of-type{
   -servicestudio-display:inline-flex !important;
 }
 .osui-timepicker__dropdown-ss-preview{

--- a/dist/OutSystemsUI.css
+++ b/dist/OutSystemsUI.css
@@ -8544,10 +8544,10 @@ span.flatpickr-weekday{
   color:var(--color-neutral-6);
   pointer-events:none;
 }
-.osui-datepicker span > input.flatpickr-input:first-of-type{
+.osui-datepicker input.flatpickr-input:first-of-type{
   display:none;
 }
-.osui-datepicker span > input.flatpickr-input:first-of-type{
+.osui-datepicker input.flatpickr-input:first-of-type{
   -servicestudio-display:inline-flex !important;
 }
 .osui-datepicker-calendar-ss-preview{
@@ -9647,10 +9647,10 @@ body.vscomp-popup-active .vscomp-wrapper{
   color:var(--color-neutral-6);
   pointer-events:none;
 }
-.osui-monthpicker span > input.flatpickr-input:first-of-type{
+.osui-monthpicker input.flatpickr-input:first-of-type{
   display:none;
 }
-.osui-monthpicker span > input.flatpickr-input:first-of-type{
+.osui-monthpicker input.flatpickr-input:first-of-type{
   -servicestudio-display:inline-flex !important;
 }
 .form .osui-monthpicker-ss-preview{
@@ -10622,10 +10622,10 @@ body.vscomp-popup-active .vscomp-wrapper{
   color:var(--color-neutral-6);
   pointer-events:none;
 }
-.osui-timepicker span > input.flatpickr-input:first-of-type{
+.osui-timepicker input.flatpickr-input:first-of-type{
   display:none;
 }
-.osui-timepicker span > input.flatpickr-input:first-of-type{
+.osui-timepicker input.flatpickr-input:first-of-type{
   -servicestudio-display:inline-flex !important;
 }
 .osui-timepicker__dropdown-ss-preview{

--- a/src/scripts/OSFramework/OSUI/Pattern/DatePicker/scss/_datepicker.scss
+++ b/src/scripts/OSFramework/OSUI/Pattern/DatePicker/scss/_datepicker.scss
@@ -34,14 +34,12 @@
 	}
 
 	// Hide the platform input which is set as hidden by the library and we're change it into the expected type, however we do not want it visible since library will add a clone to better deal with the selected dates.
-	& span > input.flatpickr-input {
-		&:first-of-type {
-			display: none;
+	input.flatpickr-input:first-of-type {
+		display: none;
 
-			// Make the platform input visible in Service Studio
-			& {
-				-servicestudio-display: inline-flex !important;
-			}
+		// Make the platform input visible in Service Studio
+		& {
+			-servicestudio-display: inline-flex !important;
 		}
 	}
 

--- a/src/scripts/OSFramework/OSUI/Pattern/DatePicker/scss/_datepicker.scss
+++ b/src/scripts/OSFramework/OSUI/Pattern/DatePicker/scss/_datepicker.scss
@@ -34,9 +34,9 @@
 	}
 
 	// Hide the platform input which is set as hidden by the library and we're change it into the expected type, however we do not want it visible since library will add a clone to better deal with the selected dates.
-	& > span > input {
+	& span > input.flatpickr-input {
 		&:first-of-type {
-			display: none !important;
+			display: none;
 
 			// Make the platform input visible in Service Studio
 			& {

--- a/src/scripts/OSFramework/OSUI/Pattern/MonthPicker/scss/_monthpicker.scss
+++ b/src/scripts/OSFramework/OSUI/Pattern/MonthPicker/scss/_monthpicker.scss
@@ -56,9 +56,9 @@
 	}
 
 	// Hide the platform input which is set as hidden by the library and we're change it into the expected type, however we do not want it visible since library will add a clone to better deal with the selected dates.
-	& > span > input {
+	& span > input.flatpickr-input {
 		&:first-of-type {
-			display: none !important;
+			display: none;
 
 			// Make the platform input visible in Service Studio
 			& {

--- a/src/scripts/OSFramework/OSUI/Pattern/MonthPicker/scss/_monthpicker.scss
+++ b/src/scripts/OSFramework/OSUI/Pattern/MonthPicker/scss/_monthpicker.scss
@@ -56,14 +56,12 @@
 	}
 
 	// Hide the platform input which is set as hidden by the library and we're change it into the expected type, however we do not want it visible since library will add a clone to better deal with the selected dates.
-	& span > input.flatpickr-input {
-		&:first-of-type {
-			display: none;
+	input.flatpickr-input:first-of-type {
+		display: none;
 
-			// Make the platform input visible in Service Studio
-			& {
-				-servicestudio-display: inline-flex !important;
-			}
+		// Make the platform input visible in Service Studio
+		& {
+			-servicestudio-display: inline-flex !important;
 		}
 	}
 }

--- a/src/scripts/OSFramework/OSUI/Pattern/TimePicker/scss/_timepicker.scss
+++ b/src/scripts/OSFramework/OSUI/Pattern/TimePicker/scss/_timepicker.scss
@@ -34,14 +34,12 @@
 	}
 
 	// Hide the platform input which is set as hidden by the library and we're change it into the expected type, however we do not want it visible since library will add a clone to better deal with the selected dates.
-	& span > input.flatpickr-input {
-		&:first-of-type {
-			display: none;
+	input.flatpickr-input:first-of-type {
+		display: none;
 
-			// Make the platform input visible in Service Studio
-			& {
-				-servicestudio-display: inline-flex !important;
-			}
+		// Make the platform input visible in Service Studio
+		& {
+			-servicestudio-display: inline-flex !important;
 		}
 	}
 

--- a/src/scripts/OSFramework/OSUI/Pattern/TimePicker/scss/_timepicker.scss
+++ b/src/scripts/OSFramework/OSUI/Pattern/TimePicker/scss/_timepicker.scss
@@ -34,9 +34,9 @@
 	}
 
 	// Hide the platform input which is set as hidden by the library and we're change it into the expected type, however we do not want it visible since library will add a clone to better deal with the selected dates.
-	& > span > input {
+	& span > input.flatpickr-input {
 		&:first-of-type {
-			display: none !important;
+			display: none;
 
 			// Make the platform input visible in Service Studio
 			& {


### PR DESCRIPTION
This PR is for fixing an issue on Datepicker that show the hidden datepicker input.

### What was happening
- The Datepicker are showing the hidden input
![image](https://github.com/OutSystems/outsystems-ui/assets/25321845/905aaeb0-0e1e-4c29-87c8-8eb01196a953)

### What was done
- Change the selectors on CSS to hide the input
![image](https://github.com/OutSystems/outsystems-ui/assets/25321845/f3900df7-6fb8-4f5f-8c28-19cd0b2743e0)

### Test Steps
1. Open test page
2. Check the Pickers input
3. Expected: no duplicated input are shown

### Checklist
-   [X] tested locally
-   [X] documented the code
-   [X] clean all warnings and errors of eslint
-   [ ] requires changes in OutSystems (if so, provide a module with changes)
-   [ ] requires new sample page in OutSystems (if so, provide a module with changes)
