### PR TITLE
ROU-4868: [OSUI] Datepicker doesn't show Initial Date, when MinDate is equal to MaxDate.

### DIFF
--- a/src/scripts/OSFramework/OSUI/Helper/Dates.ts
+++ b/src/scripts/OSFramework/OSUI/Helper/Dates.ts
@@ -92,7 +92,7 @@ namespace OSFramework.OSUI.Helper {
 		 * @return {*}  {Date}
 		 * @memberof Dates
 		 */
-		public static NormalizeDateTime(date: string | Date, normalizeToMax = true): Date {
+		public static NormalizeDateTime(date: string | Date, normalizeToMax): Date {
 			let _newDate = date;
 
 			if (typeof _newDate === 'string') {

--- a/src/scripts/Providers/OSUI/Datepicker/Flatpickr/AbstractFlatpickrConfig.ts
+++ b/src/scripts/Providers/OSUI/Datepicker/Flatpickr/AbstractFlatpickrConfig.ts
@@ -164,7 +164,7 @@ namespace Providers.OSUI.Datepicker.Flatpickr {
 		}
 
 		// Method to check the date config passed and set the correct hours, according to date time being used
-		private _validateDate(date: string): Date | string {
+		private _validateDate(date: string, isMaxDate?: boolean): Date | string {
 			const _finalDate = date;
 
 			if (OSFramework.OSUI.Helper.Dates.IsNull(_finalDate)) {
@@ -172,7 +172,7 @@ namespace Providers.OSUI.Datepicker.Flatpickr {
 			} else if (this._isUsingDateTime) {
 				return _finalDate;
 			} else {
-				return OSFramework.OSUI.Helper.Dates.NormalizeDateTime(_finalDate, date === this.MaxDate);
+				return OSFramework.OSUI.Helper.Dates.NormalizeDateTime(_finalDate, isMaxDate);
 			}
 		}
 
@@ -199,7 +199,7 @@ namespace Providers.OSUI.Datepicker.Flatpickr {
 				dateFormat: this._isUsingDateTime
 					? this.ServerDateFormat + ' H:i:S' // do not change 'H:i:S' since it's absoluted needed due to platform conversions!
 					: this.ServerDateFormat,
-				maxDate: this._validateDate(this.MaxDate),
+				maxDate: this._validateDate(this.MaxDate, true),
 				minDate: this._validateDate(this.MinDate),
 				onChange: this.OnChange,
 				onClose: this.OnClose,


### PR DESCRIPTION
This PR is to improve the Datepicker render when MinDate, MaxDate and InitialDate have the same value;

### What was happening

- When the MinDate, MaxDate, and InitialDate had the same value, the DatePicker was not rendering with a value on initialised.

### What was done

- Guarantee that minDate is set with time 00:00:00 and maxDate with time 23:59:59 when the widget is config with TimeFormat disabled.

### Test Steps

1. Fill MinDate, MaxDate and InitialDate with the same date (2024-04-18)
2. Choose disabled on TimeFormat;
3. Click Apply and check if the date picker renders with an initial value;

### Checklist

-   [x] tested locally
-   [x] documented the code
-   [x] clean all warnings and errors of eslint
-   [ ] requires changes in OutSystems (if so, provide a module with changes)
-   [ ] requires new sample page in OutSystems (if so, provide a module with changes)
