### PR TITLE
ROU-0: Rollback typedoc version

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,6 +1,6 @@
 {
 	"diffEditor.ignoreTrimWhitespace": true,
-	"files.autoSave": "off",
+	"files.autoSave": "afterDelay",
 	"editor.minimap.maxColumn": 170,
 	"editor.wordWrapColumn": 170,
 	"editor.formatOnSave": true,

--- a/package.json
+++ b/package.json
@@ -63,9 +63,9 @@
 		"stylelint": "^14.16.1",
 		"stylelint-config-prettier": "^9.0.5",
 		"stylelint-order": "^6.0.4",
-		"typedoc": "^0.25.13",
-		"typedoc-plugin-merge-modules": "^5.1.0",
-		"typedoc-umlclass": "^0.9.0",
+		"typedoc": "^0.23.9",
+		"typedoc-plugin-merge-modules": "^4.0.1",
+		"typedoc-umlclass": "^0.7.0",
 		"typescript": "^5.4.5",
 		"virtual-select-plugin": "^1.0.44"
 	}

--- a/typedoc.json
+++ b/typedoc.json
@@ -11,9 +11,6 @@
     "sort": [
         "source-order"
     ],
-    "plugin": [
-        "typedoc-umlclass"
-    ],
     "umlClassDiagram": {
         "type": "detailed",
         "location": "local",


### PR DESCRIPTION
- This PR is to rollback typedoc version back to:
```
"typedoc": "^0.23.9",
"typedoc-plugin-merge-modules": "^4.0.1",
"typedoc-umlclass": "^0.7.0",
```