### PR TITLE
ROU-10751: TabsContent is not visible at DesignTime

### DIFF
--- a/src/scripts/OSFramework/OSUI/Pattern/Tabs/scss/_tabs.scss
+++ b/src/scripts/OSFramework/OSUI/Pattern/Tabs/scss/_tabs.scss
@@ -156,6 +156,11 @@
 			&-item {
 				&:not(.osui-tabs--is-active) {
 					opacity: 0;
+
+					// Service Studio preview
+					& {
+						-servicestudio-opacity: 1;
+					}
 				}
 			}
 		}

--- a/src/scss/O11.OutSystemsUI.scss
+++ b/src/scss/O11.OutSystemsUI.scss
@@ -17,7 +17,7 @@ PS: This comment block will not be visible in the compiled version!
 =============================================================================== */
 
 /*!
-OutSystems UI 2.19.0 • O11 Platform
+OutSystems UI 2.19.1 • O11 Platform
 Website:
  • https://www.outsystems.com/outsystems-ui
 GitHub:

--- a/src/scss/ODC.OutSystemsUI.scss
+++ b/src/scss/ODC.OutSystemsUI.scss
@@ -17,7 +17,7 @@ PS: This comment block will not be visible in the compiled version!
 =============================================================================== */
 
 /*!
-OutSystems UI 2.19.0 • ODC Platform
+OutSystems UI 2.19.1 • ODC Platform
 Website:
  • https://www.outsystems.com/outsystems-ui
 GitHub:


### PR DESCRIPTION
This PR will fix an issue that was preventing tabsContent to be visible at design time (inside ServiceStudio).