### PR TITLE
ROU-4890: improve SectionIndex scroll behavior

### DIFF
--- a/src/scripts/OSFramework/OSUI/Behaviors/Scroll.ts
+++ b/src/scripts/OSFramework/OSUI/Behaviors/Scroll.ts
@@ -9,19 +9,12 @@ namespace OSFramework.OSUI.Behaviors {
 	 * Trigger a scroll navigation into a given offset position
 	 *
 	 * @param {HTMLElement} element Element where the scroll will happen
-	 * @param offSet Offset values
 	 * @param isSmooth True if the scroll should be smooth
 	 */
-	export function Scroll(element: HTMLElement, offSet: OffsetValues, isSmooth = true): void {
+	export function Scroll(element: HTMLElement, options: ScrollIntoViewOptions): void {
 		if (element) {
-			// Set the options to set at the Scroll fucntion
-			const scrollOpts = {
-				...offSet,
-				behavior: isSmooth ? GlobalEnum.ScrollBehavior.Smooth : GlobalEnum.ScrollBehavior.Auto,
-			};
-
 			// Trigger the scroll navigation!
-			element.scroll(scrollOpts);
+			element.scrollIntoView(options);
 		}
 	}
 

--- a/src/scripts/OSFramework/OSUI/GlobalEnum.ts
+++ b/src/scripts/OSFramework/OSUI/GlobalEnum.ts
@@ -151,11 +151,22 @@ namespace OSFramework.OSUI.GlobalEnum {
 	}
 
 	/**
-	 * OutSystemsUI Scroll Options
+	 * OutSystemsUI Scroll Behavior Options
 	 */
 	export enum ScrollBehavior {
 		Auto = 'auto',
+		Instant = 'instant',
 		Smooth = 'smooth',
+	}
+
+	/**
+	 * OutSystemsUI Scroll Position Options
+	 */
+	export enum ScrollPositionBehavior {
+		Start = 'start',
+		Center = 'center',
+		End = 'end',
+		Nearest = 'nearest',
 	}
 
 	/**

--- a/src/scripts/OSFramework/OSUI/Helper/Dom.ts
+++ b/src/scripts/OSFramework/OSUI/Helper/Dom.ts
@@ -221,6 +221,23 @@ namespace OSFramework.OSUI.Helper {
 		}
 
 		/**
+		 * Returns the value of a CSS Custom Property
+		 *
+		 * @static
+		 * @param {HTMLElement} element
+		 * @param {string} propertyName
+		 * @return {*}
+		 * @memberof StyleManipulation
+		 */
+		public static GetCustomProperty(element: HTMLElement, propertyName: string) {
+			if (element) {
+				return getComputedStyle(element).getPropertyValue(propertyName);
+			} else {
+				throw Error(`The element does not exist, when trying to get the Csutom Property '${propertyName}'.`);
+			}
+		}
+
+		/**
 		 * Method that will remove a given css class from a given html element.
 		 *
 		 * @static

--- a/src/scripts/OSFramework/OSUI/Helper/Dom.ts
+++ b/src/scripts/OSFramework/OSUI/Helper/Dom.ts
@@ -233,7 +233,7 @@ namespace OSFramework.OSUI.Helper {
 			if (element) {
 				return getComputedStyle(element).getPropertyValue(propertyName);
 			} else {
-				throw Error(`The element does not exist, when trying to get the Csutom Property '${propertyName}'.`);
+				throw Error(`The element does not exist, when trying to get the Custom Property '${propertyName}'.`);
 			}
 		}
 

--- a/src/scripts/OSFramework/OSUI/Pattern/SectionIndex/ISectionIndex.ts
+++ b/src/scripts/OSFramework/OSUI/Pattern/SectionIndex/ISectionIndex.ts
@@ -7,7 +7,5 @@ namespace OSFramework.OSUI.Patterns.SectionIndex {
 	 * @interface ISectionIndex
 	 * @extends {Interface.IPattern}
 	 */
-	export interface ISectionIndex extends Interface.IParent {
-		contentPaddingTop: string | number;
-	}
+	export interface ISectionIndex extends Interface.IParent {}
 }

--- a/src/scripts/OSFramework/OSUI/Pattern/SectionIndex/SectionIndex.ts
+++ b/src/scripts/OSFramework/OSUI/Pattern/SectionIndex/SectionIndex.ts
@@ -16,11 +16,22 @@ namespace OSFramework.OSUI.Patterns.SectionIndex {
 		private _activeSectionIndexItem: SectionIndexItem.ISectionIndexItem;
 		// Store the contentPaddingTop
 		private _contentPaddingTop: string | number;
+		// Store the header size if it's fixed!
+		private _headerHeight: number;
+		// Store a flag that will be used to check if the header is fixed!
+		private _headerIsFixed = true;
 		// Store the mainContent reference - The one that will have the scroll
 		private _mainScrollContainerElement: HTMLElement;
-
+		// Boolean flag to prevent code from running before the scroll has ended
 		private _navigateOnClick = false;
+		// Store the scroll settimeout, to be cleared when needed
 		private _scrollTimeout: number;
+		// Store the scroll options to be used on ScrollIntoView
+		public scrollOptions: ScrollIntoViewOptions = {
+			behavior: this.configs.SmoothScrolling ? GlobalEnum.ScrollBehavior.Smooth : GlobalEnum.ScrollBehavior.Auto,
+			inline: GlobalEnum.ScrollPositionBehavior.Start,
+			block: GlobalEnum.ScrollPositionBehavior.Start,
+		};
 
 		constructor(uniqueId: string, configs: JSON) {
 			super(uniqueId, new SectionIndexConfig(configs));
@@ -57,8 +68,19 @@ namespace OSFramework.OSUI.Patterns.SectionIndex {
 			this._contentPaddingTop = _mainContent
 				? parseFloat(
 						window.getComputedStyle(_mainContent).getPropertyValue(GlobalEnum.CssProperties.PaddingTop)
-				  )
+					)
 				: 0;
+		}
+
+		// Method to check if header IsFixed and get its height to be used
+		private _getHeaderSize(): void {
+			const header = Helper.Dom.ClassSelector(document.body, GlobalEnum.CssClassElements.Header);
+			this._headerIsFixed = !!Helper.Dom.ClassSelector(document.body, GlobalEnum.CssClassElements.HeaderIsFixed);
+
+			// If header exist and it's fixed store its height
+			if (header) {
+				this._headerHeight = this._headerIsFixed ? header.offsetHeight : 0;
+			}
 		}
 
 		// Method used to remove a given SectionIndexItem from sectionIndexItems list, it's triggered by SectionIndexItem
@@ -76,27 +98,23 @@ namespace OSFramework.OSUI.Patterns.SectionIndex {
 
 		// Method that will update the IsActive child item status
 		private _setActiveChildOnClick(child: SectionIndexItem.ISectionIndexItem): void {
+			// If its clicking on the same item, do nothing
+			if (child === this._activeSectionIndexItem) {
+				return;
+			}
+
 			// Clean the timeout
 			this._navigateOnClick = true;
 			window.clearTimeout(this._scrollTimeout);
 			this._scrollTimeout = window.setTimeout(() => {
 				// Reset flag in order to understand navigation by click has ended!
 				this._navigateOnClick = false;
-			}, 800); // enought time to deal with the scroll
+			}, 1000); // enought time to deal with the scroll
 
-			// Remove old sectionIndexItem as active if exist
-			if (this._activeSectionIndexItem) {
-				this._activeSectionIndexItem.unsetIsActive();
-			}
-
-			// Set new sectionIndexItem as active
-			child.setIsActive();
-
-			// Set the current IsActive Child
-			this._activeSectionIndexItem = child;
+			this._updateActiveItem(child);
 
 			// Trigger the Scroll navigation
-			Behaviors.Scroll(this._mainScrollContainerElement, child.TargetElementOffset, this.configs.SmoothScrolling);
+			Behaviors.Scroll(child.TargetElement, this.scrollOptions);
 		}
 
 		// Method used to set the IsActive child item at the onBodyScroll
@@ -106,23 +124,8 @@ namespace OSFramework.OSUI.Patterns.SectionIndex {
 				return;
 			}
 
-			// Get all IsActive Items
-			const isActiveChilds = this.getChildItems().filter((item) => item.IsSelected);
-			// Go through all the IsActive items
-			for (const optionItem of isActiveChilds) {
-				// In case we've multiple IsActive items, unselect all unless last one!
-				if (isActiveChilds.length === 1 || optionItem !== isActiveChilds[isActiveChilds.length - 1]) {
-					this._activeSectionIndexItem.unsetIsActive();
-				}
-			}
-
-			// Set new sectionIndexItem as active
-			child.setIsActive();
-
-			// Set the current IsActive Child
-			this._activeSectionIndexItem = child;
+			this._updateActiveItem(child);
 		}
-
 		// Method to set the SectionIndex IsFixed
 		private _toggleIsFixed(): void {
 			if (this.configs.IsFixed) {
@@ -151,6 +154,20 @@ namespace OSFramework.OSUI.Patterns.SectionIndex {
 				// Remove the Sticky class
 				Helper.Dom.Styles.RemoveClass(this.selfElement, Enum.CssClass.IsSticky);
 			}
+		}
+
+		// Method to remove current active item and set new one
+		private _updateActiveItem(child: SectionIndexItem.ISectionIndexItem): void {
+			// Remove old sectionIndexItem as active if exist
+			if (this._activeSectionIndexItem) {
+				this._activeSectionIndexItem.unsetIsActive();
+			}
+
+			// Set new sectionIndexItem as active
+			child.setIsActive();
+
+			// Set the current IsActive Child
+			this._activeSectionIndexItem = child;
 		}
 
 		/**
@@ -261,6 +278,8 @@ namespace OSFramework.OSUI.Patterns.SectionIndex {
 
 			this._getContentPaddingTop();
 
+			this._getHeaderSize();
+
 			this._toggleIsFixed();
 
 			this.finishBuild();
@@ -280,6 +299,10 @@ namespace OSFramework.OSUI.Patterns.SectionIndex {
 					case Enum.Properties.IsFixed:
 						this._toggleIsFixed();
 						break;
+					case Enum.Properties.SmoothScrolling:
+						this.scrollOptions.behavior = propertyValue
+							? GlobalEnum.ScrollBehavior.Smooth
+							: GlobalEnum.ScrollBehavior.Auto;
 				}
 			}
 		}
@@ -293,17 +316,6 @@ namespace OSFramework.OSUI.Patterns.SectionIndex {
 			this.unsetHtmlElements();
 			//Destroying the base of pattern
 			super.dispose();
-		}
-
-		/**
-		 * Getter of the contentPaddingTop property
-		 *
-		 * @readonly
-		 * @type {(string | number)}
-		 * @memberof SectionIndex
-		 */
-		public get contentPaddingTop(): string | number {
-			return this._contentPaddingTop;
 		}
 	}
 }

--- a/src/scripts/OSFramework/OSUI/Pattern/SectionIndex/SectionIndex.ts
+++ b/src/scripts/OSFramework/OSUI/Pattern/SectionIndex/SectionIndex.ts
@@ -63,6 +63,16 @@ namespace OSFramework.OSUI.Patterns.SectionIndex {
 			}
 		}
 
+		// Method to get content paddnig top
+		private _getContentPaddingTop(): void {
+			const _mainContent = Helper.Dom.ClassSelector(document, GlobalEnum.CssClassElements.MainContent);
+			this._contentPaddingTop = _mainContent
+				? parseFloat(
+						window.getComputedStyle(_mainContent).getPropertyValue(GlobalEnum.CssProperties.PaddingTop)
+					)
+				: 0;
+		}
+
 		// Method to check if header IsFixed and get its height to be used
 		private _getHeaderSize(): void {
 			const header = Helper.Dom.ClassSelector(document.body, GlobalEnum.CssClassElements.Header);
@@ -266,6 +276,8 @@ namespace OSFramework.OSUI.Patterns.SectionIndex {
 			super.build();
 
 			this.setHtmlElements();
+
+			this._getContentPaddingTop();
 
 			this._getHeaderSize();
 

--- a/src/scripts/OSFramework/OSUI/Pattern/SectionIndex/SectionIndex.ts
+++ b/src/scripts/OSFramework/OSUI/Pattern/SectionIndex/SectionIndex.ts
@@ -63,15 +63,6 @@ namespace OSFramework.OSUI.Patterns.SectionIndex {
 			}
 		}
 
-		private _getContentPaddingTop(): void {
-			const _mainContent = Helper.Dom.ClassSelector(document, GlobalEnum.CssClassElements.MainContent);
-			this._contentPaddingTop = _mainContent
-				? parseFloat(
-						window.getComputedStyle(_mainContent).getPropertyValue(GlobalEnum.CssProperties.PaddingTop)
-					)
-				: 0;
-		}
-
 		// Method to check if header IsFixed and get its height to be used
 		private _getHeaderSize(): void {
 			const header = Helper.Dom.ClassSelector(document.body, GlobalEnum.CssClassElements.Header);
@@ -275,8 +266,6 @@ namespace OSFramework.OSUI.Patterns.SectionIndex {
 			super.build();
 
 			this.setHtmlElements();
-
-			this._getContentPaddingTop();
 
 			this._getHeaderSize();
 

--- a/src/scripts/OSFramework/OSUI/Pattern/SectionIndex/scss/_sectionindex.scss
+++ b/src/scripts/OSFramework/OSUI/Pattern/SectionIndex/scss/_sectionindex.scss
@@ -5,6 +5,7 @@
 
 ///
 .osui-section-index {
+	--top-position: calc(var(--header-size) + var(--header-size-content) + var(--status-bar-height));
 	display: flex;
 	flex-direction: column;
 	position: relative;
@@ -54,6 +55,10 @@
 			width: 2px;
 		}
 	}
+
+	&__target {
+		scroll-margin: var(--target-scroll-margin);
+	}
 }
 
 // Accessibility -----------------------------------------------------------------
@@ -101,7 +106,7 @@
 			left: calc(var(--os-safe-area-right) + var(--space-base));
 			padding: 0 var(--space-base) 0 0;
 			position: fixed;
-			top: calc(var(--header-size) + var(--header-size-content) + var(--status-bar-height));
+			top: var(--top-position);
 			z-index: var(--layer-local-tier-1);
 		}
 	}

--- a/src/scripts/OSFramework/OSUI/Pattern/SectionIndexItem/Enum.ts
+++ b/src/scripts/OSFramework/OSUI/Pattern/SectionIndexItem/Enum.ts
@@ -1,6 +1,20 @@
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 namespace OSFramework.OSUI.Patterns.SectionIndexItem.Enum {
 	/**
+	 * CSS Classes Enum
+	 */
+	export enum CssClass {
+		ItemTarget = 'osui-section-index-item__target',
+	}
+
+	/**
+	 * CSS Variables Enum
+	 */
+	export enum CssVariable {
+		ScrollMargin = '--target-scroll-margin',
+	}
+
+	/**
 	 * SectionIndexItem Enum properties
 	 */
 	export enum Properties {

--- a/src/scripts/OSFramework/OSUI/Pattern/SectionIndexItem/ISectionIndexItem.ts
+++ b/src/scripts/OSFramework/OSUI/Pattern/SectionIndexItem/ISectionIndexItem.ts
@@ -25,14 +25,6 @@ namespace OSFramework.OSUI.Patterns.SectionIndexItem {
 		TargetElement: HTMLElement;
 
 		/**
-		 * Readable property to get targetElementOffset info
-		 *
-		 * @type {OffsetValues}
-		 * @memberof ISectionIndexItem
-		 */
-		TargetElementOffset: OffsetValues;
-
-		/**
 		 * Method to add the active state
 		 *
 		 * @memberof ISectionIndexItem

--- a/src/scripts/OSFramework/OSUI/Pattern/SectionIndexItem/SectionIndexItem.ts
+++ b/src/scripts/OSFramework/OSUI/Pattern/SectionIndexItem/SectionIndexItem.ts
@@ -107,7 +107,7 @@ namespace OSFramework.OSUI.Patterns.SectionIndexItem {
 
 			// If header exist and it's fixed store its height
 			if (header) {
-				this._headerHeight = this._headerIsFixed ? header.offsetHeight : 2 * header.offsetHeight;
+				this._headerHeight = this._headerIsFixed ? header.offsetHeight : 0;
 			}
 		}
 
@@ -141,8 +141,7 @@ namespace OSFramework.OSUI.Patterns.SectionIndexItem {
 			this._setHeaderSize();
 
 			// Set the target element offset top values
-			this._targetElementOffset.top =
-				this._targetElement.offsetTop + this._headerHeight + (this.parentObject.contentPaddingTop as number);
+			this._targetElementOffset.top = this._targetElement.offsetTop;
 		}
 
 		// Method to set the event listeners

--- a/src/scripts/OSFramework/OSUI/Pattern/SectionIndexItem/SectionIndexItem.ts
+++ b/src/scripts/OSFramework/OSUI/Pattern/SectionIndexItem/SectionIndexItem.ts
@@ -18,21 +18,12 @@ namespace OSFramework.OSUI.Patterns.SectionIndexItem {
 		private _eventOnScreenScroll: GlobalCallbacks.Generic;
 		//Stores the keyboard callback function
 		private _eventOnkeyBoardPress: GlobalCallbacks.Generic;
-		// Store the header size if it's fixed!
-		private _headerHeight = 0;
-		// Store a flag that will be used to check if the header is fixed!
-		private _headerIsFixed = true;
 		// Store the state
 		private _isActive = false;
 		// Store the mainContent reference - The one that will have the scroll
 		private _mainScrollContainerElement: HTMLElement;
 		// Store TargetElement HTML object
 		private _targetElement: HTMLElement = undefined;
-		// Store offset top/bottom from TargetElement HTML object
-		private _targetElementOffset: OffsetValues = {
-			bottom: 0,
-			top: 0,
-		};
 
 		constructor(uniqueId: string, configs: JSON) {
 			super(uniqueId, new SectionIndexItemConfig(configs));
@@ -51,14 +42,13 @@ namespace OSFramework.OSUI.Patterns.SectionIndexItem {
 
 		// Method to check the scroll to know if the target element is visible and sets the item as active
 		private _onScreenScroll(): void {
-			// Set target element offset info!
-			this._setTargetOffsetInfo();
+			this._setTargetElement();
 			// Get the vertical scroll position value
 			const scrollYPosition = Behaviors.ScrollVerticalPosition(this._mainScrollContainerElement);
 			// Threshold value to set element as Active
 			const thresholdVal = 40;
 			// Store the offSetValue to be checked
-			const elementOffsetTopVal = this._targetElementOffset.top - scrollYPosition.value;
+			const elementOffsetTopVal = this._targetElement.offsetTop - scrollYPosition.value;
 
 			/* Logic behind position validation:
 				- If click to nanvigate into element the calc
@@ -82,10 +72,7 @@ namespace OSFramework.OSUI.Patterns.SectionIndexItem {
 		private _onSelected(event: Event): void {
 			event.preventDefault();
 			event.stopPropagation();
-
-			// Update the offsetInfo when clicked since we could have expandable containers that will change this values accoring the scroll content height
-			this._setTargetOffsetInfo();
-
+			this._setTargetElement();
 			// Notify parent about this Item Click
 			this.notifyParent(SectionIndex.Enum.ChildNotifyActionType.Click);
 		}
@@ -100,20 +87,22 @@ namespace OSFramework.OSUI.Patterns.SectionIndexItem {
 			);
 		}
 
-		// Method to check if header IsFixed
-		private _setHeaderSize(): void {
-			const header = Helper.Dom.ClassSelector(document.body, GlobalEnum.CssClassElements.Header);
-			this._headerIsFixed = !!Helper.Dom.ClassSelector(document.body, GlobalEnum.CssClassElements.HeaderIsFixed);
-
-			// If header exist and it's fixed store its height
-			if (header) {
-				this._headerHeight = this._headerIsFixed ? header.offsetHeight : 0;
-			}
-		}
-
 		// Method to add a data attribute to be used in automated tests and to have info on DOM of which element the index is pointing
 		private _setLinkAttribute(): void {
 			Helper.Dom.Attribute.Set(this.selfElement, Enum.DataTypes.dataItem, this.configs.ScrollToWidgetId);
+		}
+
+		// Method to add scroll margin styles for the item target
+		private _setTargetAttributes(): void {
+			// Set class to target, to avoid inline property styles
+			Helper.Dom.Styles.AddClass(this._targetElement, Enum.CssClass.ItemTarget);
+			// Add CSS Variable with the offset value for the scroll target, to be used on the CSS, based on parent topPosition
+			this.setTargetScrollMargin(
+				Helper.Dom.Styles.GetCustomProperty(
+					this.parentObject.selfElement,
+					SectionIndex.Enum.CssVariable.TopPosition
+				)
+			);
 		}
 
 		// Method to set the TargetElement
@@ -123,6 +112,7 @@ namespace OSFramework.OSUI.Patterns.SectionIndexItem {
 				try {
 					// Can't be used the Helper.Dom.GetElementById since we don't want a through error if the element does not exist!
 					this._targetElement = document.getElementById(this.configs.ScrollToWidgetId);
+					this._setTargetAttributes();
 				} catch (e) {
 					// Was not able to get Target element!
 					throw new Error(
@@ -130,18 +120,6 @@ namespace OSFramework.OSUI.Patterns.SectionIndexItem {
 					);
 				}
 			}
-		}
-
-		// Method to set the offset info related with TargetElement
-		private _setTargetOffsetInfo(): void {
-			// Check if TargetElement has been already defined, otherwise define it!
-			this._setTargetElement();
-
-			// Takes into account the headerSize
-			this._setHeaderSize();
-
-			// Set the target element offset top values
-			this._targetElementOffset.top = this._targetElement.offsetTop;
 		}
 
 		// Method to set the event listeners
@@ -153,6 +131,14 @@ namespace OSFramework.OSUI.Patterns.SectionIndexItem {
 				Event.DOMEvents.Listeners.Type.ScreenOnScroll,
 				this._eventOnScreenScroll
 			);
+		}
+
+		// Method to remove scroll margin styles on the item target
+		private _unsetTargetAttributes(): void {
+			// Set class to target, to avoid inline property styles
+			Helper.Dom.Styles.RemoveClass(this._targetElement, Enum.CssClass.ItemTarget);
+			// Add CSS Variable with the offset value for the scroll target, to be used on the CSS
+			Helper.Dom.Styles.RemoveStyleAttribute(this._targetElement, Enum.CssVariable.ScrollMargin);
 		}
 
 		/**
@@ -288,6 +274,8 @@ namespace OSFramework.OSUI.Patterns.SectionIndexItem {
 		public dispose(): void {
 			this.unsetCallbacks();
 
+			this._unsetTargetAttributes();
+
 			// Notify parent about this instance will be destroyed
 			this.notifyParent(SectionIndex.Enum.ChildNotifyActionType.Removed);
 
@@ -305,6 +293,17 @@ namespace OSFramework.OSUI.Patterns.SectionIndexItem {
 				this._isActive = true;
 				Helper.Dom.Styles.AddClass(this.selfElement, Patterns.SectionIndex.Enum.CssClass.IsActiveItem);
 			}
+		}
+
+		/**
+		 * Set the scroll margin, that acts as scrollIntoView offset
+		 *
+		 * @param {(number | string)} margin
+		 * @memberof SectionIndexItem
+		 */
+		public setTargetScrollMargin(margin: number | string): void {
+			// Add CSS Variable with the offset value for the scroll target, to be used on the CSS
+			Helper.Dom.Styles.SetStyleAttribute(this._targetElement, Enum.CssVariable.ScrollMargin, margin);
 		}
 
 		/**
@@ -339,17 +338,6 @@ namespace OSFramework.OSUI.Patterns.SectionIndexItem {
 		 */
 		public get TargetElement(): HTMLElement {
 			return this._targetElement;
-		}
-
-		/**
-		 * Readable property to get targetElementOffset info
-		 *
-		 * @readonly
-		 * @type {OffsetValues}
-		 * @memberof OSFramework.Patterns.SectionIndexItem.SectionIndexItem
-		 */
-		public get TargetElementOffset(): OffsetValues {
-			return this._targetElementOffset;
 		}
 	}
 }


### PR DESCRIPTION
This PR is for improving the way the SectionIndex deals with the scroll, in particular the smooth option.

- The overall calculations were simplified, and now the offset targets the value of the SectionIndex topPosition.
- The Scroll behaviour was changed to use the [ScrollIntoView api](https://developer.mozilla.org/en-US/docs/Web/API/Element/scrollIntoView).
- As this api does not have a offset option, this is now achieved with CSS, using the [scroll-margin property](https://developer.mozilla.org/en-US/docs/Web/CSS/scroll-margin).
- A new helper was created on Dom, to return the value of a CSS Custom Property. 

### Checklist

-   [x] tested locally
-   [x] documented the code
-   [x] clean all warnings and errors of eslint
-   [x] requires changes in OutSystems (if so, provide a module with changes)
-   [ ] requires new sample page in OutSystems (if so, provide a module with changes)
