### PR TITLE
ROU-4738-v2: fix drop and tooltip issues

### DIFF
--- a/src/scripts/OSFramework/OSUI/Pattern/Dropdown/ServerSide/scss/_dropdown-serverside.scss
+++ b/src/scripts/OSFramework/OSUI/Pattern/Dropdown/ServerSide/scss/_dropdown-serverside.scss
@@ -88,9 +88,7 @@ $balloonMobileTopMargin: 5vh;
 			padding: var(--space-none) var(--space-base);
 			position: relative;
 			transition: border 250ms ease-in-out;
-			width: calc(
-				100% - 2 * var(--border-size-s)
-			); // subtracts the size of the border so it doesn't get cut off inside the tabs
+			width: 100%;
 		}
 
 		[data-expression] {
@@ -248,6 +246,14 @@ $balloonMobileTopMargin: 5vh;
 	}
 }
 
+// Inside Tabs
+.windows .osui-tabs {
+	// subtracts the size of the border so it doesn't get cut off inside the tabs, in windows
+	.osui-dropdown-serverside__selected-values-wrapper {
+		width: calc(100% - 2 * var(--border-size-s));
+	}
+}
+
 // Accessibility -----------------------------------------------------------------
 ///
 .has-accessible-features {
@@ -396,7 +402,7 @@ $balloonMobileTopMargin: 5vh;
 			overflow: hidden;
 			top: 0;
 			transition: opacity 250ms ease;
-			width: 100vh;
+			width: 100vw;
 			z-index: var(--layer-global-instant-interaction);
 
 			// Service Studio Preview

--- a/src/scripts/OSFramework/OSUI/Pattern/Tabs/scss/_tabs.scss
+++ b/src/scripts/OSFramework/OSUI/Pattern/Tabs/scss/_tabs.scss
@@ -147,9 +147,17 @@
 	}
 
 	&:not(.osui-tabs--has-drag) {
-		// To prevent render/position issues after repaints that affect the Tabs size
-		.osui-tabs__content:not(:focus-within) {
-			scroll-snap-type: x mandatory;
+		.osui-tabs__content {
+			// To prevent render/position issues after repaints that affect the Tabs size
+			&:not(:focus-within) {
+				scroll-snap-type: x mandatory;
+			}
+
+			&-item {
+				&:not(.osui-tabs--is-active) {
+					opacity: 0;
+				}
+			}
 		}
 	}
 
@@ -246,10 +254,6 @@
 			// This selector is used to prevent render issues on chrome, in some screen-sizes, due to overflow hidden and css snap
 			.columns {
 				max-width: 99.99%;
-			}
-
-			&:not(.osui-tabs--is-active) {
-				opacity: 0;
 			}
 		}
 	}


### PR DESCRIPTION
This PR is for fixing:

- Dropdown inside Tabs, only in windows
- Revert tabs code as it was causing issues with drag experience
- Fix tooltip closing when clicking on another tooltip

### Checklist

-   [x] tested locally
-   [x] documented the code
-   [x] clean all warnings and errors of eslint
-   [x] requires changes in OutSystems (if so, provide a module with changes)
-   [ ] requires new sample page in OutSystems (if so, provide a module with changes)
