### PR TITLE
[ROU-4800]: ScrollableArea - Fix issue that was preventing table gets full width.

### DIFF
--- a/src/scss/10-deprecated/_horizontal-scroll-deprecated.scss
+++ b/src/scss/10-deprecated/_horizontal-scroll-deprecated.scss
@@ -12,7 +12,7 @@
 		-servicestudio-white-space: normal;
 	}
 
-	& > * {
+	& > *:not(table) {
 		display: inline-block;
 		transform: translateZ(0);
 	}


### PR DESCRIPTION
This PR will fix an issue that was preventing table to fit 100% into the container width.

> Before the fix:
![Screen-Recording-2024-03-01-at-1](https://github.com/OutSystems/outsystems-ui/assets/5339917/216830ef-1726-4940-ba53-66d953f0fc2b)

> After the fix:
![Screen-Recording-2024-03-01-at-1 (1)](https://github.com/OutSystems/outsystems-ui/assets/5339917/ef9c1c35-c80f-4177-b2af-16174b0998ad)
