### PR TITLE
ROU-4772: Review the console.warn when changing components with starting parameters

### DIFF
--- a/src/scripts/Providers/OSUI/RangeSlider/NoUISlider/SliderInterval/NoUiSliderInterval.ts
+++ b/src/scripts/Providers/OSUI/RangeSlider/NoUISlider/SliderInterval/NoUiSliderInterval.ts
@@ -114,15 +114,9 @@ namespace Providers.OSUI.RangeSlider.NoUISlider.IntervalSlider {
 				switch (propertyName) {
 					case OSFramework.OSUI.Patterns.RangeSlider.Enum.Properties.StartingValueFrom:
 						this.setValue(propertyValue as number, this.configs.StartingValueTo);
-						console.warn(
-							`${OSFramework.OSUI.GlobalEnum.PatternName.RangeSliderInterval}: (${this.widgetId}): You should use a distinct variable to assign on the OnValueChange event. Any updates to ${OSFramework.OSUI.Patterns.RangeSlider.Enum.Properties.InitialValueFrom} parameter should ideally be made using the SetRangeSliderIntervalValue Client Action.`
-						);
 						break;
 					case OSFramework.OSUI.Patterns.RangeSlider.Enum.Properties.StartingValueTo:
 						this.setValue(this.configs.StartingValueFrom, propertyValue as number);
-						console.warn(
-							`${OSFramework.OSUI.GlobalEnum.PatternName.RangeSliderInterval}: (${this.widgetId}): You should use a distinct variable to assign on the OnValueChange event. Any updates to ${OSFramework.OSUI.Patterns.RangeSlider.Enum.Properties.InitialValueTo} parameter should ideally be made using the SetRangeSliderIntervalValue Client Action.`
-						);
 						break;
 					case OSFramework.OSUI.Patterns.RangeSlider.Enum.Properties.ShowTickMarks:
 						// Library only supports update on some options, so we need to

--- a/src/scripts/Providers/OSUI/RangeSlider/NoUISlider/SliderSingle/NoUiSliderSingle.ts
+++ b/src/scripts/Providers/OSUI/RangeSlider/NoUISlider/SliderSingle/NoUiSliderSingle.ts
@@ -107,9 +107,6 @@ namespace Providers.OSUI.RangeSlider.NoUISlider.SingleSlider {
 				switch (propertyName) {
 					case OSFramework.OSUI.Patterns.RangeSlider.Enum.Properties.StartingValueFrom:
 						this.setValue(propertyValue as number);
-						console.warn(
-							`${OSFramework.OSUI.GlobalEnum.PatternName.RangeSlider}: (${this.widgetId}): You should use a distinct variable to assign on the OnValueChange event. Any updates to ${OSFramework.OSUI.Patterns.RangeSlider.Enum.Properties.InitialValueFrom} parameter should ideally be made using the SetRangeSliderValue Client Action.`
-						);
 						break;
 					case OSFramework.OSUI.Patterns.RangeSlider.Enum.Properties.ShowTickMarks:
 						// Library only supports update on some options, so we need to


### PR DESCRIPTION
This PR is for removing the `console.warn` from RangeSlider when a starting value is updated.

### What was happening
- When a StartingValue is updated on RangeSlider or RangeSliderInterval, a `console.warn` is raised;
![2024-02-23 15 25 20](https://github.com/OutSystems/outsystems-ui/assets/25321845/d1f51956-8342-4fc6-96e0-01de14ef6589)

### What was done
- Removed the `console.warn` from RangeSlider when a starting value is updated
![2024-02-23 15 27 00](https://github.com/OutSystems/outsystems-ui/assets/25321845/7ef6db21-665c-4f0e-a2fd-109f2e4facf7)

### Test Steps
1. Open sample page
2. Click on Apply New Starting Value buttons
3. **Expected:** The RangeSlider will be updated and no `console.warn` is raised.

### Screenshots
![2024-02-23 15 27 00](https://github.com/OutSystems/outsystems-ui/assets/25321845/1e8135f2-d274-4d87-a176-8234bec106f8)

### Checklist
-   [X] tested locally
-   [X] documented the code
-   [X] clean all warnings and errors of eslint
-   [ ] requires changes in OutSystems (if so, provide a module with changes)
-   [ ] requires new sample page in OutSystems (if so, provide a module with changes)
