### PR TITLE
[ROU-3816]: Pickers in mobile are not closing on a scroll inside the input

### DIFF
--- a/gulp/ProjectSpecs/DefaultSpecs.js
+++ b/gulp/ProjectSpecs/DefaultSpecs.js
@@ -13,7 +13,7 @@ const constants = {
         ]
     },
     // list of platforms to compile and create scss files.
-    targetPlatform: {
+    platformTarget: {
         o11: 'O11',
         odc: 'ODC',
     }

--- a/gulp/ProjectSpecs/ScssStructure/PatternsUtilities.js
+++ b/gulp/ProjectSpecs/ScssStructure/PatternsUtilities.js
@@ -39,7 +39,7 @@ const sectionInfo = {
         {
             "name": "Provider Login Button",
             "path": "04-patterns/06-utilities/provider-login-button",
-            "platform": project.globalConsts.targetPlatform.odc,
+            "platform": project.globalConsts.platformTarget.odc,
         }
     ]
 };

--- a/gulp/Tasks/CreateScssFile.js
+++ b/gulp/Tasks/CreateScssFile.js
@@ -50,7 +50,7 @@ function getFileText(platformType, envType) {
 
 // Method used to Create SCSS file structure dynamically
 function createScssFile(cb, envType) {
-	const pts = project.globalConsts.targetPlatform;
+	const pts = project.globalConsts.platformTarget;
 	for(const pt in pts) {
         fs.writeFileSync(`./src/scss/${pts[pt]}.OutSystemsUI.scss`, getFileText(pts[pt], envType), 'utf8');
     }

--- a/gulp/Tasks/ScssTanspile.js
+++ b/gulp/Tasks/ScssTanspile.js
@@ -21,12 +21,12 @@ function checkForScssThemeToBeCompiled() {
     }
 
     if(process.env.npm_config_target !== undefined) {
-        if(project.globalConsts.targetPlatform[process.env.npm_config_target] === undefined) {
+        if(project.globalConsts.platformTarget[process.env.npm_config_target] === undefined) {
             result.hasError = true;
-            result.errorMessage = `Given platform '${process.env.npm_config_target}' does not exist. Plaforms availabe:\n • ${Object.keys(project.globalConsts.targetPlatform).join("\n • ")}`
+            result.errorMessage = `Given platform '${process.env.npm_config_target}' does not exist. Plaforms availabe:\n • ${Object.keys(project.globalConsts.platformTarget).join("\n • ")}`
             console.log(`\n⛔️ ERROR: ${result.errorMessage}\n`);
         } else {
-            watchScssThemes = `src/scss/${project.globalConsts.targetPlatform[process.env.npm_config_target]}.OutSystemsUI.scss`;
+            watchScssThemes = `src/scss/${project.globalConsts.platformTarget[process.env.npm_config_target]}.OutSystemsUI.scss`;
         }
     }
 

--- a/gulp/Tasks/TsTanspile.js
+++ b/gulp/Tasks/TsTanspile.js
@@ -20,15 +20,15 @@ function getDefaultPlatformType(platformType) {
 
     // Check if a platformType has been passed as an npm inline script value
     if(process.env.npm_config_target !== undefined) {
-        if(project.globalConsts.targetPlatform[process.env.npm_config_target] === undefined) {
+        if(project.globalConsts.platformTarget[process.env.npm_config_target] === undefined) {
             pt.error = true;
-            pt.errorMessage = `Given platform '${process.env.npm_config_target}' does not exist. Plaforms availabe:\n • ${Object.keys(project.globalConsts.targetPlatform).join("\n • ")}`
+            pt.errorMessage = `Given platform '${process.env.npm_config_target}' does not exist. Plaforms availabe:\n • ${Object.keys(project.globalConsts.platformTarget).join("\n • ")}`
         } else {
             pt.type = process.env.npm_config_target;
             pt.shouldCreateAll = false;
         }
     } else {
-        pt.type = platformType !== undefined ? platformType : Object.keys(project.globalConsts.targetPlatform)[0];
+        pt.type = platformType !== undefined ? platformType : Object.keys(project.globalConsts.platformTarget)[0];
     }
 
     return pt;
@@ -36,7 +36,7 @@ function getDefaultPlatformType(platformType) {
 
 // Method that will handle the end of tsCompilation
 function onTsCompileFinish(platformType, cb, shouldCreateAll) {
-    const pts = project.globalConsts.targetPlatform;
+    const pts = project.globalConsts.platformTarget;
     if(shouldCreateAll === false || platformType === pts[Object.keys(pts)[Object.keys(pts).length-1]]) {
         cb();
     }
@@ -59,12 +59,12 @@ function tsTranspile(cb, envMode, platformType) {
         return;
     }
     // Set filesPath accordingly as well
-    filesPath[pt.type] = `${distFolder}/${envMode === project.globalConsts.envType.production ? '' : envMode + "."}${project.globalConsts.targetPlatform[pt.type]}.OutSystemsUI.js`;
+    filesPath[pt.type] = `${distFolder}/${envMode === project.globalConsts.envType.production ? '' : envMode + "."}${project.globalConsts.platformTarget[pt.type]}.OutSystemsUI.js`;
     // Update tsConfig file and do the Ts compilation accordingly
-    updateTsConfigFile(cb, envMode, project.globalConsts.targetPlatform[pt.type], pt.shouldCreateAll);
+    updateTsConfigFile(cb, envMode, project.globalConsts.platformTarget[pt.type], pt.shouldCreateAll);
     // Check if there is still any pending platform to tackle
-    if(pt.shouldCreateAll && pt.type !== Object.keys(project.globalConsts.targetPlatform)[Object.keys(project.globalConsts.targetPlatform).length-1]) {
-        tsTranspile(cb, envMode, Object.keys(project.globalConsts.targetPlatform)[(Object.keys(project.globalConsts.targetPlatform).indexOf(pt.type)+1)]);
+    if(pt.shouldCreateAll && pt.type !== Object.keys(project.globalConsts.platformTarget)[Object.keys(project.globalConsts.platformTarget).length-1]) {
+        tsTranspile(cb, envMode, Object.keys(project.globalConsts.platformTarget)[(Object.keys(project.globalConsts.platformTarget).indexOf(pt.type)+1)]);
     }
 }
 
@@ -119,7 +119,7 @@ function updateFwkAndPlatformInfo(cb) {
         let specsInfo = '';
 
         specsInfo += `/*!\n`;
-        specsInfo += `${project.info.name} ${project.info.version} • ${project.globalConsts.targetPlatform[pt]} Platform\n`;
+        specsInfo += `${project.info.name} ${project.info.version} • ${project.globalConsts.platformTarget[pt]} Platform\n`;
         if (project.info.description !== '') {
             specsInfo += `${project.info.description}\n`;
         }
@@ -135,8 +135,8 @@ function updateFwkAndPlatformInfo(cb) {
         let dtsCode = fs.existsSync(dtsFilePath) ? fs.readFileSync(dtsFilePath, 'utf8') : null;
         
         // Set platformType to the OSFramework.OSUI.Constants
-        jsCode = jsCode.replace("<->platformType<->", project.globalConsts.targetPlatform[pt]);
-        dtsCode = dtsCode !== null ? dtsCode.replace("<->platformType<->", project.globalConsts.targetPlatform[pt]) : null;
+        jsCode = jsCode.replace("<->platformType<->", project.globalConsts.platformTarget[pt]);
+        dtsCode = dtsCode !== null ? dtsCode.replace("<->platformType<->", project.globalConsts.platformTarget[pt]) : null;
 
         // Update code
         let updatedCode = specsInfo + jsCode;

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -39,13 +39,13 @@ function updateIndexTemplateFile() {
 
     let jsLinks = '';
     let scssLinks = '';
-    if(process.env.npm_config_target !== undefined && project.globalConsts.targetPlatform[process.env.npm_config_target] !== undefined) {
-        code = code.replace(" • --platform--", " • " + project.globalConsts.targetPlatform[process.env.npm_config_target]);
-        jsLinks = `<li><p><a target="blank" href="./dev.${project.globalConsts.targetPlatform[process.env.npm_config_target]}.OutSystemsUI.js">${project.globalConsts.targetPlatform[process.env.npm_config_target]}.OutSystemsUI.js</a></p></li>`;
-        scssLinks = `<li><p><a target="blank" href="./dev.${project.globalConsts.targetPlatform[process.env.npm_config_target]}.OutSystemsUI.css">${project.globalConsts.targetPlatform[process.env.npm_config_target]}.OutSystemsUI.css</a></p></li>`;
+    if(process.env.npm_config_target !== undefined && project.globalConsts.platformTarget[process.env.npm_config_target] !== undefined) {
+        code = code.replace(" • --platform--", " • " + project.globalConsts.platformTarget[process.env.npm_config_target]);
+        jsLinks = `<li><p><a target="blank" href="./dev.${project.globalConsts.platformTarget[process.env.npm_config_target]}.OutSystemsUI.js">${project.globalConsts.platformTarget[process.env.npm_config_target]}.OutSystemsUI.js</a></p></li>`;
+        scssLinks = `<li><p><a target="blank" href="./dev.${project.globalConsts.platformTarget[process.env.npm_config_target]}.OutSystemsUI.css">${project.globalConsts.platformTarget[process.env.npm_config_target]}.OutSystemsUI.css</a></p></li>`;
     } else {
         code = code.replace(" • --platform--", "");
-        const pts = project.globalConsts.targetPlatform;
+        const pts = project.globalConsts.platformTarget;
         for(const pt in pts) {
             jsLinks += `<li><p><a target="blank" href="./dev.${pts[pt]}.OutSystemsUI.js">${pts[pt]}.OutSystemsUI.js</a></p></li>\n`;
             scssLinks += `<li><p><a target="blank" href="./dev.${pts[pt]}.OutSystemsUI.css">${pts[pt]}.OutSystemsUI.css</a></p></li>\n`;

--- a/src/scripts/OSFramework/OSUI/Event/DOMEvents/Listeners/ScreenOnScroll.ts
+++ b/src/scripts/OSFramework/OSUI/Event/DOMEvents/Listeners/ScreenOnScroll.ts
@@ -1,6 +1,30 @@
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 namespace OSFramework.OSUI.Event.DOMEvents.Listeners {
 	/**
+	 * Auxiliar method that will return the container where the scroll will be set
+	 *
+	 * @return {*}  {(HTMLElement | Document)}
+	 */
+	function scrollableScreenContainer(): HTMLElement | Document {
+		// Store the container element
+		let scrollableContainer: HTMLElement | Document = undefined;
+
+		// If native app, scrollable container will be the .content inside .active-scren
+		if (OSFramework.OSUI.Helper.DeviceInfo.IsNative) {
+			scrollableContainer = Helper.Dom.ClassSelector(
+				document,
+				`${GlobalEnum.CssClassElements.ActiveScreen} ${Constants.Dot}${GlobalEnum.CssClassElements.Content}`
+			);
+		} else {
+			// At non native apps, .active-screen is the one container with scroll
+			scrollableContainer = Helper.Dom.ClassSelector(document, GlobalEnum.CssClassElements.ActiveScreen);
+		}
+
+		// If any of the elements above has been find, probably user is using it's own laytout, in those cases body will be set as scrollable container.
+		return scrollableContainer !== undefined ? scrollableContainer : document.body;
+	}
+
+	/**
 	 * Class that represents the scroll on the active screen element.
 	 *
 	 * @export
@@ -9,7 +33,7 @@ namespace OSFramework.OSUI.Event.DOMEvents.Listeners {
 	 */
 	export class ScreenOnScroll extends AbstractListener<string> {
 		constructor() {
-			super( Helper.Dom.ClassSelector(document, GlobalEnum.CssClassElements.ActiveScreen), GlobalEnum.HTMLEvent.Scroll);
+			super(scrollableScreenContainer(), GlobalEnum.HTMLEvent.Scroll);
 			this.eventCallback = this._screenTrigger.bind(this);
 		}
 

--- a/src/scripts/OSFramework/OSUI/Event/DOMEvents/Listeners/ScreenOnScroll.ts
+++ b/src/scripts/OSFramework/OSUI/Event/DOMEvents/Listeners/ScreenOnScroll.ts
@@ -9,8 +9,8 @@ namespace OSFramework.OSUI.Event.DOMEvents.Listeners {
 		// Store the container element
 		let scrollableContainer: HTMLElement | Document = undefined;
 
-		// If native app, scrollable container will be the .content inside .active-scren
-		if (OSFramework.OSUI.Helper.DeviceInfo.IsNative) {
+		// If native or pwa app, scrollable container will be the .content inside .active-scren
+		if (OSFramework.OSUI.Helper.DeviceInfo.IsNative || OSFramework.OSUI.Helper.DeviceInfo.IsPwa) {
 			scrollableContainer = Helper.Dom.ClassSelector(
 				document,
 				`${GlobalEnum.CssClassElements.ActiveScreen} ${Constants.Dot}${GlobalEnum.CssClassElements.Content}`

--- a/src/scripts/OSFramework/OSUI/Event/DOMEvents/Listeners/ScreenOnScroll.ts
+++ b/src/scripts/OSFramework/OSUI/Event/DOMEvents/Listeners/ScreenOnScroll.ts
@@ -19,7 +19,7 @@ namespace OSFramework.OSUI.Event.DOMEvents.Listeners {
 				`${GlobalEnum.CssClassElements.ActiveScreen} ${Constants.Dot}${GlobalEnum.CssClassElements.Content}`
 			);
 		} else {
-			// At non native or android apps, .active-screen is the one container with scroll
+			// At non native or android apps, .active-screen is the container with scroll
 			scrollableContainer = Helper.Dom.ClassSelector(document, GlobalEnum.CssClassElements.ActiveScreen);
 		}
 

--- a/src/scripts/OSFramework/OSUI/Event/DOMEvents/Listeners/ScreenOnScroll.ts
+++ b/src/scripts/OSFramework/OSUI/Event/DOMEvents/Listeners/ScreenOnScroll.ts
@@ -9,14 +9,17 @@ namespace OSFramework.OSUI.Event.DOMEvents.Listeners {
 		// Store the container element
 		let scrollableContainer: HTMLElement | Document = undefined;
 
-		// If native or pwa app, scrollable container will be the .content inside .active-scren
-		if (OSFramework.OSUI.Helper.DeviceInfo.IsNative || OSFramework.OSUI.Helper.DeviceInfo.IsPwa) {
+		// If native or pwa app when NOT android, scrollable container will be the .content inside .active-scren
+		if (
+			OSFramework.OSUI.Helper.DeviceInfo.IsAndroid === false &&
+			(OSFramework.OSUI.Helper.DeviceInfo.IsNative || OSFramework.OSUI.Helper.DeviceInfo.IsPwa)
+		) {
 			scrollableContainer = Helper.Dom.ClassSelector(
 				document,
 				`${GlobalEnum.CssClassElements.ActiveScreen} ${Constants.Dot}${GlobalEnum.CssClassElements.Content}`
 			);
 		} else {
-			// At non native apps, .active-screen is the one container with scroll
+			// At non native or android apps, .active-screen is the one container with scroll
 			scrollableContainer = Helper.Dom.ClassSelector(document, GlobalEnum.CssClassElements.ActiveScreen);
 		}
 

--- a/src/scripts/Providers/OSUI/SharedProviderResources/Flatpickr/Enum.ts
+++ b/src/scripts/Providers/OSUI/SharedProviderResources/Flatpickr/Enum.ts
@@ -1,5 +1,10 @@
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 namespace Providers.OSUI.SharedProviderResources.Flatpickr.Enum {
+	// CssClasses Enum
+	export enum CssClasses {
+		CalendarContainer = 'flatpickr-calendar',
+	}
+
 	// Flatpickr provider info
 	export enum ProviderInfo {
 		Name = 'Flatpickr',

--- a/src/scripts/Providers/OSUI/SharedProviderResources/Flatpickr/UpdatePositionOnScroll.ts
+++ b/src/scripts/Providers/OSUI/SharedProviderResources/Flatpickr/UpdatePositionOnScroll.ts
@@ -28,14 +28,22 @@ namespace Providers.OSUI.SharedProviderResources.Flatpickr {
 		// Update the calendar position
 		private _onScreenScroll(): void {
 			if (this._picker.isBuilt) {
-				// If the calendar is open!
-				if (this._picker.provider.isOpen) {
-					// trigger provider update position method
-					this._picker.provider._positionCalendar();
-					// Update the "position" before the next "repaint"
-					this._requestAnimationOnBodyScroll = requestAnimationFrame(this._onScreenScrollEvent);
+				// Check if IsDesktop
+				if (OSFramework.OSUI.Helper.DeviceInfo.IsDesktop) {
+					// If the calendar is open!
+					if (this._picker.provider.isOpen) {
+						// trigger provider update position method
+						this._picker.provider._positionCalendar();
+						// Update the "position" before the next "repaint"
+						this._requestAnimationOnBodyScroll = requestAnimationFrame(this._onScreenScrollEvent);
+					} else {
+						cancelAnimationFrame(this._requestAnimationOnBodyScroll);
+					}
 				} else {
-					cancelAnimationFrame(this._requestAnimationOnBodyScroll);
+					// Since it's at phone or tablet, close it if it's open!
+					if (this._picker.provider.isOpen) {
+						this._picker.provider.close();
+					}
 				}
 			}
 		}

--- a/src/scripts/Providers/OSUI/SharedProviderResources/Flatpickr/UpdatePositionOnScroll.ts
+++ b/src/scripts/Providers/OSUI/SharedProviderResources/Flatpickr/UpdatePositionOnScroll.ts
@@ -30,9 +30,19 @@ namespace Providers.OSUI.SharedProviderResources.Flatpickr {
 			if (this._picker.isBuilt) {
 				// Check if IsPhone
 				if (OSFramework.OSUI.Helper.DeviceInfo.IsPhone) {
-					// Close it if it's open!
-					if (this._picker.provider.isOpen) {
-						this._picker.provider.close();
+					// Check if the active element is a child of the calendar container
+					if (
+						document.activeElement.closest(
+							`${OSFramework.OSUI.Constants.Dot}${Enum.CssClasses.CalendarContainer}`
+						) === this._picker.provider.calendarContainer
+					) {
+						// calendar can't close => trigger provider update position method
+						this._picker.provider._positionCalendar();
+					} else {
+						// Close it if it's open
+						if (this._picker.provider.isOpen) {
+							this._picker.provider.close();
+						}
 					}
 				} else {
 					// Since it's at desktop or tablet, update it's position if it's open!

--- a/src/scripts/Providers/OSUI/SharedProviderResources/Flatpickr/UpdatePositionOnScroll.ts
+++ b/src/scripts/Providers/OSUI/SharedProviderResources/Flatpickr/UpdatePositionOnScroll.ts
@@ -28,9 +28,14 @@ namespace Providers.OSUI.SharedProviderResources.Flatpickr {
 		// Update the calendar position
 		private _onScreenScroll(): void {
 			if (this._picker.isBuilt) {
-				// Check if IsDesktop
-				if (OSFramework.OSUI.Helper.DeviceInfo.IsDesktop) {
-					// If the calendar is open!
+				// Check if IsPhone
+				if (OSFramework.OSUI.Helper.DeviceInfo.IsPhone) {
+					// Close it if it's open!
+					if (this._picker.provider.isOpen) {
+						this._picker.provider.close();
+					}
+				} else {
+					// Since it's at desktop or tablet, update it's position if it's open!
 					if (this._picker.provider.isOpen) {
 						// trigger provider update position method
 						this._picker.provider._positionCalendar();
@@ -38,11 +43,6 @@ namespace Providers.OSUI.SharedProviderResources.Flatpickr {
 						this._requestAnimationOnBodyScroll = requestAnimationFrame(this._onScreenScrollEvent);
 					} else {
 						cancelAnimationFrame(this._requestAnimationOnBodyScroll);
-					}
-				} else {
-					// Since it's at phone or tablet, close it if it's open!
-					if (this._picker.provider.isOpen) {
-						this._picker.provider.close();
 					}
 				}
 			}


### PR DESCRIPTION
- This PR will fix the issue that was happening when a scroll starts at a Picker input.
- It will also fix an issue that was preventing scrollEvent to be assigned to the container that has the scroll behaviour when app is native or pwa;

![Untitled](https://github.com/OutSystems/outsystems-ui/assets/5339917/68afe7e8-2beb-464d-9df7-b4b6d4ea5b48)