### PR TITLE
ROU-4537: Prevent scroll when using arrow up and down keys on OverflowMenu

### DIFF
--- a/dist/OutSystemsUI.js
+++ b/dist/OutSystemsUI.js
@@ -1888,6 +1888,7 @@ var OSFramework;
                             }
                             else if (isArrowDownPressed || isArrowUpPressed) {
                                 this._manageFocusInsideBalloon(e.key);
+                                e.preventDefault();
                             }
                         }
                         e.stopPropagation();
@@ -7281,6 +7282,7 @@ var OSFramework;
                             (event.key === OSUI.GlobalEnum.Keycodes.ArrowDown || event.key === OSUI.GlobalEnum.Keycodes.ArrowUp)) {
                             this._isOpenedByApi = false;
                             this.open(this._isOpenedByApi, event.key);
+                            event.preventDefault();
                         }
                     }
                     _setBalloonFeature() {

--- a/src/scripts/OSFramework/OSUI/Feature/Balloon/Balloon.ts
+++ b/src/scripts/OSFramework/OSUI/Feature/Balloon/Balloon.ts
@@ -119,6 +119,7 @@ namespace OSFramework.OSUI.Feature.Balloon {
 					// Move the focus between the balloon's focusable elements when pressing ArrowDown or ArrowUp
 				} else if (isArrowDownPressed || isArrowUpPressed) {
 					this._manageFocusInsideBalloon(e.key);
+					e.preventDefault(); // Prevent scroll
 				}
 			}
 

--- a/src/scripts/OSFramework/OSUI/Pattern/OverflowMenu/OverflowMenu.ts
+++ b/src/scripts/OSFramework/OSUI/Pattern/OverflowMenu/OverflowMenu.ts
@@ -63,6 +63,7 @@ namespace OSFramework.OSUI.Patterns.OverflowMenu {
 			) {
 				this._isOpenedByApi = false;
 				this.open(this._isOpenedByApi, event.key);
+				event.preventDefault(); // Prevent scroll
 			}
 		}
 


### PR DESCRIPTION
This PR is for prevent scroll when using arrow up and down keys on OverflowMenu

### What was happening
- When using the arrow up and down keys to open the OverflowMenu and navigate between the items, the page scroll up and down.

### What was done
- Added the event.preventDefault() to the keydown event handlers of Balloon and OverflowMenu.

### Checklist
-   [x] tested locally
-   [x] documented the code
-   [x] clean all warnings and errors of eslint
-   [ ] requires changes in OutSystems (if so, provide a module with changes)
-   [ ] requires new sample page in OutSystems (if so, provide a module with changes)
