### PR TITLE
ROU-4881 - [OSUI] - Issue with overflow menu triggers console error

### DIFF
--- a/src/scripts/OSFramework/OSUI/Feature/Balloon/Balloon.ts
+++ b/src/scripts/OSFramework/OSUI/Feature/Balloon/Balloon.ts
@@ -299,6 +299,7 @@ namespace OSFramework.OSUI.Feature.Balloon {
 		 */
 		public dispose(): void {
 			this._floatingInstance?.dispose();
+			this._removeEventListeners();
 			this._unsetCallbacks();
 			super.dispose();
 		}


### PR DESCRIPTION
This PR is for fixing an issue related with the status of the ballon

### What was happening

- When the ballon was open and its state change via back button, the body click listener was still active, but the ballon reference was lost since it was dispose.

### What was done

- remove listeners on ballon dispose;

### Test Steps

1. Go to page 
2. Navigate via link to the same page
3. Open Ballon
4. Click back button to the same page
5. Click somewhere on the page
6. Check that there aren't errors on the console

### Checklist

-   [x] tested locally
-   [x] documented the code
-   [x] clean all warnings and errors of eslint
-   [ ] requires changes in OutSystems (if so, provide a module with changes)
-   [ ] requires new sample page in OutSystems (if so, provide a module with changes)
