### PR TITLE
ROU-4635 - [OSUI] - Datepicker validation showing hidden input

### DIFF
--- a/src/scripts/OSFramework/OSUI/Pattern/DatePicker/scss/_datepicker.scss
+++ b/src/scripts/OSFramework/OSUI/Pattern/DatePicker/scss/_datepicker.scss
@@ -31,15 +31,16 @@
 			color: var(--color-neutral-6);
 			pointer-events: none;
 		}
-	}
 
-	// Hide the platform input which is set as hidden by the library and we're change it into the expected type, however we do not want it visible since library will add a clone to better deal with the selected dates.
-	input.flatpickr-input:first-of-type {
-		display: none;
+		// Hide the platform input which is set as hidden by the library and we're change it into the expected type, however we do not want it visible since library will add a clone to better deal with the selected dates.
+		// We cannot use the provider class since the provider class will not be taken into consideration on the input widget react lifecycle
+		&:first-of-type {
+			display: none;
 
-		// Make the platform input visible in Service Studio
-		& {
-			-servicestudio-display: inline-flex !important;
+			// Make the platform input visible in Service Studio
+			& {
+				-servicestudio-display: inline-flex !important;
+			}
 		}
 	}
 

--- a/src/scripts/OSFramework/OSUI/Pattern/MonthPicker/scss/_monthpicker.scss
+++ b/src/scripts/OSFramework/OSUI/Pattern/MonthPicker/scss/_monthpicker.scss
@@ -53,15 +53,16 @@
 			color: var(--color-neutral-6);
 			pointer-events: none;
 		}
-	}
 
-	// Hide the platform input which is set as hidden by the library and we're change it into the expected type, however we do not want it visible since library will add a clone to better deal with the selected dates.
-	input.flatpickr-input:first-of-type {
-		display: none;
+		// Hide the platform input which is set as hidden by the library and we're change it into the expected type, however we do not want it visible since library will add a clone to better deal with the selected dates.
+		// We cannot use the provider class since the provider class will not be taken into consideration on the input widget react lifecycle
+		&:first-of-type {
+			display: none;
 
-		// Make the platform input visible in Service Studio
-		& {
-			-servicestudio-display: inline-flex !important;
+			// Make the platform input visible in Service Studio
+			& {
+				-servicestudio-display: inline-flex !important;
+			}
 		}
 	}
 }

--- a/src/scripts/OSFramework/OSUI/Pattern/TimePicker/scss/_timepicker.scss
+++ b/src/scripts/OSFramework/OSUI/Pattern/TimePicker/scss/_timepicker.scss
@@ -31,15 +31,16 @@
 			color: var(--color-neutral-6);
 			pointer-events: none;
 		}
-	}
 
-	// Hide the platform input which is set as hidden by the library and we're change it into the expected type, however we do not want it visible since library will add a clone to better deal with the selected dates.
-	input.flatpickr-input:first-of-type {
-		display: none;
+		// Hide the platform input which is set as hidden by the library and we're change it into the expected type, however we do not want it visible since library will add a clone to better deal with the selected dates.
+		// We cannot use the provider class since the provider class will not be taken into consideration on the input widget react lifecycle
+		&:first-of-type {
+			display: none;
 
-		// Make the platform input visible in Service Studio
-		& {
-			-servicestudio-display: inline-flex !important;
+			// Make the platform input visible in Service Studio
+			& {
+				-servicestudio-display: inline-flex !important;
+			}
 		}
 	}
 


### PR DESCRIPTION
This PR is for fixing an issue related with the visibility of the hidden input of the DatePicker, MonthPicker and TimePicker.


### What was happening

- When the hidden input changed to the invalid state via validation of form widget. The input was shown due to internal react logic. 

### What was done

- Change the selector on flatpickr components to guarantee that the internal input doesn't appear after a form widget validation change it to invalid.


### Test Steps

1. Add a mandatory picker to a form widget.
2. Add a Button to submit the form.
3. Run the screen, leave the input empty and submit the form
4. Check if the picker remains with **only** 1 input after changed to invalid

Repeat the test for datePicker, timePicker and monthPicker

### Checklist

-   [x] tested locally
-   [x] documented the code
-   [x] clean all warnings and errors of eslint
-   [ ] requires changes in OutSystems (if so, provide a module with changes)
-   [ ] requires new sample page in OutSystems (if so, provide a module with changes)
