### PR TITLE
ROU-4770: Fix Dropdown Server Side issues after integrating the OSUI Balloon

### DIFF
--- a/src/scripts/OSFramework/OSUI/Pattern/Dropdown/ServerSide/scss/_dropdown-serverside.scss
+++ b/src/scripts/OSFramework/OSUI/Pattern/Dropdown/ServerSide/scss/_dropdown-serverside.scss
@@ -88,7 +88,9 @@ $balloonMobileTopMargin: 5vh;
 			padding: var(--space-none) var(--space-base);
 			position: relative;
 			transition: border 250ms ease-in-out;
-			width: 100%;
+			width: calc(
+				100% - 2 * var(--border-size-s)
+			); // subtracts the size of the border so it doesn't get cut off inside the tabs
 		}
 
 		[data-expression] {

--- a/src/scripts/OSFramework/OSUI/Pattern/Tabs/scss/_tabs.scss
+++ b/src/scripts/OSFramework/OSUI/Pattern/Tabs/scss/_tabs.scss
@@ -247,6 +247,10 @@
 			.columns {
 				max-width: 99.99%;
 			}
+
+			&:not(.osui-tabs--is-active) {
+				opacity: 0;
+			}
 		}
 	}
 


### PR DESCRIPTION
This PR is for fixing Dropdown Server Side issues after integrating the OSUI Balloon

### What was happening
- Inside new Tabs and on some Tab contents and not in RTL the right border is not displayed: 
![image](https://github.com/OutSystems/outsystems-ui/assets/108938618/03c68606-67ef-4123-94da-77e0ef628999)
- Inside new Tabs when the dropdown is open and we click on another Tab without closing the dropdown balloon, we temporarily see the balloon flickering on the left side of the screen: 
![IssueDropdownSerSideInsideNewTabs](https://github.com/OutSystems/outsystems-ui/assets/108938618/34601099-ddca-4d4c-909c-7bfbaec41b5c)

### What was done
- In the Dropdown Server Side, subtracted the size of its border from the width so it is displayed correctly inside the Tabs.
- In the Tabs, added "opacity:0" to the not active tabs content items.

### Checklist

-   [x] tested locally
-   [x] documented the code
-   [x] clean all warnings and errors of eslint
-   [ ] requires changes in OutSystems (if so, provide a module with changes)
-   [ ] requires new sample page in OutSystems (if so, provide a module with changes)
