### PR TITLE
ROU-4903: [OSUI] - AnimatedLabel issue with symbols on Integer Input

### DIFF
--- a/src/scripts/OSFramework/OSUI/Pattern/AnimatedLabel/AnimatedLabel.ts
+++ b/src/scripts/OSFramework/OSUI/Pattern/AnimatedLabel/AnimatedLabel.ts
@@ -90,7 +90,14 @@ namespace OSFramework.OSUI.Patterns.AnimatedLabel {
 		 * @memberof AnimatedLabel
 		 */
 		private _inputStateToggle(isFocus = false): void {
-			const inputHasText = this._inputElement && this._inputElement.value !== '';
+			// In this flag, we are checking if the input has value.
+			// When the input is empty, the checkValidity() return true.
+			// If the input type is number, value is empty and checkValidty() is false this means that the input has invalid value.
+
+			const inputHasText =
+				this._inputElement &&
+				(this._inputElement.value !== '' ||
+					(this._inputElement.type === 'number' && this._inputElement.checkValidity() === false));
 
 			//let's check if we have something to do. Is the pattern built or (it's building) and we have text in the input?
 			if (this.isBuilt || inputHasText) {

--- a/src/scripts/OSFramework/OSUI/Pattern/AnimatedLabel/AnimatedLabel.ts
+++ b/src/scripts/OSFramework/OSUI/Pattern/AnimatedLabel/AnimatedLabel.ts
@@ -96,7 +96,7 @@ namespace OSFramework.OSUI.Patterns.AnimatedLabel {
 
 			const inputHasText =
 				this._inputElement &&
-				(this._inputElement.value !== '' ||
+				(this._inputElement.value !== Constants.EmptyString ||
 					(this._inputElement.type === 'number' && this._inputElement.checkValidity() === false));
 
 			//let's check if we have something to do. Is the pattern built or (it's building) and we have text in the input?


### PR DESCRIPTION
This PR is for fixing an issue on animated labels when the input is of type number.

### What was happening

- When we were using an Animated Label with an input of type number, and we start typing some integers and then add a '+', '-' or 'e' and the label will drop overlapping the input.

### What was done

- Improve empty input validation on AnimatedLabel component;

### Test Steps

1. Go to Animated Label on “With input type - Number” section. Check if the label is correct  when you fill the input with "e" and click outside (blur)
2. Go to Animated Label on “With input type - Number” section. Check if the label is correct  when you fill the input with "E" and click outside (blur)
3. Go to Animated Label on “With input type - Number” section. Check if the label is correct  when you fill the input with "123-" and click outside (blur)
4. Go to Animated Label on “With input type - Number” section. Check if the label is correct  when you fill the input with "123+" and click outside (blur)

### Checklist

-   [x] tested locally
-   [x] documented the code
-   [x] clean all warnings and errors of eslint
-   [ ] requires changes in OutSystems (if so, provide a module with changes)
-   [ ] requires new sample page in OutSystems (if so, provide a module with changes)
