### PR TITLE
ROU-4645: Add a missing validation when range was not defined.

### DIFF
--- a/src/scripts/Providers/OSUI/RangeSlider/NoUISlider/Utils.ts
+++ b/src/scripts/Providers/OSUI/RangeSlider/NoUISlider/Utils.ts
@@ -5,7 +5,7 @@ namespace Providers.OSUI.RangeSlider.NoUISlider.Utils {
 		const _noUiSliderConfigs = providerConfigs;
 
 		// Check if the range key is empty. If true, remove from the array
-		if (_noUiSliderConfigs.range !== undefined && _noUiSliderConfigs.range.length <= 0) {
+		if (_noUiSliderConfigs.range?.length <= 0) {
 			delete _noUiSliderConfigs.range;
 		} else {
 			const _rangeValues = {};

--- a/src/scripts/Providers/OSUI/RangeSlider/NoUISlider/Utils.ts
+++ b/src/scripts/Providers/OSUI/RangeSlider/NoUISlider/Utils.ts
@@ -5,7 +5,7 @@ namespace Providers.OSUI.RangeSlider.NoUISlider.Utils {
 		const _noUiSliderConfigs = providerConfigs;
 
 		// Check if the range key is empty. If true, remove from the array
-		if (_noUiSliderConfigs.range.length <= 0) {
+		if (_noUiSliderConfigs.range !== undefined && _noUiSliderConfigs.range.length <= 0) {
 			delete _noUiSliderConfigs.range;
 		} else {
 			const _rangeValues = {};


### PR DESCRIPTION
This PR is for fix an issue when an extensibility attribute is missing at RangeSlider by adding an extra validation before checking it's value.