### PR TITLE
ROU-4537: Fix Overflow Menu issue inside Tabs

### DIFF
--- a/dist/OutSystemsUI.d.ts
+++ b/dist/OutSystemsUI.d.ts
@@ -223,8 +223,8 @@ declare namespace OSFramework.OSUI.GlobalEnum {
     enum FloatingPosition {
         Auto = "auto",
         Bottom = "bottom",
-        BottomStart = "bottom-start",
         BottomEnd = "bottom-end",
+        BottomStart = "bottom-start",
         Center = "center",
         Left = "left",
         LeftEnd = "left-end",
@@ -233,8 +233,8 @@ declare namespace OSFramework.OSUI.GlobalEnum {
         RightEnd = "right-end",
         RightStart = "right-start",
         Top = "top",
-        TopStart = "top-start",
-        TopEnd = "top-end"
+        TopEnd = "top-end",
+        TopStart = "top-start"
     }
     enum CssProperties {
         Auto = "auto",
@@ -284,12 +284,12 @@ declare namespace OSFramework.OSUI.GlobalEnum {
         Class = "class",
         DataInput = "data-input",
         Disabled = "disabled",
+        Href = "href",
         Id = "id",
         Name = "name",
         StatusBar = "data-status-bar-height",
         Style = "style",
-        Type = "type",
-        Href = "href"
+        Type = "type"
     }
     enum HTMLElement {
         Body = "body",
@@ -402,8 +402,8 @@ declare namespace OSFramework.OSUI.GlobalEnum {
         Submenu = "Submenu",
         SwipeEvents = "SwipeEvents",
         Tabs = "Tabs",
-        TabsHeaderItem = "TabsHeaderItem",
         TabsContentItem = "TabsContentItem",
+        TabsHeaderItem = "TabsHeaderItem",
         Timepicker = "Timepicker",
         Tooltip = "Tooltip",
         TouchEvents = "TouchEvents",

--- a/dist/OutSystemsUI.js
+++ b/dist/OutSystemsUI.js
@@ -291,8 +291,8 @@ var OSFramework;
             (function (FloatingPosition) {
                 FloatingPosition["Auto"] = "auto";
                 FloatingPosition["Bottom"] = "bottom";
-                FloatingPosition["BottomStart"] = "bottom-start";
                 FloatingPosition["BottomEnd"] = "bottom-end";
+                FloatingPosition["BottomStart"] = "bottom-start";
                 FloatingPosition["Center"] = "center";
                 FloatingPosition["Left"] = "left";
                 FloatingPosition["LeftEnd"] = "left-end";
@@ -301,8 +301,8 @@ var OSFramework;
                 FloatingPosition["RightEnd"] = "right-end";
                 FloatingPosition["RightStart"] = "right-start";
                 FloatingPosition["Top"] = "top";
-                FloatingPosition["TopStart"] = "top-start";
                 FloatingPosition["TopEnd"] = "top-end";
+                FloatingPosition["TopStart"] = "top-start";
             })(FloatingPosition = GlobalEnum.FloatingPosition || (GlobalEnum.FloatingPosition = {}));
             let CssProperties;
             (function (CssProperties) {
@@ -358,12 +358,12 @@ var OSFramework;
                 HTMLAttributes["Class"] = "class";
                 HTMLAttributes["DataInput"] = "data-input";
                 HTMLAttributes["Disabled"] = "disabled";
+                HTMLAttributes["Href"] = "href";
                 HTMLAttributes["Id"] = "id";
                 HTMLAttributes["Name"] = "name";
                 HTMLAttributes["StatusBar"] = "data-status-bar-height";
                 HTMLAttributes["Style"] = "style";
                 HTMLAttributes["Type"] = "type";
-                HTMLAttributes["Href"] = "href";
             })(HTMLAttributes = GlobalEnum.HTMLAttributes || (GlobalEnum.HTMLAttributes = {}));
             let HTMLElement;
             (function (HTMLElement) {
@@ -485,8 +485,8 @@ var OSFramework;
                 PatternName["Submenu"] = "Submenu";
                 PatternName["SwipeEvents"] = "SwipeEvents";
                 PatternName["Tabs"] = "Tabs";
-                PatternName["TabsHeaderItem"] = "TabsHeaderItem";
                 PatternName["TabsContentItem"] = "TabsContentItem";
+                PatternName["TabsHeaderItem"] = "TabsHeaderItem";
                 PatternName["Timepicker"] = "Timepicker";
                 PatternName["Tooltip"] = "Tooltip";
                 PatternName["TouchEvents"] = "TouchEvents";
@@ -1874,10 +1874,14 @@ var OSFramework;
                                 this._currentFocusedElementIndex = this._currentFocusedElementIndex - 1;
                         }
                         if (this._currentFocusedElementIndex === undefined) {
-                            this.featureElem.focus();
+                            OSUI.Helper.AsyncInvocation(() => {
+                                this.featureElem.focus();
+                            });
                         }
                         else {
-                            this._focusableBalloonElements[this._currentFocusedElementIndex].focus();
+                            OSUI.Helper.AsyncInvocation(() => {
+                                this._focusableBalloonElements[this._currentFocusedElementIndex].focus();
+                            });
                         }
                     }
                     _onkeypressCallback(e) {

--- a/src/scripts/OSFramework/OSUI/Feature/Balloon/Balloon.ts
+++ b/src/scripts/OSFramework/OSUI/Feature/Balloon/Balloon.ts
@@ -99,10 +99,14 @@ namespace OSFramework.OSUI.Feature.Balloon {
 
 			// If the _currentFocusedElementIndex is undefined, focus on the balloon wrapper
 			if (this._currentFocusedElementIndex === undefined) {
-				this.featureElem.focus();
+				OSUI.Helper.AsyncInvocation(() => {
+					this.featureElem.focus();
+				});
 				// Otherwise, focus on the element corresponding ot the _currentFocusedElementIndex
 			} else {
-				(this._focusableBalloonElements[this._currentFocusedElementIndex] as HTMLElement).focus();
+				OSUI.Helper.AsyncInvocation(() => {
+					(this._focusableBalloonElements[this._currentFocusedElementIndex] as HTMLElement).focus();
+				});
 			}
 		}
 


### PR DESCRIPTION
This PR is for fix the Overflow Menu not opening correctly inside Tabs.

### What was happening
- When opening the Overflow Menu inside tab, the content of the previous Tab was appearing.

### What was done
- Changed the focus to be done async using OSUI.Helper.AsyncInvocation()


### Screenshots
Before:
![overflowMenuIssue](https://github.com/OutSystems/outsystems-ui/assets/108938618/591a3736-53e0-432b-b825-2028499eefe1)

After:
![overflowMenuIssueAfterFix](https://github.com/OutSystems/outsystems-ui/assets/108938618/9db4f32b-b401-4687-95e6-a5b86dbb6ba2)


### Checklist

-   [x] tested locally
-   [x] documented the code
-   [x] clean all warnings and errors of eslint
-   [ ] requires changes in OutSystems (if so, provide a module with changes)
-   [ ] requires new sample page in OutSystems (if so, provide a module with changes)
