### PR TITLE
ROU-4717: Adding ability to change the clicking area

### DIFF
--- a/src/scripts/OSFramework/OSUI/Pattern/AccordionItem/AccordionItemConfig.ts
+++ b/src/scripts/OSFramework/OSUI/Pattern/AccordionItem/AccordionItemConfig.ts
@@ -12,9 +12,11 @@ namespace OSFramework.OSUI.Patterns.AccordionItem {
 		public IconPosition: string;
 		public IsDisabled: boolean;
 		public StartsExpanded: boolean;
+		public ToggleWithIcon: boolean;
 
 		constructor(config: JSON) {
 			super(config);
+			this.ToggleWithIcon = false;
 		}
 
 		/**
@@ -51,6 +53,9 @@ namespace OSFramework.OSUI.Patterns.AccordionItem {
 					break;
 				case Enum.Properties.IconPosition:
 					validatedValue = this.validateString(value as string, GlobalEnum.Direction.Right);
+					break;
+				case Enum.Properties.ToggleWithIcon:
+					validatedValue = this.validateBoolean(value as boolean, false);
 					break;
 				default:
 					validatedValue = super.validateDefault(key, value);

--- a/src/scripts/OSFramework/OSUI/Pattern/AccordionItem/Enum.ts
+++ b/src/scripts/OSFramework/OSUI/Pattern/AccordionItem/Enum.ts
@@ -8,6 +8,7 @@ namespace OSFramework.OSUI.Patterns.AccordionItem.Enum {
 		IsDisabled = 'IsDisabled',
 		Icon = 'Icon',
 		StartsExpanded = 'StartsExpanded',
+		ToggleWithIcon = 'ToggleWithIcon',
 	}
 
 	/**
@@ -19,6 +20,7 @@ namespace OSFramework.OSUI.Patterns.AccordionItem.Enum {
 		PatternCollapsed = 'osui-accordion-item__content--is-collapsed',
 		PatternDisabled = 'osui-accordion-item--is-disabled',
 		PatternExpanded = 'osui-accordion-item__content--is-expanded',
+		PatternClickArea = 'osui-accordion-item__click_zone',
 		PatternContent = 'osui-accordion-item__content',
 		PatternIcon = 'osui-accordion-item__icon',
 		PatternIconCaret = 'osui-accordion-item__icon--caret',
@@ -29,6 +31,7 @@ namespace OSFramework.OSUI.Patterns.AccordionItem.Enum {
 		PatternIconPositionIsRight = 'osui-accordion-item__title--is-right',
 		PatternOpen = 'osui-accordion-item--is-open',
 		PatternTitle = 'osui-accordion-item__title',
+		PatternToggleWithIcon = 'osui-accordion-item--toggle-with-icon',
 	}
 
 	/**

--- a/src/scripts/OSFramework/OSUI/Pattern/AccordionItem/scss/_accordion-item.scss
+++ b/src/scripts/OSFramework/OSUI/Pattern/AccordionItem/scss/_accordion-item.scss
@@ -17,6 +17,19 @@
 	border-radius: var(--border-radius-soft);
 	position: relative;
 
+	&__click_zone {
+		cursor: pointer;
+	}
+
+	// Toggle on icon click
+	&--toggle-with-icon {
+		& .osui-accordion-item__title {
+			cursor: default;
+		}
+		& .osui-accordion-item__icon {
+			cursor: pointer;
+		}
+	}
 	// Active border-top
 	&:after {
 		background-color: transparent;
@@ -84,7 +97,6 @@
 
 	&__title {
 		align-items: center;
-		cursor: pointer;
 		direction: ltr;
 		display: flex;
 		font-size: var(--font-size-h6);
@@ -144,7 +156,7 @@
 			}
 		}
 
-		&--custom {
+		&--custom:not(.osui-accordion-item__click_zone) {
 			pointer-events: none;
 			-servicestudio-height: auto;
 			-servicestudio-width: auto;

--- a/src/scripts/OutSystems/OSUI/Patterns/AccordionItemAPI.ts
+++ b/src/scripts/OutSystems/OSUI/Patterns/AccordionItemAPI.ts
@@ -197,4 +197,28 @@ namespace OutSystems.OSUI.Patterns.AccordionItemAPI {
 
 		return result;
 	}
+
+	/**
+	 * Function that enables toggling the active area to expand and collapse the accordion item.
+	 *
+	 * @export
+	 * @param {string} accordionItemId
+	 * @param {boolean} isIconOnly
+	 * @return {*}  {string}
+	 */
+	export function ToggleClickableZone(accordionItemId: string, isIconOnly: boolean): string {
+		const result = OutSystems.OSUI.Utils.CreateApiResponse({
+			errorCode: ErrorCodes.AccordionItem.FailRegisterCallback,
+			callback: () => {
+				const accordionItem = GetAccordionItemById(accordionItemId);
+
+				accordionItem.changeProperty(
+					OSFramework.OSUI.Patterns.AccordionItem.Enum.Properties.ToggleWithIcon,
+					isIconOnly
+				);
+			},
+		});
+
+		return result;
+	}
 }


### PR DESCRIPTION
This PR is inspired by the [PR](https://github.com/OutSystems/outsystems-ui/pull/890) made by [@ElevenMou](https://github.com/ElevenMou) and introduces the ability to change the clickable area that will trigger the opening/closing of the Accordion Item.

### What was happening
- There was no easy ability to make just the icon of the accordion clickable.

### What was done
- Added the required functionality via API:
```
OutSystems.OSUI.Patterns.AccordionItemAPI.ToggleClickableZone("ACCORDIONITEMID", true);
```

### Test Steps
1. Go to test page, the active clickable area via the buttons
2. Depending of the value, the clickable area should be the title or just the icon.

### Screenshots
![accordion-icon-toggle](https://github.com/OutSystems/outsystems-ui/assets/10534623/6104151d-ce38-4c1d-98ff-95b2f71bcf14)

### Checklist
-   [x] tested locally
-   [x] documented the code
-   [x] clean all warnings and errors of eslint
-   [ ] requires changes in OutSystems (if so, provide a module with changes)
-   [ ] requires new sample page in OutSystems (if so, provide a module with changes)
