### PR TITLE
ROU-10860 - [OSUI] - Dropdown Server Side not working for Android

### DIFF
--- a/src/scripts/OSFramework/OSUI/Feature/Balloon/Balloon.ts
+++ b/src/scripts/OSFramework/OSUI/Feature/Balloon/Balloon.ts
@@ -180,7 +180,7 @@ namespace OSFramework.OSUI.Feature.Balloon {
 				this._eventBodyClick
 			);
 
-			if (this.featureOptions.useTriggerWidth) {
+			if (this.featureOptions.useTriggerWidth && Helper.DeviceInfo.IsMobileDevice === false) {
 				Event.DOMEvents.Listeners.GlobalListenerManager.Instance.removeHandler(
 					Event.DOMEvents.Listeners.Type.WindowResize,
 					this._eventOnWindowResize
@@ -252,7 +252,7 @@ namespace OSFramework.OSUI.Feature.Balloon {
 				);
 			}
 
-			if (this.featureOptions.useTriggerWidth) {
+			if (this.featureOptions.useTriggerWidth && Helper.DeviceInfo.IsMobileDevice === false) {
 				// Add the window resize callback that will be used to close the balloon and avoid width differences!
 				Event.DOMEvents.Listeners.GlobalListenerManager.Instance.addHandler(
 					Event.DOMEvents.Listeners.Type.WindowResize,


### PR DESCRIPTION
This PR is for fixing the Dropdown Server Side for Androdid

### What was happening

- Dropdown Server Side was closing everytime on Android phones due to keyboard opening.

### What was done

- Make sure the onResize event is only applied when we are not on phone;

### Test Steps

1. Go to sample
2. Try to interact with the widget on an Android device


### Checklist

-   [x] tested locally
-   [x] documented the code
-   [x] clean all warnings and errors of eslint
-   [ ] requires changes in OutSystems (if so, provide a module with changes)
-   [ ] requires new sample page in OutSystems (if so, provide a module with changes)
