### PR TITLE
Update CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
-* @gnbm @joselrio @BenOsodrac @bmarcelino-fe @rugoncalves @JoaoFerreira-FrontEnd @OS-giulianasilva
+* @OutSystems/rd-ui-components


### PR DESCRIPTION
This PR is to update CODEOWNERS to have the team instead of individuals so it becomes easier to maintain.