### PR TITLE
ROU-4582: SetBreakPoints - Remove wrong tablet validation when window height > width 

### DIFF
--- a/dist/OutSystemsUI.css
+++ b/dist/OutSystemsUI.css
@@ -8508,10 +8508,10 @@ span.flatpickr-weekday{
   color:var(--color-neutral-6);
   pointer-events:none;
 }
-.osui-datepicker input.flatpickr-input:first-of-type{
+.osui-datepicker input:first-of-type{
   display:none;
 }
-.osui-datepicker input.flatpickr-input:first-of-type{
+.osui-datepicker input:first-of-type{
   -servicestudio-display:inline-flex !important;
 }
 .osui-datepicker-calendar-ss-preview{
@@ -9599,10 +9599,10 @@ body.vscomp-popup-active .vscomp-wrapper{
   color:var(--color-neutral-6);
   pointer-events:none;
 }
-.osui-monthpicker input.flatpickr-input:first-of-type{
+.osui-monthpicker input:first-of-type{
   display:none;
 }
-.osui-monthpicker input.flatpickr-input:first-of-type{
+.osui-monthpicker input:first-of-type{
   -servicestudio-display:inline-flex !important;
 }
 .form .osui-monthpicker-ss-preview{
@@ -10465,10 +10465,10 @@ body.vscomp-popup-active .vscomp-wrapper{
   color:var(--color-neutral-6);
   pointer-events:none;
 }
-.osui-timepicker input.flatpickr-input:first-of-type{
+.osui-timepicker input[type=time]:first-of-type{
   display:none;
 }
-.osui-timepicker input.flatpickr-input:first-of-type{
+.osui-timepicker input[type=time]:first-of-type{
   -servicestudio-display:inline-flex !important;
 }
 .osui-timepicker__dropdown-ss-preview{

--- a/dist/OutSystemsUI.js
+++ b/dist/OutSystemsUI.js
@@ -16110,7 +16110,6 @@ var OutSystems;
                         const orient = windowWidth > windowHeight
                             ? OSFramework.OSUI.GlobalEnum.DeviceOrientation.landscape
                             : OSFramework.OSUI.GlobalEnum.DeviceOrientation.portrait;
-                        const isLandscape = orient === OSFramework.OSUI.GlobalEnum.DeviceOrientation.landscape;
                         const userValues = {
                             phone: phoneWidth,
                             tablet: tabletWidth,
@@ -16123,11 +16122,10 @@ var OutSystems;
                             OSFramework.OSUI.GlobalEnum.DeviceType.desktop,
                         ];
                         let device;
-                        const windowSize = isLandscape ? windowWidth : windowHeight;
-                        if (windowSize <= phoneMax) {
+                        if (windowWidth <= phoneMax) {
                             device = 0;
                         }
-                        else if (windowSize <= tabletMax) {
+                        else if (windowWidth <= tabletMax) {
                             device = 1;
                         }
                         else {

--- a/src/scripts/OutSystems/OSUI/Utils/DeviceDetection.ts
+++ b/src/scripts/OutSystems/OSUI/Utils/DeviceDetection.ts
@@ -149,7 +149,6 @@ namespace OutSystems.OSUI.Utils.DeviceDetection {
 				windowWidth > windowHeight
 					? OSFramework.OSUI.GlobalEnum.DeviceOrientation.landscape
 					: OSFramework.OSUI.GlobalEnum.DeviceOrientation.portrait;
-			const isLandscape = orient === OSFramework.OSUI.GlobalEnum.DeviceOrientation.landscape;
 
 			const userValues = {
 				phone: phoneWidth,
@@ -167,13 +166,10 @@ namespace OutSystems.OSUI.Utils.DeviceDetection {
 
 			let device;
 
-			// To set the device using the window dimensions, we just need to look into the largest dimension
-			const windowSize = isLandscape ? windowWidth : windowHeight;
-
-			if (windowSize <= phoneMax) {
+			if (windowWidth <= phoneMax) {
 				//Is phone!
 				device = 0;
-			} else if (windowSize <= tabletMax) {
+			} else if (windowWidth <= tabletMax) {
 				//Is Tablet!
 				device = 1;
 			} else {


### PR DESCRIPTION
This PR is to change the SetDeviceBreakpoints behavior

### What was done
- Now, the SetDeviceBreakpoints will just consider the windowWidth when setting the device.

### Test Steps
1. Go to a page using the SetDeviceBreakpoints
2. Check that the device accordingly when modifying the windowWidth

### Checklist

-   [x] tested locally
-   [x] documented the code
-   [x] clean all warnings and errors of eslint
-   [ ] requires changes in OutSystems (if so, provide a module with changes)
-   [ ] requires new sample page in OutSystems (if so, provide a module with changes)
