### PR TITLE
ROU-4736: Dropdown Search/Tag with preselected values make the focus go to the dropdown and the dropdowns aren't filled when the DropdownSetValue Action is used

### DIFF
--- a/src/scripts/Providers/OSUI/Dropdown/VirtualSelect/AbstractVirtualSelect.ts
+++ b/src/scripts/Providers/OSUI/Dropdown/VirtualSelect/AbstractVirtualSelect.ts
@@ -460,16 +460,19 @@ namespace Providers.OSUI.Dropdown.VirtualSelect {
 		 * @memberof Providers.OSUI.Dropdown.VirtualSelect.AbstractVirtualSelect
 		 */
 		public setValue(optionsToSelect: DropDownOption[], silentOnChangedEvent = true): void {
-			const selectedValues = this.getSelectedOptionsStructure().map((value) => value.value) || [];
-			let valuesToSelect = [];
+			// Make async call to wait for fetching data when the setValues API is called inside on OnAfterFecth
+			OSFramework.OSUI.Helper.AsyncInvocation(() => {
+				const selectedValues = this.getSelectedOptionsStructure().map((value) => value.value) || [];
+				let valuesToSelect = [];
 
-			if (optionsToSelect.length > 0) {
-				if (this.virtualselectOpts.multiple) valuesToSelect = optionsToSelect.map((option) => option.value);
-				else valuesToSelect = [optionsToSelect[0].value];
-			}
+				if (optionsToSelect.length > 0) {
+					if (this.virtualselectOpts.multiple) valuesToSelect = optionsToSelect.map((option) => option.value);
+					else valuesToSelect = [optionsToSelect[0].value];
+				}
 
-			if (valuesToSelect.sort().join(' ') !== selectedValues.sort().join(' '))
-				this.virtualselectConfigs.setValue(valuesToSelect, silentOnChangedEvent);
+				if (valuesToSelect.sort().join(' ') !== selectedValues.sort().join(' '))
+					this.virtualselectConfigs.setValue(valuesToSelect, silentOnChangedEvent);
+			});
 		}
 
 		/**


### PR DESCRIPTION
This PR is for fixing an issue on Dropdown Search/Tags when using popup mode and preselected values make the focus go to the dropdown when entering the screen.

### What was happening
- When using popup mode and preselected values make the focus go to the dropdown when entering the screen;
- When fill other dropdowns based on data that is fetch only on demand, the dropdown are not filled.

### What was done
- On `setValues()` method are asynchronous to wait for fetching data when the API is called inside on **OnAfterFecth**;
- Fixed an issue on provider **VirtualSelect** to prevent the focus on element when has preselected values

### Test Steps

1. Open Sample page
2. Search for "**lou**" or "**john**"
3. Click "Fetch"
4. **Expected:** The other dropdowns will be filled with preselected data and the the focus are the last element clicked

### Screenshots
![2024-02-06 16 13 07](https://github.com/OutSystems/outsystems-ui/assets/25321845/f7a4c306-83b9-45f2-8927-a218551b494c)

### Checklist

-   [X] tested locally
-   [X] documented the code
-   [X] clean all warnings and errors of eslint
-   [ ] requires changes in OutSystems (if so, provide a module with changes)
-   [ ] requires new sample page in OutSystems (if so, provide a module with changes)
