### PR TITLE
ROU-3947: Improve A11y styles on MonthPicker

### DIFF
--- a/src/scripts/Providers/OSUI/SharedProviderResources/Flatpickr/scss/_flatpickr.scss
+++ b/src/scripts/Providers/OSUI/SharedProviderResources/Flatpickr/scss/_flatpickr.scss
@@ -588,3 +588,14 @@ span.flatpickr-weekday {
 		border-color: var(--color-focus-outer);
 	}
 }
+
+body:has(.has-accessible-features) .osui-monthpicker__dropdown {
+	.numInputWrapper input,
+	.flatpickr-prev-month,
+	.flatpickr-next-month,
+	.flatpickr-monthSelect-month.selected {
+		&:focus-visible {
+			box-shadow: 0 0 0 3px var(--color-focus-outer);
+		}
+	}
+}


### PR DESCRIPTION
This PR is for improving the A11y styles on MonthPicker, when using the keyboard.

### Checklist

-   [ ] tested locally
-   [ ] documented the code
-   [ ] clean all warnings and errors of eslint
-   [ ] requires changes in OutSystems (if so, provide a module with changes)
-   [ ] requires new sample page in OutSystems (if so, provide a module with changes)
