### PR TITLE
[ROU-4542]: DatePicker - Fix screen scroll when time is in use.

### DIFF
--- a/src/scripts/Providers/OSUI/SharedProviderResources/Flatpickr/scss/_flatpickr.scss
+++ b/src/scripts/Providers/OSUI/SharedProviderResources/Flatpickr/scss/_flatpickr.scss
@@ -36,6 +36,14 @@
 
 	// Has Time
 	&.hasTime {
+		/* This will implement a workaround:
+		* 	- When Time is present and a date is selected, library will set focus to the Time input,
+		*   If Time input is not inside at the screen boundaries, browser will force a document scroll in order
+		*   be possible to put that input inside the boundaries, which creates an issue due content will be moved
+		*   to a place where then it's not possible to came from.
+		**/
+		position: fixed;
+
 		.flatpickr-time {
 			border: var(--border-size-none);
 			height: 30px;


### PR DESCRIPTION
This PR is for fix the issue happens when a date gets selected and Time is focused which if calendar time is not inside browser boundaries a scroll will occurs to all content and it's not possible to revert it.