### PR TITLE
ROU-4865: Add SilentOnChangedEvent to DropdownClear API

### DIFF
--- a/src/scripts/OutSystems/OSUI/Patterns/DropdownAPI.ts
+++ b/src/scripts/OutSystems/OSUI/Patterns/DropdownAPI.ts
@@ -29,15 +29,16 @@ namespace OutSystems.OSUI.Patterns.DropdownAPI {
 	 *
 	 * @export
 	 * @param {string} dropdownId
+	 * @param {boolean} silentOnChangedEvent
 	 * @return {*} {string} Return Message Success or message of error info if it's the case.
 	 */
-	export function Clear(dropdownId: string): string {
+	export function Clear(dropdownId: string, silentOnChangedEvent = true): string {
 		const result = OutSystems.OSUI.Utils.CreateApiResponse({
 			errorCode: ErrorCodes.Dropdown.FailClear,
 			callback: () => {
-				const _dropdownItem = GetDropdownById(dropdownId);
+				const _dropdownItem = GetDropdownById(dropdownId) as VirtualSelect;
 
-				_dropdownItem.clear();
+				_dropdownItem.clear(silentOnChangedEvent);
 			},
 		});
 

--- a/src/scripts/Providers/OSUI/Dropdown/VirtualSelect/AbstractVirtualSelect.ts
+++ b/src/scripts/Providers/OSUI/Dropdown/VirtualSelect/AbstractVirtualSelect.ts
@@ -304,7 +304,7 @@ namespace Providers.OSUI.Dropdown.VirtualSelect {
 		 * @memberof Providers.OSUI.Dropdown.VirtualSelect.AbstractVirtualSelect
 		 */
 		public clear(silentOnChangedEvent = true): void {
-			this.virtualselectConfigs.reset(silentOnChangedEvent);
+			this.virtualselectConfigs.reset(false, silentOnChangedEvent);
 		}
 
 		/**

--- a/src/scripts/Providers/OSUI/Dropdown/VirtualSelect/AbstractVirtualSelect.ts
+++ b/src/scripts/Providers/OSUI/Dropdown/VirtualSelect/AbstractVirtualSelect.ts
@@ -300,10 +300,11 @@ namespace Providers.OSUI.Dropdown.VirtualSelect {
 		/**
 		 * Clear any selected values from the Dropdown
 		 *
+		 * @param {boolean} silentOnChangedEvent If True, OnChange event will not be triggered
 		 * @memberof Providers.OSUI.Dropdown.VirtualSelect.AbstractVirtualSelect
 		 */
-		public clear(): void {
-			this.virtualselectConfigs.reset();
+		public clear(silentOnChangedEvent = true): void {
+			this.virtualselectConfigs.reset(silentOnChangedEvent);
 		}
 
 		/**


### PR DESCRIPTION
This PR is to add `SilentOnChangedEvent` to the _DropdownClear_ API.

### What was happening

- DropdownClear client action was triggering the on-change event and causing an infinite loop:
![DropdownClearInfiniteLoop](https://github.com/OutSystems/outsystems-ui/assets/29493222/95a1e47c-64b0-4a19-b0bf-f1115c7e4829)


### What was done

- Added to the _DropdownClear_ API a new input parameter called `SilentOnChangedEvent` to control when to trigger the on-change event.

### Test Steps

1. Go to the test page
2. Select some options on the left Dropdown
3. Checked the change is triggered and the feedback message is displayed
4. Select some options on the right Dropdown
5. Checked the change is not triggered and no feedback message is displayed
6. Repeated the same steps for dropdown tags

### Checklist

-   [X] tested locally
-   [X] documented the code
-   [X] clean all warnings and errors of eslint
-   [X] requires changes in OutSystems
-   [ ] requires new sample page in OutSystems (if so, provide a module with changes)
