### PR TITLE
ROU-4692 - [OSUI] Sidebar is not working as expected when a button is used to open

### DIFF
--- a/src/scripts/OSFramework/OSUI/Pattern/Sidebar/Sidebar.ts
+++ b/src/scripts/OSFramework/OSUI/Pattern/Sidebar/Sidebar.ts
@@ -255,9 +255,7 @@ namespace OSFramework.OSUI.Patterns.Sidebar {
 			this._clickedOutsideElement = true;
 			if (
 				targetElem.closest(`${Constants.Dot}${Enum.CssClass.Header}`) ||
-				(targetElem.closest(`${Constants.Dot}${Enum.CssClass.Content}`) &&
-					this.selfElement.contains(targetElem) === false)
-				// This is right because the overlay is part of the selfElement.
+				targetElem.closest(`${Constants.Dot}${Enum.CssClass.Content}`)
 			) {
 				// If the click was inside the side bar, then change the flag to false.
 				this._clickedOutsideElement = false;

--- a/src/scripts/OSFramework/OSUI/Pattern/Sidebar/Sidebar.ts
+++ b/src/scripts/OSFramework/OSUI/Pattern/Sidebar/Sidebar.ts
@@ -205,11 +205,11 @@ namespace OSFramework.OSUI.Patterns.Sidebar {
 				if (this._clickOutsideToClose || (this.configs.HasOverlay && this._clickOutsideToClose === undefined)) {
 					Event.DOMEvents.Listeners.GlobalListenerManager.Instance.addHandler(
 						Event.DOMEvents.Listeners.Type.BodyOnMouseDown,
-						this._eventOverlayMouseDown.bind(this)
+						this._eventOverlayMouseDown
 					);
 					Event.DOMEvents.Listeners.GlobalListenerManager.Instance.addHandler(
 						Event.DOMEvents.Listeners.Type.BodyOnClick,
-						this._eventOverlayClick.bind(this)
+						this._eventOverlayClick
 					);
 				}
 			}
@@ -257,6 +257,7 @@ namespace OSFramework.OSUI.Patterns.Sidebar {
 				targetElem.closest(`${Constants.Dot}${Enum.CssClass.Header}`) ||
 				(targetElem.closest(`${Constants.Dot}${Enum.CssClass.Content}`) &&
 					this.selfElement.contains(targetElem) === false)
+				// This is right because the overlay is part of the selfElement.
 			) {
 				// If the click was inside the side bar, then change the flag to false.
 				this._clickedOutsideElement = false;


### PR DESCRIPTION
This PR is for fixing the sidebar toggle when the ClickOutsideToClose feature was on.


### What was happening

- We discovered that the body handlers that should be removed on close were not.

### What was done

- remove bind(this) from add Handler on openSidebar;

### Test Steps

1. Config a sample with a sidebar, on the onInitialized call the API to Config the ClickOutsudeToClose feature
2. Add Buttons on the screen to open and toggle the sidebar
3. Add a button on the sidebar to close itself
4. Run the page and check if the toggle interaction work properly
5. Check if the handlers are not being duplicated under OSFramework.OSUI.Event.DOMEvents.Listeners.GlobalListenerManager.Instance;

### Checklist

-   [x] tested locally
-   [x] documented the code
-   [x] clean all warnings and errors of eslint
-   [ ] requires changes in OutSystems (if so, provide a module with changes)
-   [ ] requires new sample page in OutSystems (if so, provide a module with changes)
