### PR TITLE
ROU-4559: Fix overflowMenu display property

### DIFF
--- a/src/scripts/OSFramework/OSUI/Pattern/OverflowMenu/scss/_overflowmenu.scss
+++ b/src/scripts/OSFramework/OSUI/Pattern/OverflowMenu/scss/_overflowmenu.scss
@@ -4,6 +4,7 @@
 /// Patterns - Navigation - OverflowMenu
 
 .osui-overflow-menu {
+    display: inline-block;
     --osui-overflow-menu-min-width: 170px;
     --border-radius-rounded: 16px;
 


### PR DESCRIPTION
This PR is for fixing the css for OverflowMenu's article element, that had display: block, preventing other elements to be placed on its side.

### Checklist

-   [x] tested locally
-   [x] documented the code
-   [x] clean all warnings and errors of eslint
-   [x] requires changes in OutSystems (if so, provide a module with changes)
-   [ ] requires new sample page in OutSystems (if so, provide a module with changes)
