### PR TITLE
ROU-4712: closes unexpectedly when is used on an Android Tablet

### DIFF
--- a/src/scripts/Providers/OSUI/Dropdown/VirtualSelect/AbstractVirtualSelect.ts
+++ b/src/scripts/Providers/OSUI/Dropdown/VirtualSelect/AbstractVirtualSelect.ts
@@ -10,6 +10,7 @@ namespace Providers.OSUI.Dropdown.VirtualSelect {
 		private _onMouseUpEvent: OSFramework.OSUI.GlobalCallbacks.Generic;
 		private _onSelectedOptionEvent: OSFramework.OSUI.GlobalCallbacks.Generic;
 		private _platformEventSelectedOptCallback: OSFramework.OSUI.Patterns.Dropdown.Callbacks.OSOnSelectEvent;
+		private _windowWidth: number;
 
 		// Store the hidden input AriaLabel value
 		protected hiddenInputWrapperAriaLabelVal: string;
@@ -66,17 +67,24 @@ namespace Providers.OSUI.Dropdown.VirtualSelect {
 			this.triggerPlatformEventCallback(this._platformEventSelectedOptCallback, this.getSelectedValues());
 		}
 
-		// Close the dropdown if it's open!
+		// Close the dropdown if it's open and if the resize is vertically changed!
 		private _onWindowResize() {
-			if (this.provider.isOpened()) {
+			// If there is a horizontal resize and the Dropdown is open, close it!
+			if (this.provider.isOpened() && this._windowWidth !== window.innerWidth) {
 				this.virtualselectConfigs.close();
 			}
+
+			// Update windowWidth value
+			this._windowWidth = window.innerWidth;
 		}
 
-		// Set the ElementId that is expected from VirtualSelect config
-		private _setElementId(): void {
-			// Store the ElementId where the provider will create the Dropdown
+		// Set Dropdown Element ID and window width
+		private _setDropdownProps(): void {
+			// Define the ElementId that is expected from VirtualSelect config and where the provider will create the Dropdown
 			this.configs.ElementId = '#' + this.selfElement.id;
+
+			// Set the windowWidth value
+			this._windowWidth = window.innerWidth;
 		}
 
 		// Set Pattern Events
@@ -231,7 +239,7 @@ namespace Providers.OSUI.Dropdown.VirtualSelect {
 		public build(): void {
 			super.build();
 
-			this._setElementId();
+			this._setDropdownProps();
 
 			this.setCallbacks();
 


### PR DESCRIPTION
This PR is for fixing an issue on mobile devices that trigger the onresize event and closes unexpectedly the keyboard

### What was happening
- When a DropdownSearch is used on Android devices that reported a desktop resolution, the dropdown will open and closes automatically. This happens because the device was detected as a desktop which will trigger the _eventOnWindowResize.

### What was done
- Created a flag that will store the value of window.width to only trigger the resize event when a vertical resize occurs

### Test Steps
1. Open sample page on an Android Device in landscape
2. Open a dropdown
3. Click on the input search to open keyboard (Expected: the keyboard will continue open)
4. Rotate device (Expected: The keyboard and dropdown will close)
5. Open a dropdown
6. Click on the input search to open keyboard (Expected: the keyboard will continue open)
7. Rotate device (Expected: The keyboard and dropdown will close) 

### Checklist
-   [X] tested locally
-   [X] documented the code
-   [X] clean all warnings and errors of eslint
-   [ ] requires changes in OutSystems (if so, provide a module with changes)
-   [ ] requires new sample page in OutSystems (if so, provide a module with changes)
