### PR TITLE
ROU-4593: Fixed Balloon onBodyClick

### DIFF
--- a/src/scripts/OSFramework/OSUI/Feature/Balloon/Balloon.ts
+++ b/src/scripts/OSFramework/OSUI/Feature/Balloon/Balloon.ts
@@ -48,9 +48,12 @@ namespace OSFramework.OSUI.Feature.Balloon {
 
 		// Method to handle the body click callback, that closes the Balloon
 		private _bodyClickCallback(_args: string, e: MouseEvent): void {
-			if (e.target === this.featureOptions?.anchorElem || this._isOpenedByApi) {
+			const _eventTarget = e.target;
+
+			if (_eventTarget === this.featureOptions?.anchorElem || this._isOpenedByApi || this.featureElem.contains(_eventTarget as HTMLElement)) {
 				return;
 			}
+			
 			if (this.isOpen) {
 				this._toggleBalloon(false, true);
 				e.stopPropagation();


### PR DESCRIPTION
This PR is for changing the bodyOnClick on the Balloon feature, to validate if the e.target is present inside the OverflowMenu pattern.

### Checklist

-   [x] tested locally
-   [x] documented the code
-   [x] clean all warnings and errors of eslint
-   [x] requires changes in OutSystems (if so, provide a module with changes)
-   [ ] requires new sample page in OutSystems (if so, provide a module with changes)
