### PR TITLE
- fix time-picker selector to be stronger than .chrome input[type=time].

### DIFF
--- a/src/scripts/OSFramework/OSUI/Pattern/TimePicker/scss/_timepicker.scss
+++ b/src/scripts/OSFramework/OSUI/Pattern/TimePicker/scss/_timepicker.scss
@@ -34,7 +34,7 @@
 
 		// Hide the platform input which is set as hidden by the library and we're change it into the expected type, however we do not want it visible since library will add a clone to better deal with the selected dates.
 		// We cannot use the provider class since the provider class will not be taken into consideration on the input widget react lifecycle
-		&:first-of-type {
+		&[type='time']:first-of-type {
 			display: none;
 
 			// Make the platform input visible in Service Studio


### PR DESCRIPTION
This PR is for...
- fix time-picker selector to be stronger than .chrome input[type=time].

### Checklist

-   [x] tested locally
-   [x] documented the code
-   [ ] clean all warnings and errors of eslint
-   [ ] requires changes in OutSystems (if so, provide a module with changes)
-   [ ] requires new sample page in OutSystems (if so, provide a module with changes)
