### PR TITLE
ROU-4654: Fix issue of Safari related to scrollend event

### DIFF
--- a/src/scripts/OSFramework/OSUI/Helper/FocusFirstInvalidInput.ts
+++ b/src/scripts/OSFramework/OSUI/Helper/FocusFirstInvalidInput.ts
@@ -37,22 +37,29 @@ namespace OSFramework.OSUI.Helper {
 			isSmooth: boolean,
 			elementParentClass: string
 		): void {
-			// Set the scrollable element to add the ScrollEnd event
-			const activeScreenElement = Helper.Dom.ClassSelector(
-				document.body,
-				GlobalEnum.CssClassElements.ActiveScreen
-			);
-
-			// Set the temporary function for event of ScrollEnd, to focus on element after the scroll occur
-			const focusOnScrollEnd = () => {
-				element.focus();
-				activeScreenElement.removeEventListener(GlobalEnum.HTMLEvent.ScrollEnd, focusOnScrollEnd);
-			};
+			const browser = OSFramework.OSUI.Helper.DeviceInfo.GetBrowser();
 
 			OutSystems.OSUI.Utils.ScrollToElement(element.id, isSmooth, 0, elementParentClass);
 
-			// Add event on scrollable element, to focus on target element
-			activeScreenElement.addEventListener(GlobalEnum.HTMLEvent.ScrollEnd, focusOnScrollEnd);
+			// Set the element focus directly because the event scrollend isn't supported by safari or iOS
+			if (browser === GlobalEnum.Browser.safari || OSFramework.OSUI.Helper.DeviceInfo.IsIos) {
+				element.focus();
+			} else {
+				// Set the scrollable element to add the ScrollEnd event
+				const activeScreenElement = Helper.Dom.ClassSelector(
+					document.body,
+					GlobalEnum.CssClassElements.ActiveScreen
+				);
+
+				// Set the temporary function for event of ScrollEnd, to focus on element after the scroll occur
+				const focusOnScrollEnd = () => {
+					element.focus();
+					activeScreenElement.removeEventListener(GlobalEnum.HTMLEvent.ScrollEnd, focusOnScrollEnd);
+				};
+
+				// Add event on scrollable element, to focus on target element
+				activeScreenElement.addEventListener(GlobalEnum.HTMLEvent.ScrollEnd, focusOnScrollEnd);
+			}
 		}
 
 		// Method that will search for the closest element with ID


### PR DESCRIPTION
This PR is for fix issue of Safari related to scrollend event

### What was happening
- On Safari or iOS, the event scrollend isn't supported.

### What was done
- Created a validation for safari and iOS to focus the element whitout scrollend event.

### Checklist
-   [X] tested locally
-   [X] documented the code
-   [X] clean all warnings and errors of eslint
-   [ ] requires changes in OutSystems (if so, provide a module with changes)
-   [ ] requires new sample page in OutSystems (if so, provide a module with changes)
