### PR TITLE
ROU-4771: Remove css for popover widget related to position

### DIFF
--- a/gulp/ProjectSpecs/ScssStructure/Widgets.js
+++ b/gulp/ProjectSpecs/ScssStructure/Widgets.js
@@ -1,3 +1,5 @@
+const project = require('../DefaultSpecs');
+
 /* 
 * Section Info
 **/
@@ -61,6 +63,11 @@ const sectionInfo = {
         {
             "name": "Popover",
             "path": "03-widgets/popover"
+        },
+        {
+            "name": "Popover - ODC",
+            "path": "03-widgets/popover-odc",
+            "platform": project.globalConsts.platformTarget.odc,
         },
         {
             "name": "Popup",

--- a/gulp/Tasks/CreateScss/GetPartialsList.js
+++ b/gulp/Tasks/CreateScss/GetPartialsList.js
@@ -71,15 +71,19 @@ function createPartialsList(env, platformType) {
 
             // 1. Go through each section assets
             for (const asset of sectionInfo.assets) {
-                // Check if Asset is also present at the SectionIndex
-                if (sectionInfo.addToSectionIndex && sectionInfo.assets.length > 1 && asset.name !== '') {
-                    // Create a asset SubComment
-                    partialsListText += createSectionCommentTitle(`${sectionIndex}.${assetIndex}. ${asset.name}`, 2);
-                }
+                if(asset.platform !== undefined && asset.platform !== platformType) {
+                    continue
+                } else {
+                    // Check if Asset is also present at the SectionIndex
+                    if (sectionInfo.addToSectionIndex && sectionInfo.assets.length > 1 && asset.name !== '') {
+                        // Create a asset SubComment
+                        partialsListText += createSectionCommentTitle(`${sectionIndex}.${assetIndex}. ${asset.name}`, 2);
+                    }
 
-                // Check if the current assest do not have other assets assigned (Patterns case)
-                if (asset.path !== undefined) {
-                    partialsListText += getImportLineText(asset.path);
+                    // Check if the current asset do not have other assets assigned (Patterns case)
+                    if (asset.path !== undefined) {
+                        partialsListText += getImportLineText(asset.path);
+                    }
                 }
 
                 // Check if the current Asset also contains it's own Assets (Ex: Patterns case)

--- a/gulp/Tasks/CreateScss/SectionIndex.js
+++ b/gulp/Tasks/CreateScss/SectionIndex.js
@@ -71,8 +71,11 @@ function createIndexSection(env, platformType) {
 
                 // 1. Go through each section assets
                 for (const asset of sectionInfo.assets) {
+                    if(asset.platform !== undefined && asset.platform !== platformType) {
+                        continue;
+                    } 
                     // Check if Asset is also present at the SectionIndex
-                    if (sectionInfo.addToSectionIndex && sectionInfo.assets.length > 1 && asset.name !== '') {
+                    else if (sectionInfo.addToSectionIndex && sectionInfo.assets.length > 1 && asset.name !== '') {
                         // Create a asset SubComment
                         indexSection += getLineText(`${sectionIndex}.${assetIndex}. ${asset.name}`, 1);
                     }

--- a/src/scss/03-widgets/_popover-odc.scss
+++ b/src/scss/03-widgets/_popover-odc.scss
@@ -1,0 +1,15 @@
+/* Widgets - Popover */
+////
+/// @group Widgets-Popover
+/// Widgets - Popover
+
+// IsRTL -------------------------------------------------------------------------
+///
+.is-rtl {
+	// This is a temporary fix for popover in ODC, until the platform merge the O11 popover fix into ODC
+	[data-popover] > .popover-bottom {
+		margin-left: initial;
+		margin-right: -50%;
+		transform: translateX(50%) translateY(-100%) !important; // We using the !important to override the platform inline style on popover
+	}
+}

--- a/src/scss/03-widgets/_popover-odc.scss
+++ b/src/scss/03-widgets/_popover-odc.scss
@@ -1,15 +1,23 @@
 /* Widgets - Popover */
 ////
 /// @group Widgets-Popover
-/// Widgets - Popover
+/// Widgets - Popover (This is a temporary fix for popover in ODC, until the platform merge the O11 popover fix into ODC)
+
+///
+[data-popover] > .popover-bottom.align-bottom.align-center {
+	transform: translateX(-50%) translateY(-100%);
+}
 
 // IsRTL -------------------------------------------------------------------------
 ///
 .is-rtl {
-	// This is a temporary fix for popover in ODC, until the platform merge the O11 popover fix into ODC
-	[data-popover] > .popover-bottom {
+	[data-popover] > .popover-bottom.align-center {
 		margin-left: initial;
 		margin-right: -50%;
-		transform: translateX(50%) translateY(-100%) !important; // We using the !important to override the platform inline style on popover
+		transform: translateX(50%);
+
+		&.align-bottom {
+			transform: translateX(50%) translateY(-100%);
+		}
 	}
 }

--- a/src/scss/03-widgets/_popover.scss
+++ b/src/scss/03-widgets/_popover.scss
@@ -37,12 +37,6 @@
 			&-top {
 				display: inline;
 			}
-
-			&-bottom {
-				margin-left: initial;
-				margin-right: -50%;
-				transform: translateX(50%) translateY(-100%) !important; // We using the !important to override the platform inline style on popover
-			}
 		}
 	}
 }

--- a/src/scss/ODC.OutSystemsUI.scss
+++ b/src/scss/ODC.OutSystemsUI.scss
@@ -62,9 +62,10 @@ Section Index:
     4.12. Upload
     4.13. Button Group
     4.14. Popover
-    4.15. Popup
-    4.16. Feedback Message
-    4.17. Radio Button
+    4.15. Popover - ODC
+    4.16. Popup
+    4.17. Feedback Message
+    4.18. Radio Button
 5. Providers
     5.1. Flatpickr
     5.2. NoUiSlider
@@ -302,11 +303,13 @@ Functions & Mixins
 @import '03-widgets/button-group';
 /*! 4.14. Popover */
 @import '03-widgets/popover';
-/*! 4.15. Popup */
+/*! 4.15. Popover - ODC */
+@import '03-widgets/popover-odc';
+/*! 4.16. Popup */
 @import '03-widgets/popup';
-/*! 4.16. Feedback Message */
+/*! 4.17. Feedback Message */
 @import '03-widgets/feedback-message';
-/*! 4.17. Radio Button */
+/*! 4.18. Radio Button */
 @import '03-widgets/radio-button';
 
 /*! ==============================================================================


### PR DESCRIPTION
This PR is for fixing the Popover widget position when is used with RTL enabled

### What was happening
- Due to the new improvements made on Popover widget calculations on platform side, the CSS created form Popover under the OutSystems UI, apply the wrong position of widget.
![image](https://github.com/OutSystems/outsystems-ui/assets/25321845/81ff6e74-dc02-4bec-8c32-4280f145f4d0)

### What was done
- Remove css for popover widget related to position

### Test Steps
1. Open Sample Page
2. Enable the RTL
3. Select the Widgets on Category Patterns dropdown
4. Scroll down the page and Open the Popover
Expected: The Popover will open and will be placed properly

### Screenshots
![image](https://github.com/OutSystems/outsystems-ui/assets/25321845/96ccc00b-4162-43f1-924b-db3e5e0893e2)

### Checklist
-   [X] tested locally
-   [X] documented the code
-   [X] clean all warnings and errors of eslint
-   [ ] requires changes in OutSystems (if so, provide a module with changes)
-   [ ] requires new sample page in OutSystems (if so, provide a module with changes)
