### PR TITLE
ROU-4807: fix transform property

### DIFF
--- a/src/scss/07-keyframes/_animate.scss
+++ b/src/scss/07-keyframes/_animate.scss
@@ -129,12 +129,12 @@
 @keyframes scaleup {
 	0% {
 		opacity: 0;
-		-webkit-transform: translateX(0) translateY(0) translateZ(0) scale(0);
+		transform: translateX(0) translateY(0) translateZ(0) scale(0);
 	}
 
 	100% {
 		opacity: 1;
-		-webkit-transform: translateX(0) translateY(0) translateZ(0) scale(1);
+		transform: translateX(0) translateY(0) translateZ(0) scale(1);
 	}
 }
 


### PR DESCRIPTION
This PR is for fixing the scss compilation for the scaleup animation.

The issue with the screen-transition scss compilation (transition with multiple properties resulta in 3 transition properties being compiled). From my research and attempts, this seems an issue from scss and was not able to find any workaround. That being said, in runtime it will still work as expected.


### Checklist

-   [x] tested locally
-   [x] documented the code
-   [x] clean all warnings and errors of eslint
-   [ ] requires changes in OutSystems (if so, provide a module with changes)
-   [ ] requires new sample page in OutSystems (if so, provide a module with changes)
