### PR TITLE
ROU-4761 - [OSUI] - Update VirtualSelect library to the latest version v1.0.42

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,6 +67,6 @@
 		"typedoc-plugin-merge-modules": "^4.0.1",
 		"typedoc-umlclass": "^0.7.0",
 		"typescript": "^4.5.0",
-		"virtual-select-plugin": "^1.0.41"
+		"virtual-select-plugin": "^1.0.42"
 	}
 }

--- a/src/scripts/Providers/OSUI/Dropdown/VirtualSelect/AbstractVirtualSelectEnum.ts
+++ b/src/scripts/Providers/OSUI/Dropdown/VirtualSelect/AbstractVirtualSelectEnum.ts
@@ -5,7 +5,7 @@ namespace Providers.OSUI.Dropdown.VirtualSelect.Enum {
 	 */
 	export enum ProviderInfo {
 		Name = 'VirtualSelect',
-		Version = '1.0.41',
+		Version = '1.0.42',
 	}
 
 	/**

--- a/src/scripts/Providers/OSUI/Dropdown/VirtualSelect/README.md
+++ b/src/scripts/Providers/OSUI/Dropdown/VirtualSelect/README.md
@@ -1,3 +1,3 @@
-# VirtualSelect · ![virtualselect version](https://img.shields.io/badge/version-v1.0.41-informational)
+# VirtualSelect · ![virtualselect version](https://img.shields.io/badge/version-v1.0.42-informational)
 
 All info about this Provider <a href="https://sa-si-dev.github.io/virtual-select/#/">here</a>.

--- a/src/scripts/Providers/OSUI/Dropdown/VirtualSelect/scss/_virtualselect_lib.scss
+++ b/src/scripts/Providers/OSUI/Dropdown/VirtualSelect/scss/_virtualselect_lib.scss
@@ -1,5 +1,5 @@
 /*!
- * Virtual Select v1.0.41
+ * Virtual Select v1.0.42
  * https://sa-si-dev.github.io/virtual-select
  * Licensed under MIT (https://github.com/sa-si-dev/virtual-select/blob/master/LICENSE)
  */


### PR DESCRIPTION
This PR is for updating virtual-select version for 1.0.42.

### Checklist

-   [x] tested locally
-   [x] documented the code
-   [x] clean all warnings and errors of eslint
-   [ ] requires changes in OutSystems (if so, provide a module with changes)
-   [ ] requires new sample page in OutSystems (if so, provide a module with changes)
