### PR TITLE
[ROU-4791]: Rating - Remove display property to fix a11y issue at NVDA.

### DIFF
--- a/src/scripts/OSFramework/OSUI/Pattern/Rating/scss/_rating.scss
+++ b/src/scripts/OSFramework/OSUI/Pattern/Rating/scss/_rating.scss
@@ -108,16 +108,17 @@
 		&:first-of-type {
 			+ .rating-item {
 				background: transparent;
-				display: none;
+				box-shadow: 0 0 0 3px var(--color-focus-outer);
 				height: 100%;
 				left: 0;
+				opacity: 0;
+				pointer-events: none;
 				position: absolute;
 				top: 0;
 				width: 100%;
-				box-shadow: 0 0 0 3px var(--color-focus-outer);
 			}
 			&:focus:checked + .rating-item {
-				display: block;
+				opacity: 1;
 			}
 		}
 


### PR DESCRIPTION
This PR will fix an a11y issue when at NVDA for Rating pattern once it was using display property that it will also hide the element for the screen reader as well. This change will use opacity instead.