### PR TITLE
ROU-4704: Removed :has() exceptions

### DIFF
--- a/src/scripts/OSFramework/OSUI/Pattern/Dropdown/ServerSide/scss/_dropdown-serverside.scss
+++ b/src/scripts/OSFramework/OSUI/Pattern/Dropdown/ServerSide/scss/_dropdown-serverside.scss
@@ -353,14 +353,6 @@ $balloonMobileTopMargin: 5vh;
 	}
 }
 
-// Fallback for fierfox that don't support yet :has(), but it's already in development
-// https://bugzilla.mozilla.org/show_bug.cgi?id=418039
-.firefox {
-	.osui-dropdown-serverside__balloon-wrapper.osui-dropdown-serverside--is-opened {
-		z-index: var(--layer-global-instant-interaction);
-	}
-}
-
 // Inside Form & Popup
 .form {
 	.osui-dropdown-serverside--is-inside-popup input[data-input] {

--- a/src/scripts/Providers/OSUI/SharedProviderResources/Flatpickr/scss/_flatpickr.scss
+++ b/src/scripts/Providers/OSUI/SharedProviderResources/Flatpickr/scss/_flatpickr.scss
@@ -559,13 +559,6 @@ span.flatpickr-weekday {
 	z-index: var(--osui-flatpickr-layer);
 }
 
-// Exception for firefox support for :has()
-@supports not selector(:has(*)) {
-	.is-rtl .flatpickr-calendar {
-		--osui-flatpickr-layer: calc(var(--osui-menu-layer) + var(--layer-local-tier-1));
-	}
-}
-
 // Accessibility ------------------------------------------------------------------
 // cannot use has-accessible-features class, as the pickder is detached from its context on layout
 .osui-datepicker-calendar {


### PR DESCRIPTION
This PR is for removing the fallbacks for the :has() CSS selector on Firefox, as its fully supported since version 121: https://web.dev/blog/web-platform-12-2023?hl=en#the_has_selector


### Checklist

-   [x] tested locally
-   [x] documented the code
-   [x] clean all warnings and errors of eslint
-   [ ] requires changes in OutSystems (if so, provide a module with changes)
-   [ ] requires new sample page in OutSystems (if so, provide a module with changes)
