### PR TITLE
ROU-4574: Fix OverflowMenu position

### DIFF
--- a/dist/OutSystemsUI.css
+++ b/dist/OutSystemsUI.css
@@ -7746,7 +7746,7 @@ span.flatpickr-weekday{
   height:auto;
   left:var(--osui-floating-position-x);
   opacity:0;
-  position:absolute;
+  position:fixed;
   pointer-events:none;
   top:var(--osui-floating-position-y);
   visibility:hidden;
@@ -12870,7 +12870,7 @@ html[data-uieditorversion^="1"] .wizard-wrapper-item{
   background-color:var(--color-neutral-6);
 }
 .osui-dropdown-serverside__balloon-content > *:not([data-list]){
-  z-index:var(--layer-local-tier-1);
+  z-index:var(--layer-local-tier-2);
 }
 .osui-dropdown-serverside__balloon--has-not-search .osui-dropdown-serverside__balloon-content{
   border-top:none;
@@ -12966,8 +12966,17 @@ body:has(.popup-dialog):has(.osui-dropdown-serverside--is-opened) .osui-dropdown
 .has-accessible-features .osui-dropdown-serverside__balloon-search:before{
   color:var(--color-neutral-7);
 }
+.has-accessible-features .osui-dropdown-serverside__balloon-search input:focus,
+.has-accessible-features .osui-dropdown-serverside__balloon-search .form-control[data-input]:focus{
+  -webkit-box-shadow:inset 0 0 0 3px var(--color-focus-outer);
+          box-shadow:inset 0 0 0 3px var(--color-focus-outer);
+}
 .has-accessible-features .osui-dropdown-serverside__balloon-content::-webkit-scrollbar-thumb{
   background-color:var(--color-neutral-7);
+}
+.has-accessible-features .osui-dropdown-serverside__balloon-content:focus{
+  -webkit-box-shadow:inset 0 0 0 3px var(--color-focus-outer);
+          box-shadow:inset 0 0 0 3px var(--color-focus-outer);
 }
 .is-rtl .osui-dropdown-serverside__selected-values{
   margin-left:var(--space-base);
@@ -13062,7 +13071,7 @@ body:has(.popup-dialog):has(.osui-dropdown-serverside--is-opened) .osui-dropdown
   -webkit-box-align:center;
       -ms-flex-align:center;
           align-items:center;
-  background-color:var(--color-neutral-0);
+  background-color:transparent;
   color:var(--color-neutral-9);
   cursor:pointer;
   display:-webkit-box;
@@ -13111,6 +13120,10 @@ body:has(.popup-dialog):has(.osui-dropdown-serverside--is-opened) .osui-dropdown
 }
 .has-accessible-features .osui-dropdown-serverside-item:hover{
   background-color:var(--color-neutral-4);
+}
+.has-accessible-features .osui-dropdown-serverside-item:focus{
+  -webkit-box-shadow:inset 0 0 0 3px var(--color-focus-outer);
+          box-shadow:inset 0 0 0 3px var(--color-focus-outer);
 }
 .tablet .osui-dropdown-serverside-item,
 .phone .osui-dropdown-serverside-item{

--- a/dist/OutSystemsUI.js
+++ b/dist/OutSystemsUI.js
@@ -4456,12 +4456,6 @@ var OSFramework;
             var BottomSheet;
             (function (BottomSheet_1) {
                 class BottomSheet extends Patterns.AbstractPattern {
-                    get gestureEventInstance() {
-                        return this._gestureEventInstance;
-                    }
-                    get hasGestureEvents() {
-                        return this._hasGestureEvents;
-                    }
                     constructor(uniqueId, configs) {
                         super(uniqueId, new BottomSheet_1.BottomSheetConfig(configs));
                         this._isOpen = false;
@@ -4473,6 +4467,12 @@ var OSFramework;
                                 mass: 1,
                             },
                         };
+                    }
+                    get gestureEventInstance() {
+                        return this._gestureEventInstance;
+                    }
+                    get hasGestureEvents() {
+                        return this._hasGestureEvents;
                     }
                     _handleFocusBehavior() {
                         const opts = {
@@ -5422,7 +5422,11 @@ var OSFramework;
                                     if (event.key === OSUI.GlobalEnum.Keycodes.Escape) {
                                         this._close();
                                     }
-                                    if (event.key === OSUI.GlobalEnum.Keycodes.Enter || event.key === OSUI.GlobalEnum.Keycodes.Space) {
+                                    if (event.key === OSUI.GlobalEnum.Keycodes.Enter ||
+                                        event.key === OSUI.GlobalEnum.Keycodes.Space ||
+                                        event.key === OSUI.GlobalEnum.Keycodes.ArrowUp ||
+                                        event.key === OSUI.GlobalEnum.Keycodes.ArrowDown ||
+                                        event.key === OSUI.GlobalEnum.Keycodes.Home) {
                                         this._selectValuesWrapper.click();
                                     }
                                     break;
@@ -5702,6 +5706,7 @@ var OSFramework;
                                     OSFramework.OSUI.Helper.Dom.Styles.ContainsClass(layoutElemContainer, OSFramework.OSUI.Constants.HasAccessibilityClass);
                             if (this._balloonSearchInputElement !== undefined) {
                                 OSUI.Helper.A11Y.TabIndex(this._balloonSearchInputElement, tabIndexValue);
+                                OSUI.Helper.A11Y.AriaHidden(this._balloonSearchInputElement, (tabIndexValue === OSUI.Constants.A11YAttributes.States.TabIndexHidden).toString());
                             }
                             OSUI.Helper.A11Y.TabIndex(this._balloonOptionsWrapperElement, tabIndexValue);
                             if (this._balloonFocusableElemsInFooter.length > 0) {

--- a/src/scripts/OSFramework/OSUI/Feature/Balloon/scss/_balloon.scss
+++ b/src/scripts/OSFramework/OSUI/Feature/Balloon/scss/_balloon.scss
@@ -14,7 +14,7 @@
     height: auto;
     left: var(--osui-floating-position-x);
     opacity: 0;
-    position: absolute;
+    position: fixed;
     pointer-events: none;
     top: var(--osui-floating-position-y);
     visibility: hidden;


### PR DESCRIPTION
This PR is for fixing the OverflowMenu position, when affected by overflow: hidden from parent elements.

### Checklist

-   [x] tested locally
-   [x] documented the code
-   [x] clean all warnings and errors of eslint
-   [ ] requires changes in OutSystems (if so, provide a module with changes)
-   [ ] requires new sample page in OutSystems (if so, provide a module with changes)
