### PR TITLE
ROU-4529: Improve accessibility on the SkipContent link

### DIFF
--- a/dist/OutSystemsUI.d.ts
+++ b/dist/OutSystemsUI.d.ts
@@ -180,6 +180,7 @@ declare namespace OSFramework.OSUI.GlobalEnum {
         HeaderIsFixed = "fixed-header",
         HeaderIsVisible = "header-is--visible",
         HeaderTopContent = "header-top-content",
+        InputNotValid = "not-valid",
         IsTouch = "is--touch",
         Layout = "layout",
         LayoutNative = "layout-native",
@@ -190,7 +191,7 @@ declare namespace OSFramework.OSUI.GlobalEnum {
         MainContent = "main-content",
         MenuLinks = "app-menu-links",
         Placeholder = "ph",
-        InputNotValid = "not-valid"
+        SkipContent = "skip-nav"
     }
     enum CSSSelectors {
         InputFormControl = "input.form-control",
@@ -287,7 +288,8 @@ declare namespace OSFramework.OSUI.GlobalEnum {
         Name = "name",
         StatusBar = "data-status-bar-height",
         Style = "style",
-        Type = "type"
+        Type = "type",
+        Href = "href"
     }
     enum HTMLElement {
         Body = "body",
@@ -4618,6 +4620,12 @@ declare namespace OutSystems.OSUI.Utils.LayoutPrivate {
         private static _onOrientationChange;
         static Set(): void;
         static Unset(): void;
+    }
+}
+declare namespace OutSystems.OSUI.Utils.LayoutPrivate {
+    abstract class SkipContentLink {
+        private static _setLink;
+        static Set(): void;
     }
 }
 declare namespace OutSystems.OSUI.Utils {

--- a/dist/OutSystemsUI.js
+++ b/dist/OutSystemsUI.js
@@ -243,6 +243,7 @@ var OSFramework;
                 CssClassElements["HeaderIsFixed"] = "fixed-header";
                 CssClassElements["HeaderIsVisible"] = "header-is--visible";
                 CssClassElements["HeaderTopContent"] = "header-top-content";
+                CssClassElements["InputNotValid"] = "not-valid";
                 CssClassElements["IsTouch"] = "is--touch";
                 CssClassElements["Layout"] = "layout";
                 CssClassElements["LayoutNative"] = "layout-native";
@@ -253,7 +254,7 @@ var OSFramework;
                 CssClassElements["MainContent"] = "main-content";
                 CssClassElements["MenuLinks"] = "app-menu-links";
                 CssClassElements["Placeholder"] = "ph";
-                CssClassElements["InputNotValid"] = "not-valid";
+                CssClassElements["SkipContent"] = "skip-nav";
             })(CssClassElements = GlobalEnum.CssClassElements || (GlobalEnum.CssClassElements = {}));
             let CSSSelectors;
             (function (CSSSelectors) {
@@ -362,6 +363,7 @@ var OSFramework;
                 HTMLAttributes["StatusBar"] = "data-status-bar-height";
                 HTMLAttributes["Style"] = "style";
                 HTMLAttributes["Type"] = "type";
+                HTMLAttributes["Href"] = "href";
             })(HTMLAttributes = GlobalEnum.HTMLAttributes || (GlobalEnum.HTMLAttributes = {}));
             let HTMLElement;
             (function (HTMLElement) {
@@ -16348,6 +16350,31 @@ var OutSystems;
                     }
                 }
                 LayoutPrivate.OnOrientationChange = OnOrientationChange;
+            })(LayoutPrivate = Utils.LayoutPrivate || (Utils.LayoutPrivate = {}));
+        })(Utils = OSUI.Utils || (OSUI.Utils = {}));
+    })(OSUI = OutSystems.OSUI || (OutSystems.OSUI = {}));
+})(OutSystems || (OutSystems = {}));
+var OutSystems;
+(function (OutSystems) {
+    var OSUI;
+    (function (OSUI) {
+        var Utils;
+        (function (Utils) {
+            var LayoutPrivate;
+            (function (LayoutPrivate) {
+                class SkipContentLink {
+                    static _setLink() {
+                        const mainContent = OSFramework.OSUI.Helper.Dom.ClassSelector(document, OSFramework.OSUI.GlobalEnum.CssClassElements.MainContent);
+                        const skipContentLink = OSFramework.OSUI.Helper.Dom.ClassSelector(document, OSFramework.OSUI.GlobalEnum.CssClassElements.SkipContent);
+                        if (mainContent && skipContentLink) {
+                            skipContentLink.setAttribute(OSFramework.OSUI.GlobalEnum.HTMLAttributes.Href, mainContent.getAttribute(OSFramework.OSUI.GlobalEnum.HTMLAttributes.Id));
+                        }
+                    }
+                    static Set() {
+                        this._setLink();
+                    }
+                }
+                LayoutPrivate.SkipContentLink = SkipContentLink;
             })(LayoutPrivate = Utils.LayoutPrivate || (Utils.LayoutPrivate = {}));
         })(Utils = OSUI.Utils || (OSUI.Utils = {}));
     })(OSUI = OutSystems.OSUI || (OutSystems.OSUI = {}));

--- a/src/scripts/OSFramework/OSUI/GlobalEnum.ts
+++ b/src/scripts/OSFramework/OSUI/GlobalEnum.ts
@@ -80,8 +80,8 @@ namespace OSFramework.OSUI.GlobalEnum {
 	export enum FloatingPosition {
 		Auto = 'auto',
 		Bottom = 'bottom',
-		BottomStart = 'bottom-start',
 		BottomEnd = 'bottom-end',
+		BottomStart = 'bottom-start',
 		Center = 'center',
 		Left = 'left',
 		LeftEnd = 'left-end',
@@ -90,8 +90,8 @@ namespace OSFramework.OSUI.GlobalEnum {
 		RightEnd = 'right-end',
 		RightStart = 'right-start',
 		Top = 'top',
-		TopStart = 'top-start',
 		TopEnd = 'top-end',
+		TopStart = 'top-start',
 	}
 
 	/**
@@ -165,12 +165,12 @@ namespace OSFramework.OSUI.GlobalEnum {
 		Class = 'class',
 		DataInput = 'data-input',
 		Disabled = 'disabled',
+		Href = 'href',
 		Id = 'id',
 		Name = 'name',
 		StatusBar = 'data-status-bar-height',
 		Style = 'style',
 		Type = 'type',
-		Href = 'href',
 	}
 
 	/**
@@ -325,8 +325,8 @@ namespace OSFramework.OSUI.GlobalEnum {
 		Submenu = 'Submenu',
 		SwipeEvents = 'SwipeEvents',
 		Tabs = 'Tabs',
-		TabsHeaderItem = 'TabsHeaderItem',
 		TabsContentItem = 'TabsContentItem',
+		TabsHeaderItem = 'TabsHeaderItem',
 		Timepicker = 'Timepicker',
 		Tooltip = 'Tooltip',
 		TouchEvents = 'TouchEvents',

--- a/src/scripts/OSFramework/OSUI/GlobalEnum.ts
+++ b/src/scripts/OSFramework/OSUI/GlobalEnum.ts
@@ -23,6 +23,7 @@ namespace OSFramework.OSUI.GlobalEnum {
 		HeaderIsFixed = 'fixed-header',
 		HeaderIsVisible = 'header-is--visible',
 		HeaderTopContent = 'header-top-content',
+		InputNotValid = 'not-valid',
 		IsTouch = 'is--touch',
 		Layout = 'layout',
 		LayoutNative = 'layout-native',
@@ -33,7 +34,7 @@ namespace OSFramework.OSUI.GlobalEnum {
 		MainContent = 'main-content',
 		MenuLinks = 'app-menu-links',
 		Placeholder = 'ph',
-		InputNotValid = 'not-valid',
+		SkipContent = 'skip-nav',
 	}
 
 	/**
@@ -169,6 +170,7 @@ namespace OSFramework.OSUI.GlobalEnum {
 		StatusBar = 'data-status-bar-height',
 		Style = 'style',
 		Type = 'type',
+		Href = 'href',
 	}
 
 	/**

--- a/src/scripts/OutSystems/OSUI/Utils/LayoutPrivateSkipContentLink.ts
+++ b/src/scripts/OutSystems/OSUI/Utils/LayoutPrivateSkipContentLink.ts
@@ -1,0 +1,31 @@
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+namespace OutSystems.OSUI.Utils.LayoutPrivate {
+	export abstract class SkipContentLink {
+		// Function that will set the link on skip content to pass on A11Y checkers
+		private static _setLink(): void {
+			const mainContent = OSFramework.OSUI.Helper.Dom.ClassSelector(
+				document,
+				OSFramework.OSUI.GlobalEnum.CssClassElements.MainContent
+			);
+			const skipContentLink = OSFramework.OSUI.Helper.Dom.ClassSelector(
+				document,
+				OSFramework.OSUI.GlobalEnum.CssClassElements.SkipContent
+			);
+
+			// Check if elements exists on DOM to prevent errors on custom layouts
+			if (mainContent && skipContentLink) {
+				skipContentLink.setAttribute(
+					OSFramework.OSUI.GlobalEnum.HTMLAttributes.Href,
+					mainContent.getAttribute(OSFramework.OSUI.GlobalEnum.HTMLAttributes.Id)
+				);
+			}
+		}
+
+		/**
+		 * Function used to add link to skip content element
+		 */
+		public static Set(): void {
+			this._setLink();
+		}
+	}
+}


### PR DESCRIPTION
This PR is for adding an API to set the link on SkipContent to fix the warnings on A11Y checkers

### What was done
- Created an API to set the link on skip content element

### Test Steps
1. Open test page
2. Run an A11Y checker
3. Expected: No warnings related to skip content link

### Checklist
-   [X] tested locally
-   [X] documented the code
-   [X] clean all warnings and errors of eslint
-   [ ] requires changes in OutSystems (if so, provide a module with changes)
-   [ ] requires new sample page in OutSystems (if so, provide a module with changes)
