### PR TITLE
ROU-0: rollback TypeScript version back to 4.5.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
 		"typedoc": "^0.23.9",
 		"typedoc-plugin-merge-modules": "^4.0.1",
 		"typedoc-umlclass": "^0.7.0",
-		"typescript": "^5.4.5",
+		"typescript": "^4.5.0",
 		"virtual-select-plugin": "^1.0.44"
 	}
 }


### PR DESCRIPTION
This PR is rollback TypeScript version back to 4.5.0