### PR TITLE
ROU-0: rollback TypeScript and type doc versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,9 +63,9 @@
 		"stylelint": "^14.16.1",
 		"stylelint-config-prettier": "^9.0.5",
 		"stylelint-order": "^6.0.4",
-		"typedoc": "^0.25.13",
-		"typedoc-plugin-merge-modules": "^5.1.0",
-		"typedoc-umlclass": "^0.9.0",
+		"typedoc": "^0.23.9",
+		"typedoc-plugin-merge-modules": "^4.0.1",
+		"typedoc-umlclass": "^0.7.0",
 		"typescript": "^5.4.5",
 		"virtual-select-plugin": "^1.0.44"
 	}

--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
 		"typedoc": "^0.23.9",
 		"typedoc-plugin-merge-modules": "^4.0.1",
 		"typedoc-umlclass": "^0.7.0",
-		"typescript": "^5.4.5",
+		"typescript": "^4.5.0",
 		"virtual-select-plugin": "^1.0.44"
 	}
 }


### PR DESCRIPTION
This PR is to rollback some dependencies since the docs generation started to fail: 
- rollback TypeScript version back to `v4.5.0`
- rollback typedoc version back to:
    ```
    "typedoc": "^0.23.9",
    "typedoc-plugin-merge-modules": "^4.0.1",
    "typedoc-umlclass": "^0.7.0",
    ```