### PR TITLE
ROU-4675: Remove aria attributes from FipContent

### DIFF
--- a/src/scripts/OSFramework/OSUI/Pattern/FlipContent/FlipContent.ts
+++ b/src/scripts/OSFramework/OSUI/Pattern/FlipContent/FlipContent.ts
@@ -113,10 +113,8 @@ namespace OSFramework.OSUI.Patterns.FlipContent {
 		 */
 		private _updateA11yProperties(): void {
 			if (this.configs.FlipSelf) {
-				Helper.A11Y.AriaAtomicTrue(this.selfElement);
 				Helper.A11Y.TabIndexTrue(this.selfElement);
 			} else {
-				Helper.A11Y.AriaAtomicFalse(this.selfElement);
 				Helper.A11Y.TabIndexFalse(this.selfElement);
 			}
 		}
@@ -129,10 +127,8 @@ namespace OSFramework.OSUI.Patterns.FlipContent {
 		 */
 		protected setA11YProperties(): void {
 			if (this.configs.FlipSelf) {
-				Helper.A11Y.AriaAtomicTrue(this.selfElement);
 				Helper.A11Y.TabIndexTrue(this.selfElement);
 				Helper.A11Y.RoleButton(this.selfElement);
-				Helper.A11Y.AriaLivePolite(this.selfElement);
 			}
 		}
 


### PR DESCRIPTION
This PR is for removing the aria attributes aria-live and aria-polite from the FlipContent

[Sample page](url)

### What was happening
- The assistive technology reads twice the content of each side.

### What was done
- Removed the aria attributes from FilpContent (aria-live and aria-polite).

### Test Steps
1. Open Sample Page
2. Tab into pattern with VoiceOver enabled
3. Expected: The Voiceover only reads once the content of each side.

### Checklist
-   [X] tested locally
-   [X] documented the code
-   [ ] clean all warnings and errors of eslint
-   [ ] requires changes in OutSystems (if so, provide a module with changes)
-   [ ] requires new sample page in OutSystems (if so, provide a module with changes)
