### PR TITLE
ROU-4654: FocusFirstInvalidInput not focusing

### DIFF
--- a/src/scripts/OSFramework/OSUI/GlobalEnum.ts
+++ b/src/scripts/OSFramework/OSUI/GlobalEnum.ts
@@ -206,6 +206,7 @@ namespace OSFramework.OSUI.GlobalEnum {
 		Prefix = 'on',
 		Resize = 'resize',
 		Scroll = 'scroll',
+		ScrollEnd = 'scrollend',
 		TouchEnd = 'touchend',
 		TouchMove = 'touchmove',
 		TouchStart = 'touchstart',

--- a/src/scripts/OSFramework/OSUI/Helper/FocusFirstInvalidInput.ts
+++ b/src/scripts/OSFramework/OSUI/Helper/FocusFirstInvalidInput.ts
@@ -80,7 +80,7 @@ namespace OSFramework.OSUI.Helper {
 				callback: () => {
 					let element: HTMLElement = document.body;
 
-					if (elementId !== '') {
+					if (elementId !== Constants.EmptyString) {
 						element = Helper.Dom.GetElementById(elementId);
 					}
 

--- a/src/scripts/OSFramework/OSUI/Helper/FocusFirstInvalidInput.ts
+++ b/src/scripts/OSFramework/OSUI/Helper/FocusFirstInvalidInput.ts
@@ -37,13 +37,28 @@ namespace OSFramework.OSUI.Helper {
 			isSmooth: boolean,
 			elementParentClass: string
 		): void {
+			// Set the scrollable element to add the ScrollEnd event
+			const activeScreenElement = Helper.Dom.ClassSelector(
+				document.body,
+				GlobalEnum.CssClassElements.ActiveScreen
+			);
+
+			// Set the temporary function for event of ScrollEnd, to focus on element after the scroll occur
+			const focusOnScrollEnd = () => {
+				element.focus();
+				activeScreenElement.removeEventListener(GlobalEnum.HTMLEvent.ScrollEnd, focusOnScrollEnd);
+			};
+
 			OutSystems.OSUI.Utils.ScrollToElement(element.id, isSmooth, 0, elementParentClass);
+
+			// Add event on scrollable element, to focus on target element
+			activeScreenElement.addEventListener(GlobalEnum.HTMLEvent.ScrollEnd, focusOnScrollEnd);
 		}
 
 		// Method that will search for the closest element with ID
 		private static _searchElementId(element: HTMLElement, isSmooth: boolean, elementParentClass: string): void {
 			const elementToSearch = element.parentElement;
-			if (elementToSearch.id !== '') {
+			if (elementToSearch.id !== Constants.EmptyString) {
 				this._scrollToInvalidInput(elementToSearch, isSmooth, elementParentClass);
 			} else {
 				this._searchElementId(elementToSearch, isSmooth, elementParentClass);
@@ -69,7 +84,10 @@ namespace OSFramework.OSUI.Helper {
 						element = Helper.Dom.GetElementById(elementId);
 					}
 
-					this._checkInvalidInputs(element, isSmooth, elementParentClass);
+					// Wait for platform to add invalid classes
+					Helper.AsyncInvocation(() => {
+						this._checkInvalidInputs(element, isSmooth, elementParentClass);
+					});
 				},
 			});
 


### PR DESCRIPTION
This PR is for fixing the issue on FocusFirstInvalidInput action.

### What was happening
- After a validation in a form an call the action FocusFirstInvalidInput to validate if exists any invalid inputs, the action never focus on the first invalid input:
![image](https://github.com/OutSystems/outsystems-ui/assets/25321845/58a1c498-2186-4eac-859a-2302a4056235)


### What was done
- The action was reviewed on typescript to make it assync from the validation of the form. This is needed because we need to wait for platform to apply the non-valid classes
- Added the **scrollend** event listener to the scrollable element when the parameter IsSmooth is true, to focus only when the scroll animation is ended.
![image](https://github.com/OutSystems/outsystems-ui/assets/25321845/83d3606c-1b77-4325-9fac-12c5c352d374)

### Test Steps
1. Open sample page
2. Scroll to the button on bottom
3. Click on each button
4. Expected: The page will scroll up and the first invalid input will be focused

### Checklist
-   [X] tested locally
-   [X] documented the code
-   [X] clean all warnings and errors of eslint
-   [ ] requires changes in OutSystems (if so, provide a module with changes)
-   [ ] requires new sample page in OutSystems (if so, provide a module with changes)
