### PR TITLE
ROU-4582:  SetBreakPoints - Remove wrong tablet validation when window height > width 

### DIFF
--- a/dist/OutSystemsUI.d.ts
+++ b/dist/OutSystemsUI.d.ts
@@ -57,6 +57,7 @@ declare namespace OSFramework.OSUI.Constants {
             True: string;
         };
     };
+    const AllowPropagationAttr = "[data-allow-event-propagation]";
     const Dot = ".";
     const Comma = ",";
     const EnableLogMessages = false;
@@ -3591,7 +3592,6 @@ declare namespace OSFramework.OSUI.Patterns.Tooltip {
         private _eventIconOnMouseLeave;
         private _eventOnBalloonClick;
         private _eventOnBlur;
-        private _eventOnBodyClick;
         private _eventOnClick;
         private _eventOnFocus;
         private _eventOnKeypress;
@@ -3604,6 +3604,7 @@ declare namespace OSFramework.OSUI.Patterns.Tooltip {
         private _isIconMouseEnter;
         private _isOpen;
         private _isOpenedByApi;
+        private _isSafari;
         private _platformEventOnToggleCallback;
         private _requestAnimationOnBodyScroll;
         private _requestAnimationOnWindowResize;
@@ -3619,7 +3620,6 @@ declare namespace OSFramework.OSUI.Patterns.Tooltip {
         private _onBalloonWrapperMouseEnter;
         private _onBalloonWrapperMouseLeave;
         private _onBlur;
-        private _onBodyClick;
         private _onClick;
         private _onFocus;
         private _onIconMouseEnter;

--- a/src/scripts/OutSystems/OSUI/Utils/DeviceDetection.ts
+++ b/src/scripts/OutSystems/OSUI/Utils/DeviceDetection.ts
@@ -166,16 +166,17 @@ namespace OutSystems.OSUI.Utils.DeviceDetection {
 			];
 
 			let device;
-			if (windowWidth < phoneMax || (isLandscape === false && windowHeight < phoneMax)) {
+
+			// To set the device using the window dimensions, we just need to look into the largest dimension
+			const windowSize = isLandscape ? windowWidth : windowHeight;
+
+			if (windowSize <= phoneMax) {
 				//Is phone!
 				device = 0;
-			} else if (
-				(windowWidth >= phoneMax && windowWidth <= tabletMax) ||
-				(windowHeight >= phoneMax && windowHeight <= tabletMax && isLandscape)
-			) {
+			} else if (windowSize <= tabletMax) {
 				//Is Tablet!
 				device = 1;
-			} else if (windowWidth > tabletMax || (windowHeight > tabletMax && isLandscape)) {
+			} else {
 				//Is Desktop!
 				device = 2;
 			}


### PR DESCRIPTION
This PR is to fix the SetDeviceBreakpoint assigning a desktop as a tablet.


### What was happening
-  When at desktop and if widowHeight <= tabletMax it will be set the tablet class, which is wrong.

### What was done
- Simplified the logic so it can work as expected:
    - The user sets the phoneWidth and tabletWidth breakpoints.
    - If both window dimensions are smaller than the phoneWidth, then it is a phone.
    - If both window dimensions are bigger than the phoneWidth and smaller than the tabletWidth, then it is a tablet.
    - If both window dimensions are bigger than the tabletWidth, then it is a desktop.
    - To achieve that, we just need to validate the biggest dimension:
        - If landscape, we check the width
        - If portrait, we check the height. 
- So these changes were done:
    - Created a new variable, windowSize, to get the largest size between windowWidth and windowHeight. If in landscape orientation, get the width, if in portrait orientation, get the height.
    - Used the windowSize to set the correct device .

### Screenshots
- Before:
![wrongValidationSetDeviceBreakpoint](https://github.com/OutSystems/outsystems-ui/assets/108938618/281abd61-31fe-470a-ab59-39f44d23eb14)
- After: 
![validationSetDeviceBreakpoint](https://github.com/OutSystems/outsystems-ui/assets/108938618/0f002cde-8e1a-4c60-ba74-e2d2db5c115b)

### Checklist

-   [x] tested locally
-   [x] documented the code
-   [x] clean all warnings and errors of eslint
-   [ ] requires changes in OutSystems (if so, provide a module with changes)
-   [ ] requires new sample page in OutSystems (if so, provide a module with changes)
