### PR TITLE
ROU-0 Update typedoc.json to fix error

### DIFF
--- a/typedoc.json
+++ b/typedoc.json
@@ -11,6 +11,9 @@
     "sort": [
         "source-order"
     ],
+    "plugin": [
+        "typedoc-umlclass"
+    ],
     "umlClassDiagram": {
         "type": "detailed",
         "location": "local",


### PR DESCRIPTION
This PR is to update typedoc.json to fix the error after updating type docs

[Sample page](url)

### What was happening

- While running `npx typedoc` we were getting the following issue right after updating **typedoc** to **v0.25.13** and **typedoc-umlclass** to **v0.9.0**

`[error] Tried to set an option (umlClassDiagram) that was not declared. You may have meant:
	media
	customCss
	htmlLang
	emit
	name
	readme
	cname
	gaID
	sort
Error: Process completed with exit code 1.
`

### What was done

- Added a new setting to `typedoc.json` according to the example from [typedoc-umlclass](https://www.npmjs.com/package/typedoc-umlclass):
`"plugin": [
        "typedoc-umlclass"
    ]`
 

### Test Steps

1. Ran  `npx typedoc` 
2. Check that the error doesn't occur now


### Checklist

-   [X] tested locally
-   [ ] documented the code
-   [X] clean all warnings and errors of eslint
-   [ ] requires changes in OutSystems (if so, provide a module with changes)
-   [ ] requires new sample page in OutSystems (if so, provide a module with changes)
