### PR TITLE
ROU-4672: Fix keyboard tab navigation

### DIFF
--- a/src/scripts/OSFramework/OSUI/Pattern/SectionIndex/SectionIndex.ts
+++ b/src/scripts/OSFramework/OSUI/Pattern/SectionIndex/SectionIndex.ts
@@ -57,7 +57,7 @@ namespace OSFramework.OSUI.Patterns.SectionIndex {
 			this._contentPaddingTop = _mainContent
 				? parseFloat(
 						window.getComputedStyle(_mainContent).getPropertyValue(GlobalEnum.CssProperties.PaddingTop)
-				  )
+					)
 				: 0;
 		}
 

--- a/src/scripts/OSFramework/OSUI/Pattern/SectionIndexItem/SectionIndexItem.ts
+++ b/src/scripts/OSFramework/OSUI/Pattern/SectionIndexItem/SectionIndexItem.ts
@@ -40,16 +40,12 @@ namespace OSFramework.OSUI.Patterns.SectionIndexItem {
 
 		// Method to set the A11y keyboard navigation
 		private _onKeyboardPressed(event: KeyboardEvent): void {
-			event.preventDefault();
-			event.stopPropagation();
-
-			switch (event.key) {
-				// If Enter or Space Keys trigger as a click event!
-				case GlobalEnum.Keycodes.Enter:
-				case GlobalEnum.Keycodes.Space:
-					// Triggered as it was clicked!
-					this._onSelected(event);
-					break;
+			// If Enter or Space Keys trigger as a click event!
+			if (event.key === GlobalEnum.Keycodes.Enter || event.key === GlobalEnum.Keycodes.Space) {
+				event.preventDefault();
+				event.stopPropagation();
+				// Triggered as it was clicked!
+				this._onSelected(event);
 			}
 		}
 


### PR DESCRIPTION
This PR is for fixing the keyboard tab navigation between the SectionIndexItem patterns.

### Checklist

-   [ ] tested locally
-   [ ] documented the code
-   [ ] clean all warnings and errors of eslint
-   [ ] requires changes in OutSystems (if so, provide a module with changes)
-   [ ] requires new sample page in OutSystems (if so, provide a module with changes)
