### PR TITLE
[ROU-3816 V2]: Fixed ScreenOnScroll and ToggleNativeBehavior API issues

### DIFF
--- a/src/scripts/OSFramework/OSUI/Event/DOMEvents/Listeners/AbstractListener.ts
+++ b/src/scripts/OSFramework/OSUI/Event/DOMEvents/Listeners/AbstractListener.ts
@@ -84,5 +84,26 @@ namespace OSFramework.OSUI.Event.DOMEvents.Listeners {
 				this._eventTarget.removeEventListener(this._eventType, this.eventCallback);
 			}
 		}
+
+		/**
+		 * Getter that allows to obtain the eventTarget reference
+		 *
+		 * @readonly
+		 * @type {HTMLElement | Document | Window}
+		 * @memberof AbstractListener
+		 */
+		public get eventTarget(): HTMLElement | Document | Window {
+			return this._eventTarget;
+		}
+
+		/**
+		 * Setter that allows to update the eventTarget reference
+		 *
+		 * @type {HTMLElement | Document | Window}
+		 * @memberof AbstractListener
+		 */
+		public set eventTarget(el: HTMLElement | Document | Window) {
+			this._eventTarget = el;
+		}
 	}
 }

--- a/src/scripts/OSFramework/OSUI/Event/DOMEvents/Listeners/AbstractListener.ts
+++ b/src/scripts/OSFramework/OSUI/Event/DOMEvents/Listeners/AbstractListener.ts
@@ -99,7 +99,6 @@ namespace OSFramework.OSUI.Event.DOMEvents.Listeners {
 		/**
 		 * Setter that allows to update the eventTarget reference
 		 *
-		 * @type {HTMLElement | Document | Window}
 		 * @memberof AbstractListener
 		 */
 		public set eventTarget(el: HTMLElement | Document | Window) {

--- a/src/scripts/OSFramework/OSUI/Event/DOMEvents/Listeners/ScreenOnScroll.ts
+++ b/src/scripts/OSFramework/OSUI/Event/DOMEvents/Listeners/ScreenOnScroll.ts
@@ -10,17 +10,19 @@ namespace OSFramework.OSUI.Event.DOMEvents.Listeners {
 		let scrollableContainer: HTMLElement | Document = undefined;
 
 		// If native or pwa app when NOT android, scrollable container will be the .content inside .active-scren
-		if (
-			OSFramework.OSUI.Helper.DeviceInfo.IsAndroid === false &&
-			(OSFramework.OSUI.Helper.DeviceInfo.IsNative || OSFramework.OSUI.Helper.DeviceInfo.IsPwa)
-		) {
-			scrollableContainer = Helper.Dom.ClassSelector(
-				document,
-				`${GlobalEnum.CssClassElements.ActiveScreen} ${Constants.Dot}${GlobalEnum.CssClassElements.Content}`
-			);
-		} else {
-			// At non native or android apps, .active-screen is the container with scroll
-			scrollableContainer = Helper.Dom.ClassSelector(document, GlobalEnum.CssClassElements.ActiveScreen);
+		switch (Helper.DeviceInfo.GetOperatingSystem()) {
+			case GlobalEnum.MobileOS.Android:
+			case GlobalEnum.MobileOS.MacOS:
+			case GlobalEnum.MobileOS.Unknown:
+			case GlobalEnum.MobileOS.Windows:
+				scrollableContainer = Helper.Dom.ClassSelector(document, GlobalEnum.CssClassElements.ActiveScreen);
+				break;
+			case GlobalEnum.MobileOS.IOS:
+				scrollableContainer = Helper.Dom.ClassSelector(
+					document,
+					`${GlobalEnum.CssClassElements.ActiveScreen} ${Constants.Dot}${GlobalEnum.CssClassElements.Content}`
+				);
+				break;
 		}
 
 		// If any of the elements above has been find, probably user is using it's own laytout, in those cases body will be set as scrollable container.

--- a/src/scripts/OSFramework/OSUI/Event/DOMEvents/Listeners/ScreenOnScroll.ts
+++ b/src/scripts/OSFramework/OSUI/Event/DOMEvents/Listeners/ScreenOnScroll.ts
@@ -9,7 +9,7 @@ namespace OSFramework.OSUI.Event.DOMEvents.Listeners {
 		// Store the container element
 		let scrollableContainer: HTMLElement | Document = undefined;
 
-		// If native or pwa app when NOT android, scrollable container will be the .content inside .active-scren
+		// Check based on the OS since Helper.DeviceInfo.Is* are returnin false in all cases since body classes are not set when this will be executed.
 		switch (Helper.DeviceInfo.GetOperatingSystem()) {
 			case GlobalEnum.MobileOS.Android:
 			case GlobalEnum.MobileOS.MacOS:

--- a/src/scripts/OSFramework/OSUI/Event/DOMEvents/Listeners/ScreenOnScroll.ts
+++ b/src/scripts/OSFramework/OSUI/Event/DOMEvents/Listeners/ScreenOnScroll.ts
@@ -44,5 +44,26 @@ namespace OSFramework.OSUI.Event.DOMEvents.Listeners {
 		private _screenTrigger(evt: Event): void {
 			this.trigger(GlobalEnum.HTMLEvent.Scroll, evt);
 		}
+
+		/**
+		 * Method to set a new handler and update the target if it's the case.
+		 * - At screen transitions if we do not update the eventTarget this event will be lost since the container will not be the same instance at the new screen!
+		 *
+		 * @param {GlobalCallbacks.OSGeneric} handler
+		 * @memberof ScreenOnScroll
+		 */
+		public addHandler(handler: GlobalCallbacks.OSGeneric): void {
+			// Check if the current eventTarget is different from the current one.
+			if (this.eventTarget !== scrollableScreenContainer()) {
+				// Remove the assigned event from the previous eventTarget
+				this.removeEvent();
+				// Update the new eventTarget
+				this.eventTarget = scrollableScreenContainer();
+				// Reassign the event but to the new target
+				this.addEvent();
+			}
+			// Set handler
+			super.addHandler(handler);
+		}
 	}
 }

--- a/src/scripts/OSFramework/OSUI/Event/DOMEvents/Listeners/ScreenOnScroll.ts
+++ b/src/scripts/OSFramework/OSUI/Event/DOMEvents/Listeners/ScreenOnScroll.ts
@@ -5,27 +5,19 @@ namespace OSFramework.OSUI.Event.DOMEvents.Listeners {
 	 *
 	 * @return {*}  {(HTMLElement | Document)}
 	 */
-	function scrollableScreenContainer(): HTMLElement | Document {
+	function getScrollableScreenContainer(): HTMLElement | Document {
 		// Store the container element
-		let scrollableContainer: HTMLElement | Document = undefined;
+		let scrollableContainer = Helper.Dom.ClassSelector(document, GlobalEnum.CssClassElements.ActiveScreen);
 
-		// Check based on the OS since Helper.DeviceInfo.Is* are returnin false in all cases since body classes are not set when this will be executed.
-		switch (Helper.DeviceInfo.GetOperatingSystem()) {
-			case GlobalEnum.MobileOS.Android:
-			case GlobalEnum.MobileOS.MacOS:
-			case GlobalEnum.MobileOS.Unknown:
-			case GlobalEnum.MobileOS.Windows:
-				scrollableContainer = Helper.Dom.ClassSelector(document, GlobalEnum.CssClassElements.ActiveScreen);
-				break;
-			case GlobalEnum.MobileOS.IOS:
-				scrollableContainer = Helper.Dom.ClassSelector(
-					document,
-					`${GlobalEnum.CssClassElements.ActiveScreen} ${Constants.Dot}${GlobalEnum.CssClassElements.Content}`
-				);
-				break;
+		// Check based on the OS once Helper.DeviceInfo.Is* are returning false in all cases since body classes are not set when this will be executed.
+		if (Helper.DeviceInfo.GetOperatingSystem() === GlobalEnum.MobileOS.IOS) {
+			scrollableContainer = Helper.Dom.ClassSelector(
+				document,
+				`${GlobalEnum.CssClassElements.ActiveScreen} ${Constants.Dot}${GlobalEnum.CssClassElements.Content}`
+			);
 		}
 
-		// If any of the elements above has been find, probably user is using it's own laytout, in those cases body will be set as scrollable container.
+		// If any of the elements above has been found, probably user is using it's own laytout, in those cases body will be set as scrollable container.
 		return scrollableContainer !== undefined ? scrollableContainer : document.body;
 	}
 
@@ -38,7 +30,7 @@ namespace OSFramework.OSUI.Event.DOMEvents.Listeners {
 	 */
 	export class ScreenOnScroll extends AbstractListener<string> {
 		constructor() {
-			super(scrollableScreenContainer(), GlobalEnum.HTMLEvent.Scroll);
+			super(getScrollableScreenContainer(), GlobalEnum.HTMLEvent.Scroll);
 			this.eventCallback = this._screenTrigger.bind(this);
 		}
 
@@ -56,11 +48,11 @@ namespace OSFramework.OSUI.Event.DOMEvents.Listeners {
 		 */
 		public addHandler(handler: GlobalCallbacks.OSGeneric): void {
 			// Check if the current eventTarget is different from the current one.
-			if (this.eventTarget !== scrollableScreenContainer()) {
+			if (this.eventTarget !== getScrollableScreenContainer()) {
 				// Remove the assigned event from the previous eventTarget
 				this.removeEvent();
 				// Update the new eventTarget
-				this.eventTarget = scrollableScreenContainer();
+				this.eventTarget = getScrollableScreenContainer();
 				// Reassign the event but to the new target
 				this.addEvent();
 			}

--- a/src/scripts/Providers/OSUI/Datepicker/Flatpickr/AbstractFlatpickr.ts
+++ b/src/scripts/Providers/OSUI/Datepicker/Flatpickr/AbstractFlatpickr.ts
@@ -564,19 +564,6 @@ namespace Providers.OSUI.Datepicker.Flatpickr {
 		}
 
 		/**
-		 * Method used to toggle the default native behavior of DatePicker
-		 *
-		 * @memberof Providers.OSUI.DatePicker.Flatpickr.AbstractFlatpickr
-		 */
-		public toggleNativeBehavior(isNative: boolean): void {
-			// Invert the boolean value of IsNative because of provider option
-			if (this.configs.DisableMobile !== !isNative) {
-				this.configs.DisableMobile = !isNative;
-				this.prepareToAndRedraw();
-			}
-		}
-
-		/**
 		 * Method used to update the prompt message
 		 *
 		 * @param promptMessage The new prompt message value

--- a/src/scripts/Providers/OSUI/Datepicker/Flatpickr/RangeDate/FlatpickrRangeDate.ts
+++ b/src/scripts/Providers/OSUI/Datepicker/Flatpickr/RangeDate/FlatpickrRangeDate.ts
@@ -153,6 +153,15 @@ namespace Providers.OSUI.Datepicker.Flatpickr.RangeDate {
 		}
 
 		/**
+		 * This method has no implementation on this pattern context!
+		 *
+		 * @memberof Providers.OSUI.DatePicker.Flatpickr.RangeDate.OSUIFlatpickrRangeDate
+		 */
+		public toggleNativeBehavior(): void {
+			console.log(OSFramework.OSUI.GlobalEnum.WarningMessages.MethodNotImplemented);
+		}
+
+		/**
 		 * Method used to update the StartInitialDate and EndInitialDate values
 		 *
 		 * @param startDate The new StartInitialDate value

--- a/src/scripts/Providers/OSUI/Datepicker/Flatpickr/SingleDate/FlatpickrSingleDate.ts
+++ b/src/scripts/Providers/OSUI/Datepicker/Flatpickr/SingleDate/FlatpickrSingleDate.ts
@@ -196,6 +196,19 @@ namespace Providers.OSUI.Datepicker.Flatpickr.SingleDate {
 		}
 
 		/**
+		 * Method used to toggle the default native behavior of DatePicker
+		 *
+		 * @memberof Providers.OSUI.DatePicker.Flatpickr.SingleDate.OSUIFlatpickrSingleDate
+		 */
+		public toggleNativeBehavior(isNative: boolean): void {
+			// Invert the boolean value of IsNative because of provider option
+			if (this.configs.DisableMobile !== !isNative) {
+				this.configs.DisableMobile = !isNative;
+				this.prepareToAndRedraw();
+			}
+		}
+
+		/**
 		 * Method used to update the InitialDate config value
 		 *
 		 * @param value The new InitialDate value that will be set

--- a/src/scripts/Providers/OSUI/SharedProviderResources/Flatpickr/UpdatePositionOnScroll.ts
+++ b/src/scripts/Providers/OSUI/SharedProviderResources/Flatpickr/UpdatePositionOnScroll.ts
@@ -51,10 +51,8 @@ namespace Providers.OSUI.SharedProviderResources.Flatpickr {
 						this._picker.provider._positionCalendar();
 						// Update the "position" before the next "repaint"
 						this._requestAnimationOnBodyScroll = requestAnimationFrame(this._onScreenScrollEvent);
-					} else {
-						if (this._requestAnimationOnBodyScroll !== undefined) {
-							cancelAnimationFrame(this._requestAnimationOnBodyScroll);
-						}
+					} else if (this._requestAnimationOnBodyScroll !== undefined) {
+						cancelAnimationFrame(this._requestAnimationOnBodyScroll);
 					}
 				}
 			}

--- a/src/scripts/Providers/OSUI/SharedProviderResources/Flatpickr/UpdatePositionOnScroll.ts
+++ b/src/scripts/Providers/OSUI/SharedProviderResources/Flatpickr/UpdatePositionOnScroll.ts
@@ -29,7 +29,7 @@ namespace Providers.OSUI.SharedProviderResources.Flatpickr {
 		private _onScreenScroll(): void {
 			if (this._picker.isBuilt) {
 				// Check if IsPhone
-				if (OSFramework.OSUI.Helper.DeviceInfo.IsPhone) {
+				if (this._picker.provider.isOpen && OSFramework.OSUI.Helper.DeviceInfo.IsPhone) {
 					// Check if the active element is a child of the calendar container
 					if (
 						document.activeElement.closest(
@@ -39,12 +39,12 @@ namespace Providers.OSUI.SharedProviderResources.Flatpickr {
 						// calendar can't close => trigger provider update position method
 						this._picker.provider._positionCalendar();
 					} else {
-						// Close it if it's open
-						if (this._picker.provider.isOpen) {
-							this._picker.provider.close();
-						}
+						this._picker.provider.close();
 					}
-				} else {
+				}
+
+				// Ensure app is not running as a phone
+				if (OSFramework.OSUI.Helper.DeviceInfo.IsPhone === false) {
 					// Since it's at desktop or tablet, update it's position if it's open!
 					if (this._picker.provider.isOpen) {
 						// trigger provider update position method
@@ -52,7 +52,9 @@ namespace Providers.OSUI.SharedProviderResources.Flatpickr {
 						// Update the "position" before the next "repaint"
 						this._requestAnimationOnBodyScroll = requestAnimationFrame(this._onScreenScrollEvent);
 					} else {
-						cancelAnimationFrame(this._requestAnimationOnBodyScroll);
+						if (this._requestAnimationOnBodyScroll !== undefined) {
+							cancelAnimationFrame(this._requestAnimationOnBodyScroll);
+						}
 					}
 				}
 			}


### PR DESCRIPTION
**This PR will add fixes related with:**
> ToggleNativebehaviour API:
- Method was implemented in both DatePicker and DatePickerRange, which ends into an issue since the redraw was happening in both contexts when at DatePickerRange this will never happen.

> ScreenOnScroll event:
- Implemented logic to validate if ScreenOnScroll container has changed, if so, update the targetElement accordingly, this will happen at the screen transition when the container with scroll will be the same but not the same instance!

Also improved code readability on contexts mentioned above.