### PR TITLE
[ROU-4795]: Rating - Add Disable/Enable API methods.

### DIFF
--- a/src/scripts/OSFramework/OSUI/Pattern/Rating/IRating.ts
+++ b/src/scripts/OSFramework/OSUI/Pattern/Rating/IRating.ts
@@ -7,5 +7,19 @@ namespace OSFramework.OSUI.Patterns.Rating {
 	 * @interface IRating
 	 * @extends {Interface.IPattern}
 	 */
-	export interface IRating extends Interface.IPattern {}
+	export interface IRating extends Interface.IPattern {
+		/**
+		 * Method that will set Rating as disabled
+		 *
+		 * @memberof IRating
+		 */
+		disable(): void;
+
+		/**
+		 * Method that will set Rating as enabled
+		 *
+		 * @memberof IRating
+		 */
+		enable(): void;
+	}
 }

--- a/src/scripts/OSFramework/OSUI/Pattern/Rating/Rating.ts
+++ b/src/scripts/OSFramework/OSUI/Pattern/Rating/Rating.ts
@@ -171,11 +171,11 @@ namespace OSFramework.OSUI.Patterns.Rating {
 			const ratingInputId: string = this.uniqueId + '-rating-' + index;
 
 			// Create input and label html
-			const input = `<input type="${GlobalEnum.HTMLElement.Radio}" class="${Enum.CssClass.RatingInput} ${Enum.CssClass.WCAGHideText}" id=${ratingInputId} name=${this._ratingInputName} value=${index} aria-hidden="${Constants.A11YAttributes.States.True}">`;
+			const input = `<input type="${GlobalEnum.HTMLElement.Radio}" class="${Enum.CssClass.RatingInput} ${Enum.CssClass.WCAGHideText}" id=${ratingInputId} name=${this._ratingInputName} value=${index}>`;
 
 			let label = '';
 			if (!this.configs.IsEdit) {
-				label = `<label class='${Enum.CssClass.RatingItem}' for=${ratingInputId} aria-hidden="${Constants.A11YAttributes.States.True}"><span class="${Enum.CssClass.WCAGHideText}">Rating ${index}</span>${labelHTML}</label>`;
+				label = `<label class='${Enum.CssClass.RatingItem}' for=${ratingInputId}><span class="${Enum.CssClass.WCAGHideText}">Rating ${index}</span>${labelHTML}</label>`;
 			} else {
 				label = `<label class='${Enum.CssClass.RatingItem}' for=${ratingInputId}><span class="${Enum.CssClass.WCAGHideText}">Rating ${index}</span>${labelHTML}</label>`;
 			}
@@ -282,21 +282,11 @@ namespace OSFramework.OSUI.Patterns.Rating {
 		 * @memberof Rating
 		 */
 		private _setIsEdit(): void {
-			const LabelList = this.selfElement.querySelectorAll(Constants.Dot + Enum.CssClass.RatingItem);
-
 			// Toggle the is-edit class
 			if (this.configs.IsEdit) {
 				Helper.Dom.Styles.AddClass(this.selfElement, Enum.CssClass.IsEdit);
-
-				LabelList.forEach((label) => {
-					label.removeAttribute(Constants.A11YAttributes.Aria.Hidden);
-				});
 			} else {
 				Helper.Dom.Styles.RemoveClass(this.selfElement, Enum.CssClass.IsEdit);
-
-				LabelList.forEach((label) => {
-					label.ariaHidden = Constants.A11YAttributes.States.True;
-				});
 			}
 
 			// Review if there's a need to add/remove the click event, accordingly to the IsEdit value

--- a/src/scripts/OSFramework/OSUI/Pattern/Rating/Rating.ts
+++ b/src/scripts/OSFramework/OSUI/Pattern/Rating/Rating.ts
@@ -267,6 +267,12 @@ namespace OSFramework.OSUI.Patterns.Rating {
 		private _setIsDisabled(isDisabled: boolean): void {
 			this._disabled = isDisabled;
 			this._setFieldsetDisabledStatus(isDisabled);
+
+			if (isDisabled) {
+				this._unsetEvents();
+			} else {
+				this._setEvents();
+			}
 		}
 
 		/**
@@ -447,12 +453,12 @@ namespace OSFramework.OSUI.Patterns.Rating {
 		 * @memberof Rating
 		 */
 		private _unsetEvents(): void {
-			if (this.selfElement && this.configs.IsEdit === false) {
+			if ((this.selfElement && this.configs.IsEdit === false) || this._disabled) {
 				this.selfElement.removeEventListener(GlobalEnum.HTMLEvent.Click, this._eventOnRatingClick);
 			}
 
 			// Manage RatingInput elements events accordingly
-			this._toggleRatingInputsEvents(!this.configs.IsEdit);
+			this._toggleRatingInputsEvents(!this.configs.IsEdit && !this._disabled);
 		}
 
 		/**

--- a/src/scripts/OSFramework/OSUI/Pattern/Rating/Rating.ts
+++ b/src/scripts/OSFramework/OSUI/Pattern/Rating/Rating.ts
@@ -12,6 +12,8 @@ namespace OSFramework.OSUI.Patterns.Rating {
 		private _disabled: boolean;
 		// Store the click event with bind(this)
 		private _eventOnRatingClick: GlobalCallbacks.Generic;
+		// Store the keyup event
+		private _eventOnRatingInputKeyup: GlobalCallbacks.Generic;
 		// Store if the rating value is half
 		private _isHalfValue: boolean;
 		// Store the callback to be used on the OnSelect event
@@ -106,24 +108,25 @@ namespace OSFramework.OSUI.Patterns.Rating {
 		}
 
 		/**
-		 * Method to manage the click event
+		 * Method used to set the keyboard keydown event
 		 *
 		 * @private
+		 * @param {KeyboardEvent} e event
 		 * @memberof Rating
 		 */
-		private _manageRatingEvent(): void {
-			// Check if a event was already added
-			if (this._ratingHasEventAdded) {
-				// If true, remove event
-				this.selfElement.removeEventListener(GlobalEnum.HTMLEvent.Click, this._eventOnRatingClick);
-
-				// And set variable as false
-				this._ratingHasEventAdded = false;
-			} else if (this.configs.IsEdit) {
-				// Otherwise, if there is no event already added and the param IsEdit is true, add new event
-				this.selfElement.addEventListener(GlobalEnum.HTMLEvent.Click, this._eventOnRatingClick);
-				// And set variable as true
-				this._ratingHasEventAdded = true;
+		private _ratingInputOnKeyup(e: KeyboardEvent): void {
+			// Ensure keys pressed are arrows
+			if (
+				e.key === GlobalEnum.Keycodes.ArrowUp ||
+				e.key === GlobalEnum.Keycodes.ArrowRight ||
+				e.key === GlobalEnum.Keycodes.ArrowDown ||
+				e.key === GlobalEnum.Keycodes.ArrowLeft
+			) {
+				/* Block the default borwser behaviour!
+					- This is needed in order to avoid let user be able to select a star when IsEdit=False,
+				by default and since pattern will not be disabled, arrow keys are used to navigate through a 
+				group of checkbox elements, on this case we must block this native behaviour!  */
+				e.preventDefault();
 			}
 		}
 
@@ -155,18 +158,6 @@ namespace OSFramework.OSUI.Patterns.Rating {
 				this._setValue(true);
 			}
 		}
-		/**
-		 * Method to remove the event listeners
-		 *
-		 * @private
-		 * @memberof Rating
-		 */
-		private _removeEvents(): void {
-			// remove event listener if any was added
-			if (this.selfElement && this._ratingHasEventAdded) {
-				this.selfElement.removeEventListener(GlobalEnum.HTMLEvent.Click, this._eventOnRatingClick);
-			}
-		}
 
 		/**
 		 * Method called on createItems() to render the correct HTML structure for each item
@@ -182,9 +173,9 @@ namespace OSFramework.OSUI.Patterns.Rating {
 			const ratingInputId: string = this.uniqueId + '-rating-' + index;
 
 			// Create input and label html
-			const input = `<input type="${GlobalEnum.HTMLElement.Radio}"class="${Enum.CssClass.RatingInput} ${Enum.CssClass.WCAGHideText}" id=${ratingInputId} name=${this._ratingInputName} value=${index} aria-hidden="${Constants.A11YAttributes.States.True}">`;
+			const input = `<input type="${GlobalEnum.HTMLElement.Radio}" class="${Enum.CssClass.RatingInput} ${Enum.CssClass.WCAGHideText}" id=${ratingInputId} name=${this._ratingInputName} value=${index} aria-hidden="${Constants.A11YAttributes.States.True}">`;
 
-			let label;
+			let label = '';
 			if (!this.configs.IsEdit) {
 				label = `<label class='${Enum.CssClass.RatingItem}' for=${ratingInputId} aria-hidden="${Constants.A11YAttributes.States.True}"><span class="${Enum.CssClass.WCAGHideText}">Rating ${index}</span>${labelHTML}</label>`;
 			} else {
@@ -193,6 +184,25 @@ namespace OSFramework.OSUI.Patterns.Rating {
 
 			// Append new input + label to fieldset's html
 			this._ratingFieldsetElem.innerHTML += input + label;
+		}
+
+		/**
+		 * Method that will add the needed events
+		 *
+		 * @private
+		 * @memberof Rating
+		 */
+		private _setEvents(): void {
+			if (this.configs.IsEdit) {
+				// Otherwise, if there is no event already added and the param IsEdit is true, add new event
+				this.selfElement.addEventListener(GlobalEnum.HTMLEvent.Click, this._eventOnRatingClick);
+			}
+
+			// Manage RatingInput elements events accordingly
+			this._toggleRatingInputsEvents(!this.configs.IsEdit);
+
+			// Set events added flag variable
+			this._ratingHasEventAdded = true;
 		}
 
 		/**
@@ -249,7 +259,6 @@ namespace OSFramework.OSUI.Patterns.Rating {
 		 * @memberof Rating
 		 */
 		private _setInitialPropertiesValues(): void {
-			this._disabled = !this.configs.IsEdit;
 			this._ratingInputName = 'rating-' + this.uniqueId;
 			this._ratingHasEventAdded = false;
 		}
@@ -262,9 +271,8 @@ namespace OSFramework.OSUI.Patterns.Rating {
 		 * @memberof Rating
 		 */
 		private _setIsDisabled(isDisabled: boolean): void {
-			this._setFieldsetDisabledStatus(isDisabled);
-
 			this._disabled = isDisabled;
+			this._setFieldsetDisabledStatus(isDisabled);
 		}
 
 		/**
@@ -274,8 +282,6 @@ namespace OSFramework.OSUI.Patterns.Rating {
 		 * @memberof Rating
 		 */
 		private _setIsEdit(): void {
-			// Set the fieldset and input disabled attribute status
-			this._setIsDisabled(!this.configs.IsEdit);
 			const LabelList = this.selfElement.querySelectorAll(Constants.Dot + Enum.CssClass.RatingItem);
 
 			// Toggle the is-edit class
@@ -294,7 +300,11 @@ namespace OSFramework.OSUI.Patterns.Rating {
 			}
 
 			// Review if there's a need to add/remove the click event, accordingly to the IsEdit value
-			this._manageRatingEvent();
+			if (this._ratingHasEventAdded) {
+				this._unsetEvents();
+			} else {
+				this._setEvents();
+			}
 		}
 
 		/**
@@ -402,6 +412,28 @@ namespace OSFramework.OSUI.Patterns.Rating {
 		}
 
 		/**
+		 * Method used to manage the Rating inputs events, they will be only set when IsEdit=False
+		 * - This is needed in order to grant keyboard behaves like ckick, in order to avoid user be able
+		 * to select any star by using keyboard navigation when IsEdit=False!
+		 *
+		 * @private
+		 * @param {boolean} add Flag to indicates if events should be added or removed.
+		 * @memberof Rating
+		 */
+		private _toggleRatingInputsEvents(add: boolean): void {
+			// Get the list of inputs
+			const inputsList = this.selfElement.querySelectorAll(Constants.Dot + Enum.CssClass.RatingInput);
+
+			for (const input of inputsList) {
+				if (add) {
+					input.addEventListener(GlobalEnum.HTMLEvent.keyDown, this._eventOnRatingInputKeyup);
+				} else {
+					input.removeEventListener(GlobalEnum.HTMLEvent.keyDown, this._eventOnRatingInputKeyup);
+				}
+			}
+		}
+
+		/**
 		 * Method that triggers the OnSelect event
 		 *
 		 * @private
@@ -412,6 +444,24 @@ namespace OSFramework.OSUI.Patterns.Rating {
 			if (this._platformEventOnSelect !== undefined) {
 				this.triggerPlatformEventCallback(this._platformEventOnSelect, value);
 			}
+		}
+
+		/**
+		 * Method to remove the event listeners
+		 *
+		 * @private
+		 * @memberof Rating
+		 */
+		private _unsetEvents(): void {
+			if (this.selfElement) {
+				this.selfElement.removeEventListener(GlobalEnum.HTMLEvent.Click, this._eventOnRatingClick);
+			}
+
+			// Manage RatingInput elements events accordingly
+			this._toggleRatingInputsEvents(!this.configs.IsEdit);
+
+			// Set events added flag variable
+			this._ratingHasEventAdded = false;
 		}
 
 		/**
@@ -432,6 +482,7 @@ namespace OSFramework.OSUI.Patterns.Rating {
 		 */
 		protected setCallbacks(): void {
 			this._eventOnRatingClick = this._ratingOnClick.bind(this);
+			this._eventOnRatingInputKeyup = this._ratingInputOnKeyup.bind(this);
 		}
 
 		/**
@@ -453,6 +504,7 @@ namespace OSFramework.OSUI.Patterns.Rating {
 		 */
 		protected unsetCallbacks(): void {
 			this._eventOnRatingClick = undefined;
+			this._eventOnRatingInputKeyup = undefined;
 		}
 
 		/**
@@ -487,11 +539,9 @@ namespace OSFramework.OSUI.Patterns.Rating {
 
 			this._handlePlaceholders();
 
-			this._setFieldsetDisabledStatus(!this.configs.IsEdit);
-
 			this._createItems();
 
-			this._manageRatingEvent();
+			this._setEvents();
 
 			this._setValue();
 
@@ -534,17 +584,35 @@ namespace OSFramework.OSUI.Patterns.Rating {
 		}
 
 		/**
+		 * Method to set the Rating as disabled
+		 *
+		 * @memberof Rating
+		 */
+		public disable(): void {
+			this._setIsDisabled(true);
+		}
+
+		/**
 		 * Method to destroy the Rating pattern
 		 *
 		 * @memberof OSFramework.Patterns.Rating.Rating
 		 */
 		public dispose(): void {
-			this._removeEvents();
+			this._unsetEvents();
 
 			this.unsetCallbacks();
 			this.unsetHtmlElements();
 
 			super.dispose();
+		}
+
+		/**
+		 * Method to set the Rating as enabled
+		 *
+		 * @memberof Rating
+		 */
+		public enable(): void {
+			this._setIsDisabled(false);
 		}
 
 		/**

--- a/src/scripts/OSFramework/OSUI/Pattern/Rating/Rating.ts
+++ b/src/scripts/OSFramework/OSUI/Pattern/Rating/Rating.ts
@@ -20,8 +20,6 @@ namespace OSFramework.OSUI.Patterns.Rating {
 		private _platformEventOnSelect: GlobalCallbacks.OSGeneric;
 		// Store the fieldset html element
 		private _ratingFieldsetElem: HTMLElement;
-		// Store if the rating already has an event added
-		private _ratingHasEventAdded: boolean;
 		// Store the rating icons html element
 		private _ratingIconStatesElem: HTMLElement;
 		// Store the input name to be used on clones
@@ -200,9 +198,6 @@ namespace OSFramework.OSUI.Patterns.Rating {
 
 			// Manage RatingInput elements events accordingly
 			this._toggleRatingInputsEvents(!this.configs.IsEdit);
-
-			// Set events added flag variable
-			this._ratingHasEventAdded = true;
 		}
 
 		/**
@@ -260,7 +255,6 @@ namespace OSFramework.OSUI.Patterns.Rating {
 		 */
 		private _setInitialPropertiesValues(): void {
 			this._ratingInputName = 'rating-' + this.uniqueId;
-			this._ratingHasEventAdded = false;
 		}
 
 		/**
@@ -300,10 +294,10 @@ namespace OSFramework.OSUI.Patterns.Rating {
 			}
 
 			// Review if there's a need to add/remove the click event, accordingly to the IsEdit value
-			if (this._ratingHasEventAdded) {
-				this._unsetEvents();
-			} else {
+			if (this.configs.IsEdit) {
 				this._setEvents();
+			} else {
+				this._unsetEvents();
 			}
 		}
 
@@ -453,15 +447,12 @@ namespace OSFramework.OSUI.Patterns.Rating {
 		 * @memberof Rating
 		 */
 		private _unsetEvents(): void {
-			if (this.selfElement) {
+			if (this.selfElement && this.configs.IsEdit === false) {
 				this.selfElement.removeEventListener(GlobalEnum.HTMLEvent.Click, this._eventOnRatingClick);
 			}
 
 			// Manage RatingInput elements events accordingly
 			this._toggleRatingInputsEvents(!this.configs.IsEdit);
-
-			// Set events added flag variable
-			this._ratingHasEventAdded = false;
 		}
 
 		/**

--- a/src/scripts/OSFramework/OSUI/Pattern/Rating/scss/_rating.scss
+++ b/src/scripts/OSFramework/OSUI/Pattern/Rating/scss/_rating.scss
@@ -29,10 +29,14 @@
 	}
 
 	&.is-edit {
-		pointer-events: initial;
-		.rating-item {
-			cursor: pointer;
-			pointer-events: auto;
+		// Ensure edit mode will only be available when fieldset is not disabled
+		&:not(:has(fieldset[disabled='true'])) {
+			pointer-events: initial;
+
+			.rating-item {
+				cursor: pointer;
+				pointer-events: auto;
+			}
 		}
 	}
 

--- a/src/scripts/OutSystems/OSUI/ErrorCodes.ts
+++ b/src/scripts/OutSystems/OSUI/ErrorCodes.ts
@@ -193,6 +193,8 @@ namespace OutSystems.OSUI.ErrorCodes {
 		FailChangeProperty: 'OSUI-API-19001',
 		FailDispose: 'OSUI-API-19002',
 		FailRegisterCallback: 'OSUI-API-19003',
+		FailEnable: 'OSUI-API-19004',
+		FailDisable: 'OSUI-API-19005',
 	};
 
 	export const Search = {

--- a/src/scripts/OutSystems/OSUI/Patterns/RatingAPI.ts
+++ b/src/scripts/OutSystems/OSUI/Patterns/RatingAPI.ts
@@ -52,7 +52,7 @@ namespace OutSystems.OSUI.Patterns.RatingAPI {
 	 */
 	export function Disable(ratingId: string): string {
 		const result = OutSystems.OSUI.Utils.CreateApiResponse({
-			errorCode: ErrorCodes.Rating.FailDispose,
+			errorCode: ErrorCodes.Rating.FailDisable,
 			callback: () => {
 				const rating = GetRatingById(ratingId);
 
@@ -93,7 +93,7 @@ namespace OutSystems.OSUI.Patterns.RatingAPI {
 	 */
 	export function Enable(ratingId: string): string {
 		const result = OutSystems.OSUI.Utils.CreateApiResponse({
-			errorCode: ErrorCodes.Rating.FailDispose,
+			errorCode: ErrorCodes.Rating.FailEnable,
 			callback: () => {
 				const rating = GetRatingById(ratingId);
 

--- a/src/scripts/OutSystems/OSUI/Patterns/RatingAPI.ts
+++ b/src/scripts/OutSystems/OSUI/Patterns/RatingAPI.ts
@@ -45,6 +45,25 @@ namespace OutSystems.OSUI.Patterns.RatingAPI {
 	}
 
 	/**
+	 * Function that will set Rating with given ID as disabled
+	 *
+	 * @export
+	 * @param {string} ratingId
+	 */
+	export function Disable(ratingId: string): string {
+		const result = OutSystems.OSUI.Utils.CreateApiResponse({
+			errorCode: ErrorCodes.Rating.FailDispose,
+			callback: () => {
+				const rating = GetRatingById(ratingId);
+
+				rating.disable();
+			},
+		});
+
+		return result;
+	}
+
+	/**
 	 *
 	 *
 	 * @export
@@ -60,6 +79,25 @@ namespace OutSystems.OSUI.Patterns.RatingAPI {
 				rating.dispose();
 
 				_ratingsMap.delete(ratingId);
+			},
+		});
+
+		return result;
+	}
+
+	/**
+	 * Function that will set Rating with given ID as enabled
+	 *
+	 * @export
+	 * @param {string} ratingId
+	 */
+	export function Enable(ratingId: string): string {
+		const result = OutSystems.OSUI.Utils.CreateApiResponse({
+			errorCode: ErrorCodes.Rating.FailDispose,
+			callback: () => {
+				const rating = GetRatingById(ratingId);
+
+				rating.enable();
 			},
 		});
 


### PR DESCRIPTION
This PR is for adding new Disable/Enable API methods to the Rating.

It will also change the **IsEdit** behaviour since now IsEdit will only be used to set the rating as in edit/reading mode.
Previous IsEdit was being manage disable status, which ends into an a11y issue once when **IsEdit=False** user was not able to focus the rating neither through keyboard navigation or mouse click.

> Before new API methods and IsEdit changed behaviour:
![Rating-IsEditAsEnabled](https://github.com/OutSystems/outsystems-ui/assets/5339917/4894766d-e323-4837-b641-550634422606)

> After changes made:
![Rating-IsEditDisable-Enable](https://github.com/OutSystems/outsystems-ui/assets/5339917/b0270932-03f0-4eb1-9887-af9588ae6a1a)
