### PR TITLE
ROU-4723: closing timePicker on scroll

### DIFF
--- a/src/scripts/Providers/OSUI/SharedProviderResources/Flatpickr/UpdatePositionOnScroll.ts
+++ b/src/scripts/Providers/OSUI/SharedProviderResources/Flatpickr/UpdatePositionOnScroll.ts
@@ -50,12 +50,13 @@ namespace Providers.OSUI.SharedProviderResources.Flatpickr {
 						this._isTimePicker ||
 						document.activeElement.closest(
 							`${OSFramework.OSUI.Constants.Dot}${Enum.CssClasses.CalendarContainer}`
-						) !== this._picker.provider.calendarContainer
+						) === this._picker.provider.calendarContainer
 					) {
-						this._picker.provider.close();
-					} else {
-						// calendar can't close => trigger provider update position method
+						// Prevents the calendar from closing and updates its position to stay in view.
 						this._picker.provider._positionCalendar();
+					} else {
+						// Closes the calendar if the active element is outside the calendar container.
+						this._picker.provider.close();
 					}
 				}
 

--- a/src/scripts/Providers/OSUI/SharedProviderResources/Flatpickr/UpdatePositionOnScroll.ts
+++ b/src/scripts/Providers/OSUI/SharedProviderResources/Flatpickr/UpdatePositionOnScroll.ts
@@ -34,17 +34,14 @@ namespace Providers.OSUI.SharedProviderResources.Flatpickr {
 			if (this._picker.isBuilt) {
 				// Check if IsPhone
 				if (this._picker.provider.isOpen && OSFramework.OSUI.Helper.DeviceInfo.IsPhone) {
-					//
 					/**
-					 * Check if the picker is a timepicker, if so, the picker will be closed.
-					 * - There this need (to check if the active element is not a child of the calendar) due the way
-					 * we've now the active-screen and content containers, since once at native mobile apps both of this
-					 * containers will have the overflow-y as auto, with ends on the ability to scroll the content even when
-					 * at the content (native apps) is the one blocked for the picker if it's open... When scroll occurs on top
-					 * of picker the entire screen (header included) will do have scroll. This approach will make calendar
-					 * update it's position accordingly.
+					 * This condition checks if the active element is not a child of the calendar container. This is necessary due to the design of
+					 * active-screen and content containers in both web and native mobile app environments, where `overflow-y` is set to `auto`. This setting
+					 * allows content to be scrollable even when a picker is open in native apps, which could lead to unintended scrolling of the entire screen,
+					 * including the header, when interacting with the picker. To prevent this, the calendar's position is updated to remain in view during scroll events.
 					 *
-					 * Also if not a timepicker, then will check if active element is a child of the calendar container
+					 * However, this behavior is excluded for the timepicker. When the timepicker is triggered (e.g., by focusing on an input field), the appearance
+					 * of the keyboard may cause the page to scroll. In this scenario, we avoid closing the timepicker to maintain user interaction continuity.
 					 */
 					if (
 						this._isTimePicker ||

--- a/src/scripts/Providers/OSUI/SharedProviderResources/Flatpickr/UpdatePositionOnScroll.ts
+++ b/src/scripts/Providers/OSUI/SharedProviderResources/Flatpickr/UpdatePositionOnScroll.ts
@@ -34,8 +34,18 @@ namespace Providers.OSUI.SharedProviderResources.Flatpickr {
 			if (this._picker.isBuilt) {
 				// Check if IsPhone
 				if (this._picker.provider.isOpen && OSFramework.OSUI.Helper.DeviceInfo.IsPhone) {
-					// Check if the picker is a timepicker, if so, the picker will be closed.
-					// If not a timepicker, then will check if active element is a child of the calendar container
+					//
+					/**
+					 * Check if the picker is a timepicker, if so, the picker will be closed.
+					 * - There this need (to check if the active element is not a child of the calendar) due the way
+					 * we've now the active-screen and content containers, since once at native mobile apps both of this
+					 * containers will have the overflow-y as auto, with ends on the ability to scroll the content even when
+					 * at the content (native apps) is the one blocked for the picker if it's open... When scroll occurs on top
+					 * of picker the entire screen (header included) will do have scroll. This approach will make calendar
+					 * update it's position accordingly.
+					 *
+					 * Also if not a timepicker, then will check if active element is a child of the calendar container
+					 */
 					if (
 						this._isTimePicker ||
 						document.activeElement.closest(

--- a/src/scripts/Providers/OSUI/SharedProviderResources/Flatpickr/UpdatePositionOnScroll.ts
+++ b/src/scripts/Providers/OSUI/SharedProviderResources/Flatpickr/UpdatePositionOnScroll.ts
@@ -35,13 +35,18 @@ namespace Providers.OSUI.SharedProviderResources.Flatpickr {
 				// Check if IsPhone
 				if (this._picker.provider.isOpen && OSFramework.OSUI.Helper.DeviceInfo.IsPhone) {
 					/**
-					 * This condition checks if the active element is not a child of the calendar container. This is necessary due to the design of
-					 * active-screen and content containers in both web and native mobile app environments, where `overflow-y` is set to `auto`. This setting
-					 * allows content to be scrollable even when a picker is open in native apps, which could lead to unintended scrolling of the entire screen,
-					 * including the header, when interacting with the picker. To prevent this, the calendar's position is updated to remain in view during scroll events.
+					 * This condition checks if the active element is not a child of the calendar container.
+					 * This is necessary due to the design of active-screen and content containers in both web
+					 * and native mobile app environments, where `overflow-y` is set to `auto`. This setting
+					 * allows content to be scrollable even when a picker is open in native apps, which could
+					 * lead to unintended scrolling of the entire screen, including the header, when interacting
+					 * with the picker. To prevent this, the calendar's position is updated to remain in view
+					 * during scroll events.
 					 *
-					 * However, this behavior is excluded for the timepicker. When the timepicker is triggered (e.g., by focusing on an input field), the appearance
-					 * of the keyboard may cause the page to scroll. In this scenario, we avoid closing the timepicker to maintain user interaction continuity.
+					 * However, this behavior is excluded for the timepicker. When the timepicker is triggered
+					 * (e.g., by focusing on an input field), the appearance of the keyboard may cause the page
+					 * to scroll. In this scenario, we avoid closing the timepicker to maintain user interaction
+					 * continuity.
 					 */
 					if (
 						this._isTimePicker ||

--- a/src/scripts/Providers/OSUI/SharedProviderResources/Flatpickr/UpdatePositionOnScroll.ts
+++ b/src/scripts/Providers/OSUI/SharedProviderResources/Flatpickr/UpdatePositionOnScroll.ts
@@ -1,6 +1,8 @@
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 namespace Providers.OSUI.SharedProviderResources.Flatpickr {
 	export class UpdatePositionOnScroll {
+		// Indicates wether the picker is a time picker or other type of picker (Month, Date, DateTime).
+		private _isTimePicker: boolean;
 		// Event OnScreenScroll
 		private _onScreenScrollEvent: OSFramework.OSUI.GlobalCallbacks.Generic;
 		// Store the picker instance
@@ -19,6 +21,8 @@ namespace Providers.OSUI.SharedProviderResources.Flatpickr {
 		) {
 			// Set picker object
 			this._picker = picker;
+			// Set if the picker is a time picker
+			this._isTimePicker = this._picker instanceof TimePicker.Flatpickr.OSUIFlatpickrTime;
 			// Set onBodyScrollEvent callback
 			this._setCallbacks();
 			// Set the Events

--- a/src/scripts/Providers/OSUI/SharedProviderResources/Flatpickr/UpdatePositionOnScroll.ts
+++ b/src/scripts/Providers/OSUI/SharedProviderResources/Flatpickr/UpdatePositionOnScroll.ts
@@ -34,16 +34,18 @@ namespace Providers.OSUI.SharedProviderResources.Flatpickr {
 			if (this._picker.isBuilt) {
 				// Check if IsPhone
 				if (this._picker.provider.isOpen && OSFramework.OSUI.Helper.DeviceInfo.IsPhone) {
-					// Check if the active element is a child of the calendar container
+					// Check if the picker is a timepicker, if so, the picker will be closed.
+					// If not a timepicker, then will check if active element is a child of the calendar container
 					if (
+						this._isTimePicker ||
 						document.activeElement.closest(
 							`${OSFramework.OSUI.Constants.Dot}${Enum.CssClasses.CalendarContainer}`
-						) === this._picker.provider.calendarContainer
+						) !== this._picker.provider.calendarContainer
 					) {
+						this._picker.provider.close();
+					} else {
 						// calendar can't close => trigger provider update position method
 						this._picker.provider._positionCalendar();
-					} else {
-						this._picker.provider.close();
 					}
 				}
 


### PR DESCRIPTION
This PR is for ~adjusting the scroll behavior so that the time picker, behaves like the other pickers.~ improving the comments and the code.

### What was happening
- When scrolling from the input that associated with the time picker, the time picker would not close (unlike the other pickers);
- The reason was, that the time picker has an input that gets focused, once it's open. This made the activeElement to be different from the element where the picker was instantiate;

### What was done
- ~Added a private attribute, `_isTimePicker`, to the class `UpdatePositionOnScroll`~
- ~On the callback of the scroll, now checking for that attribute, in case it's true (meaning it the timepicker, the code will not check if the scroll starting element is the same as where the picker is instantiated.~
- The behavior for the timepicker was kept, since when the input is focused, a scroll can occur in the page do to the repositioning of the element because of the keyboard.
- Improved the comments and explanation with the help of @joselrio

### Test Steps
1. Open the time picker
2. Scroll on the page, while starting on top of the input of the time picker
3. The time picker should **not** close, when the scroll is started

### Checklist
-   [x] tested locally
-   [x] documented the code
-   [x] clean all warnings and errors of eslint
-   [ ] requires changes in OutSystems (if so, provide a module with changes)
-   [ ] requires new sample page in OutSystems (if so, provide a module with changes)
