### PR TITLE
ROU-4898 - Issue with date pickers in OutSystems UI v2.18.4

### DIFF
--- a/src/scripts/Providers/OSUI/Datepicker/Flatpickr/SingleDate/FlatpickrSingleDate.ts
+++ b/src/scripts/Providers/OSUI/Datepicker/Flatpickr/SingleDate/FlatpickrSingleDate.ts
@@ -156,8 +156,17 @@ namespace Providers.OSUI.Datepicker.Flatpickr.SingleDate {
 						? (new Date(this.provider.selectedDates[0]) as Date)
 						: undefined;
 
-				// Check if InitialDate has been "asked" to be changed dynamically without user selected a date at calendar!
-				if (providerSelectedDate === undefined || providerSelectedDate.getTime() !== newDateValue.getTime()) {
+				// Only allow to change if it was not a clear action (newDateValue is NOT null)
+				if (
+					providerSelectedDate === undefined &&
+					OSFramework.OSUI.Helper.Dates.IsNull(newDateValue) === false
+				) {
+					redrawAtInitialDateChange = true;
+					// Check if InitialDate has been "asked" to be changed dynamically without the user selecting a date on the calendar!
+				} else if (
+					providerSelectedDate !== undefined &&
+					providerSelectedDate?.getTime() !== newDateValue.getTime()
+				) {
 					redrawAtInitialDateChange = true;
 				}
 			}


### PR DESCRIPTION
This PR is for fixing an issue related to the clear API. It was only working on the second call.

### What was happening

- When the date picker was configured using only one var for the initial date and the selected date, the clear action didn't work. This was happening because we were doing a redraw when was not needed

### What was done

- improve change property validation for the initial date;

### Test Steps

1. Go to the section **Reuse InitialDate as SelectedDate** on the sample page
2. Click on the clear button
3. Check the input is clear and the date inside the DatePicker is unselected


### Checklist

-   [x] tested locally
-   [x] documented the code
-   [x] clean all warnings and errors of eslint
-   [ ] requires changes in OutSystems (if so, provide a module with changes)
-   [ ] requires new sample page in OutSystems (if so, provide a module with changes)
