### PR TITLE
ROU-4633 - [OSUI] - Issue applying favicon icon in PWA application

### DIFF
--- a/src/scripts/OutSystems/OSUI/Utils/Utilities.ts
+++ b/src/scripts/OutSystems/OSUI/Utils/Utilities.ts
@@ -11,7 +11,7 @@ namespace OutSystems.OSUI.Utils {
 			callback: () => {
 				const existingFavicon = OSFramework.OSUI.Helper.Dom.TagSelector(
 					document.head,
-					"link[rel*='icon']"
+					"link[rel='shortcut icon']"
 				) as HTMLLinkElement;
 
 				if (existingFavicon) {


### PR DESCRIPTION
This PR is for fixing the favicon API on PWA applications

### What was happening

- The API AddFavicon was not working on PWA since the selector that checks if the favicon exists was editing `link rel="apple-touch-icon" ` instead of creating the link for the favicon.

### What was done

- change Favicon selector to be more strict.

### Test Steps

1. Generate a PWA Application that has a favicon
2. Check if the favicon is there when running the layout


### Checklist

-   [x] tested locally
-   [x] documented the code
-   [ ] clean all warnings and errors of eslint
-   [ ] requires changes in OutSystems (if so, provide a module with changes)
-   [ ] requires new sample page in OutSystems (if so, provide a module with changes)
