### PR TITLE
ROU-4712: Dropdown Search closes unexpectedly when is used on an Android Tablet

### DIFF
--- a/src/scripts/OSFramework/OSUI/Helper/Device.ts
+++ b/src/scripts/OSFramework/OSUI/Helper/Device.ts
@@ -461,7 +461,7 @@ namespace OSFramework.OSUI.Helper {
 		}
 
 		/**
-		 * Method to return if is a mobile device based on is operating system
+		 * Method to return if is running on a mobile device
 		 *
 		 * @readonly
 		 * @static

--- a/src/scripts/OSFramework/OSUI/Helper/Device.ts
+++ b/src/scripts/OSFramework/OSUI/Helper/Device.ts
@@ -461,6 +461,21 @@ namespace OSFramework.OSUI.Helper {
 		}
 
 		/**
+		 * Method to return if is a mobile device based on is operating system
+		 *
+		 * @readonly
+		 * @static
+		 * @type {boolean}
+		 * @memberof DeviceInfo
+		 */
+		public static get IsMobileDevice(): boolean {
+			const isMobileDevice =
+				DeviceInfo.GetOperatingSystem() === GlobalEnum.MobileOS.Android ||
+				DeviceInfo.GetOperatingSystem() === GlobalEnum.MobileOS.IOS;
+			return isMobileDevice;
+		}
+
+		/**
 		 * Gets the Notch Position.
 		 *
 		 * @private

--- a/src/scripts/Providers/OSUI/Dropdown/VirtualSelect/AbstractVirtualSelect.ts
+++ b/src/scripts/Providers/OSUI/Dropdown/VirtualSelect/AbstractVirtualSelect.ts
@@ -42,13 +42,6 @@ namespace Providers.OSUI.Dropdown.VirtualSelect {
 			}
 		}
 
-		// Method to close the Dropdown if it's opened
-		private _closeOpened(): void {
-			if (this.provider.isOpened()) {
-				this.virtualselectConfigs.close();
-			}
-		}
-
 		// Manage the attributes to be added
 		private _manageAttributes(): void {
 			// Manage A11Y attributes
@@ -71,7 +64,7 @@ namespace Providers.OSUI.Dropdown.VirtualSelect {
 
 		// Close the dropdown when a orientation change occurs
 		private _onOrientationChange() {
-			this._closeOpened();
+			this.close();
 		}
 
 		// Get the selected options and pass them into callBack
@@ -82,7 +75,7 @@ namespace Providers.OSUI.Dropdown.VirtualSelect {
 
 		// Close the dropdown when a resize occurs
 		private _onWindowResize() {
-			this._closeOpened();
+			this.close();
 		}
 
 		// Set the Dropdown properties
@@ -317,13 +310,17 @@ namespace Providers.OSUI.Dropdown.VirtualSelect {
 		}
 
 		/**
-		 * Method used to close the Dropdown
+		 * Method used to close the Dropdown if is opened
 		 *
 		 * @memberof Providers.OSUI.Dropdown.VirtualSelect.AbstractVirtualSelect
 		 */
 		public close(): void {
 			// SetTimeout is needed in order to ensure there is no conflit between OnClickBody and a button click that trigger this method.
-			OSFramework.OSUI.Helper.AsyncInvocation(this.virtualselectConfigs.close.bind(this.virtualselectConfigs));
+			if (this.provider.isOpened()) {
+				OSFramework.OSUI.Helper.AsyncInvocation(
+					this.virtualselectConfigs.close.bind(this.virtualselectConfigs)
+				);
+			}
 		}
 
 		/**

--- a/src/scripts/Providers/OSUI/Dropdown/VirtualSelect/AbstractVirtualSelectConfig.ts
+++ b/src/scripts/Providers/OSUI/Dropdown/VirtualSelect/AbstractVirtualSelectConfig.ts
@@ -19,6 +19,7 @@ namespace Providers.OSUI.Dropdown.VirtualSelect {
 		public NoOptionsText: string;
 		public NoResultsText: string;
 		public OptionsList: DropDownOption[];
+		public PopupDropboxBreakpoint: string;
 		public Prompt: string;
 		public SearchPrompt: string;
 		public ShowDropboxAsPopup = true;
@@ -195,6 +196,7 @@ namespace Providers.OSUI.Dropdown.VirtualSelect {
 				selectAllOnlyVisible: true,
 				selectedValue: this.getSelectedValues() as [],
 				showDropboxAsPopup: this.ShowDropboxAsPopup,
+				popupDropboxBreakpoint: this.PopupDropboxBreakpoint,
 				silentInitialValueSet: true,
 				textDirection: OutSystems.OSUI.Utils.GetIsRTL()
 					? OSFramework.OSUI.GlobalEnum.Direction.RTL


### PR DESCRIPTION
This PR is for fixing an issue on mobile devices that trigger the onresise event and closes unexpectedly the keyboard.

### What was happening
- When a DropdownSearch is opened on an tablet android device, the keyboard opens and closes unexpectedly because of the OnResize event that is triggered

### What was done
- Create a method IsMobileDevice that returns if is a mobile device
- Added an validation that uses the value of IsMobileDevice to add the event OnOrientationChange for mobile devices or the OnResize event to desktop applications

### Test Steps

1. Open sample page on an Android Device in landscape
2. Open a dropdown
3. Click on the input search to open keyboard (Expected: the keyboard will continue open)
4. Rotate device (Expected: The keyboard and dropdown will close)
5. Open a dropdown
6. Click on the input search to open keyboard (Expected: the keyboard will continue open)
7. Rotate device (Expected: The keyboard and dropdown will close)

### Checklist
-   [X] tested locally
-   [X] documented the code
-   [X] clean all warnings and errors of eslint
-   [ ] requires changes in OutSystems (if so, provide a module with changes)
-   [ ] requires new sample page in OutSystems (if so, provide a module with changes)
