### PR TITLE
ROU-4647: Tabs - TabIndex leave current tabs

### DIFF
--- a/dist/OutSystemsUI.d.ts
+++ b/dist/OutSystemsUI.d.ts
@@ -3350,6 +3350,8 @@ declare namespace OSFramework.OSUI.Patterns.Tabs {
         private _changeActiveHeaderItem;
         private _getTargetIndex;
         private _handleKeypressEvent;
+        private _handleKeypressEventOnTabContent;
+        private _handleKeypressEventOnTabHeader;
         private _handleOnResizeEvent;
         private _handleTabIndicator;
         private _prepareHeaderAndContentItems;

--- a/dist/OutSystemsUI.d.ts
+++ b/dist/OutSystemsUI.d.ts
@@ -3350,8 +3350,6 @@ declare namespace OSFramework.OSUI.Patterns.Tabs {
         private _changeActiveHeaderItem;
         private _getTargetIndex;
         private _handleKeypressEvent;
-        private _handleKeypressEventOnTabContent;
-        private _handleKeypressEventOnTabHeader;
         private _handleOnResizeEvent;
         private _handleTabIndicator;
         private _prepareHeaderAndContentItems;

--- a/dist/OutSystemsUI.d.ts
+++ b/dist/OutSystemsUI.d.ts
@@ -63,7 +63,7 @@ declare namespace OSFramework.OSUI.Constants {
     const EnableLogMessages = false;
     const EmptyString = "";
     const FocusTrapIgnoreAttr = "ignore-focus-trap";
-    const FocusableElems = "a[href]:not([disabled]),[tabindex=\"0\"], button:not([disabled]), textarea:not([disabled]), input[type=\"text\"]:not([disabled]), input[type=\"radio\"]:not([disabled]), input[type=\"checkbox\"]:not([disabled]),input[type=\"submit\"]:not([disabled]), select:not([disabled])";
+    const FocusableElems = "a[href]:not([disabled]),[tabindex=\"0\"], button:not([disabled]), textarea:not([disabled]), input:not([disabled]), select:not([disabled])";
     const JavaScriptTypes: {
         Undefined: string;
         Boolean: string;

--- a/dist/OutSystemsUI.js
+++ b/dist/OutSystemsUI.js
@@ -10200,10 +10200,22 @@ var OSFramework;
                         return newTabIndex;
                     }
                     _handleKeypressEvent(e) {
-                        let targetHeaderItemIndex;
-                        if (e.target !== this._activeTabHeaderElement.selfElement) {
-                            return;
+                        if (e.target === this._activeTabHeaderElement.selfElement) {
+                            this._handleKeypressEventOnTabHeader(e);
                         }
+                        else if (e.target === this._activeTabContentElement.selfElement) {
+                            this._handleKeypressEventOnTabContent(e);
+                        }
+                    }
+                    _handleKeypressEventOnTabContent(e) {
+                        if (e.shiftKey === true && e.key === OSUI.GlobalEnum.Keycodes.Tab) {
+                            e.preventDefault();
+                            const tabHeaderItem = this.getChildByIndex(this.configs.StartingTab, Tabs_1.Enum.ChildTypes.TabsHeaderItem);
+                            tabHeaderItem.selfElement.focus();
+                        }
+                    }
+                    _handleKeypressEventOnTabHeader(e) {
+                        let targetHeaderItemIndex;
                         switch (e.key) {
                             case OSUI.GlobalEnum.Keycodes.ArrowRight:
                                 targetHeaderItemIndex = this.configs.StartingTab + 1;
@@ -10226,6 +10238,10 @@ var OSFramework;
                             case OSUI.GlobalEnum.Keycodes.Home:
                                 targetHeaderItemIndex = 0;
                                 this.changeTab(targetHeaderItemIndex, undefined, true);
+                                break;
+                            case OSUI.GlobalEnum.Keycodes.Tab:
+                                e.preventDefault();
+                                this.getChildByIndex(this.configs.StartingTab, Tabs_1.Enum.ChildTypes.TabsContentItem).selfElement.focus();
                                 break;
                         }
                         const targetHeaderItem = this.getChildByIndex(targetHeaderItemIndex, Tabs_1.Enum.ChildTypes.TabsHeaderItem);

--- a/dist/OutSystemsUI.js
+++ b/dist/OutSystemsUI.js
@@ -105,7 +105,7 @@ var OSFramework;
             Constants.EnableLogMessages = false;
             Constants.EmptyString = '';
             Constants.FocusTrapIgnoreAttr = 'ignore-focus-trap';
-            Constants.FocusableElems = 'a[href]:not([disabled]),[tabindex="0"], button:not([disabled]), textarea:not([disabled]), input[type="text"]:not([disabled]), input[type="radio"]:not([disabled]), input[type="checkbox"]:not([disabled]),input[type="submit"]:not([disabled]), select:not([disabled])';
+            Constants.FocusableElems = 'a[href]:not([disabled]),[tabindex="0"], button:not([disabled]), textarea:not([disabled]), input:not([disabled]), select:not([disabled])';
             Constants.JavaScriptTypes = {
                 Undefined: 'undefined',
                 Boolean: 'boolean',

--- a/dist/OutSystemsUI.js
+++ b/dist/OutSystemsUI.js
@@ -10200,22 +10200,10 @@ var OSFramework;
                         return newTabIndex;
                     }
                     _handleKeypressEvent(e) {
-                        if (e.target === this._activeTabHeaderElement.selfElement) {
-                            this._handleKeypressEventOnTabHeader(e);
-                        }
-                        else if (e.target === this._activeTabContentElement.selfElement) {
-                            this._handleKeypressEventOnTabContent(e);
-                        }
-                    }
-                    _handleKeypressEventOnTabContent(e) {
-                        if (e.shiftKey === true && e.key === OSUI.GlobalEnum.Keycodes.Tab) {
-                            e.preventDefault();
-                            const tabHeaderItem = this.getChildByIndex(this.configs.StartingTab, Tabs_1.Enum.ChildTypes.TabsHeaderItem);
-                            tabHeaderItem.selfElement.focus();
-                        }
-                    }
-                    _handleKeypressEventOnTabHeader(e) {
                         let targetHeaderItemIndex;
+                        if (e.target !== this._activeTabHeaderElement.selfElement) {
+                            return;
+                        }
                         switch (e.key) {
                             case OSUI.GlobalEnum.Keycodes.ArrowRight:
                                 targetHeaderItemIndex = this.configs.StartingTab + 1;
@@ -10238,10 +10226,6 @@ var OSFramework;
                             case OSUI.GlobalEnum.Keycodes.Home:
                                 targetHeaderItemIndex = 0;
                                 this.changeTab(targetHeaderItemIndex, undefined, true);
-                                break;
-                            case OSUI.GlobalEnum.Keycodes.Tab:
-                                e.preventDefault();
-                                this.getChildByIndex(this.configs.StartingTab, Tabs_1.Enum.ChildTypes.TabsContentItem).selfElement.focus();
                                 break;
                         }
                         const targetHeaderItem = this.getChildByIndex(targetHeaderItemIndex, Tabs_1.Enum.ChildTypes.TabsHeaderItem);

--- a/src/scripts/OSFramework/OSUI/Constants.ts
+++ b/src/scripts/OSFramework/OSUI/Constants.ts
@@ -74,7 +74,7 @@ namespace OSFramework.OSUI.Constants {
 
 	/* Store focusable elements when doing a focus trap inside an element*/
 	export const FocusableElems =
-		'a[href]:not([disabled]),[tabindex="0"], button:not([disabled]), textarea:not([disabled]), input[type="text"]:not([disabled]), input[type="radio"]:not([disabled]), input[type="checkbox"]:not([disabled]),input[type="submit"]:not([disabled]), select:not([disabled])';
+		'a[href]:not([disabled]),[tabindex="0"], button:not([disabled]), textarea:not([disabled]), input:not([disabled]), select:not([disabled])';
 
 	/* Store JavaScript types*/
 	export const JavaScriptTypes = {

--- a/src/scripts/OSFramework/OSUI/Pattern/Tabs/Tabs.ts
+++ b/src/scripts/OSFramework/OSUI/Pattern/Tabs/Tabs.ts
@@ -248,27 +248,11 @@ namespace OSFramework.OSUI.Patterns.Tabs {
 		 * @memberof Tabs
 		 */
 		private _handleKeypressEvent(e: KeyboardEvent): void {
-			// Check if target is the header, to do not change tab on x arrow press
-			if (e.target === this._activeTabHeaderElement.selfElement) {
-				this._handleKeypressEventOnTabHeader(e);
-			} else if (e.target === this._activeTabContentElement.selfElement) {
-				this._handleKeypressEventOnTabContent(e);
-			}
-		}
-
-		private _handleKeypressEventOnTabContent(e: KeyboardEvent) {
-			if (e.shiftKey === true && e.key === GlobalEnum.Keycodes.Tab) {
-				e.preventDefault();
-				const tabHeaderItem = this.getChildByIndex(
-					this.configs.StartingTab,
-					Enum.ChildTypes.TabsHeaderItem
-				) as TabsHeaderItem.ITabsHeaderItem;
-				tabHeaderItem.selfElement.focus();
-			}
-		}
-
-		private _handleKeypressEventOnTabHeader(e: KeyboardEvent) {
 			let targetHeaderItemIndex;
+			// Check if target is the header, to do not change tab on x arrow press
+			if (e.target !== this._activeTabHeaderElement.selfElement) {
+				return;
+			}
 
 			switch (e.key) {
 				case GlobalEnum.Keycodes.ArrowRight:
@@ -305,10 +289,6 @@ namespace OSFramework.OSUI.Patterns.Tabs {
 
 					this.changeTab(targetHeaderItemIndex, undefined, true);
 
-					break;
-				case GlobalEnum.Keycodes.Tab:
-					e.preventDefault();
-					this.getChildByIndex(this.configs.StartingTab, Enum.ChildTypes.TabsContentItem).selfElement.focus();
 					break;
 			}
 

--- a/src/scripts/OSFramework/OSUI/Pattern/Tabs/Tabs.ts
+++ b/src/scripts/OSFramework/OSUI/Pattern/Tabs/Tabs.ts
@@ -248,11 +248,27 @@ namespace OSFramework.OSUI.Patterns.Tabs {
 		 * @memberof Tabs
 		 */
 		private _handleKeypressEvent(e: KeyboardEvent): void {
-			let targetHeaderItemIndex;
 			// Check if target is the header, to do not change tab on x arrow press
-			if (e.target !== this._activeTabHeaderElement.selfElement) {
-				return;
+			if (e.target === this._activeTabHeaderElement.selfElement) {
+				this._handleKeypressEventOnTabHeader(e);
+			} else if (e.target === this._activeTabContentElement.selfElement) {
+				this._handleKeypressEventOnTabContent(e);
 			}
+		}
+
+		private _handleKeypressEventOnTabContent(e: KeyboardEvent) {
+			if (e.shiftKey === true && e.key === GlobalEnum.Keycodes.Tab) {
+				e.preventDefault();
+				const tabHeaderItem = this.getChildByIndex(
+					this.configs.StartingTab,
+					Enum.ChildTypes.TabsHeaderItem
+				) as TabsHeaderItem.ITabsHeaderItem;
+				tabHeaderItem.selfElement.focus();
+			}
+		}
+
+		private _handleKeypressEventOnTabHeader(e: KeyboardEvent) {
+			let targetHeaderItemIndex;
 
 			switch (e.key) {
 				case GlobalEnum.Keycodes.ArrowRight:
@@ -289,6 +305,10 @@ namespace OSFramework.OSUI.Patterns.Tabs {
 
 					this.changeTab(targetHeaderItemIndex, undefined, true);
 
+					break;
+				case GlobalEnum.Keycodes.Tab:
+					e.preventDefault();
+					this.getChildByIndex(this.configs.StartingTab, Enum.ChildTypes.TabsContentItem).selfElement.focus();
 					break;
 			}
 


### PR DESCRIPTION
This PR is for fixing the Tab focusing on the input of the previous Tab when using TabKey to navigate.

### What was happening
- When setting the tabIndex of the focusable elements inside the inactive and active Tabs, some inputs such as datetime, date and time were not being reached.
- Because of that, when using the tab key to navigate from the Tab Header to the Tab Content, the input of the previous Tab Content was being focused.

### What was done
- Edited the string used to get all the focusable elements in OSFramework.Helper.Dom.GetFocusableElements

### Test Steps
1. Go to a page with inputs of the type date, datetime, and time inside Tabs.
2. For all the Tabs, check that it is not possible to reach the previous Tab's content using the Tab key.

### Checklist

-   [x] tested locally
-   [x] documented the code
-   [x] clean all warnings and errors of eslint
-   [ ] requires changes in OutSystems (if so, provide a module with changes)
-   [ ] requires new sample page in OutSystems (if so, provide a module with changes)
