### PR TITLE
ROU-10851: fix AnimatedLabel on init value

### DIFF
--- a/src/scripts/OSFramework/OSUI/Pattern/AnimatedLabel/AnimatedLabel.ts
+++ b/src/scripts/OSFramework/OSUI/Pattern/AnimatedLabel/AnimatedLabel.ts
@@ -235,13 +235,16 @@ namespace OSFramework.OSUI.Patterns.AnimatedLabel {
 		 * @memberof OSFramework.Patterns.AnimatedLabel.AnimatedLabel
 		 */
 		public build(): void {
-			super.build();
+			//OS takes a while to set the TextArea
+			Helper.AsyncInvocation(() => {
+				super.build();
 
-			this.setHtmlElements();
+				this.setHtmlElements();
 
-			this.setCallbacks();
+				this.setCallbacks();
 
-			this.finishBuild();
+				this.finishBuild();
+			});
 		}
 
 		/**

--- a/src/scripts/OSFramework/OSUI/Pattern/AnimatedLabel/AnimatedLabel.ts
+++ b/src/scripts/OSFramework/OSUI/Pattern/AnimatedLabel/AnimatedLabel.ts
@@ -267,10 +267,12 @@ namespace OSFramework.OSUI.Patterns.AnimatedLabel {
 		 * @memberof OSFramework.Patterns.AnimatedLabel.AnimatedLabel
 		 */
 		public updateOnRender(): void {
-			// Do not run this instead the pattern is totally built
-			if (this.isBuilt) {
-				this._inputStateToggle();
-			}
+			Helper.AsyncInvocation(() => {
+				// Do not run this instead the pattern is totally built
+				if (this.isBuilt) {
+					this._inputStateToggle();
+				}
+			});
 		}
 	}
 }

--- a/src/scripts/OSFramework/OSUI/Pattern/AnimatedLabel/AnimatedLabel.ts
+++ b/src/scripts/OSFramework/OSUI/Pattern/AnimatedLabel/AnimatedLabel.ts
@@ -235,16 +235,13 @@ namespace OSFramework.OSUI.Patterns.AnimatedLabel {
 		 * @memberof OSFramework.Patterns.AnimatedLabel.AnimatedLabel
 		 */
 		public build(): void {
-			//OS takes a while to set the TextArea
-			Helper.AsyncInvocation(() => {
-				super.build();
+			super.build();
 
-				this.setHtmlElements();
+			this.setHtmlElements();
 
-				this.setCallbacks();
+			this.setCallbacks();
 
-				this.finishBuild();
-			});
+			this.finishBuild();
 		}
 
 		/**


### PR DESCRIPTION
This PR is for fixing the issue that prevents the AnimatedLabel to correctly appear as active on the screen load, when there's already a default value.

This was happening as the build method was async, while the render method responsible for the active state was running first than the build. As such, the render method was also made async.

### Checklist

-   [x] tested locally
-   [ ] documented the code
-   [ ] clean all warnings and errors of eslint
-   [ ] requires changes in OutSystems (if so, provide a module with changes)
-   [ ] requires new sample page in OutSystems (if so, provide a module with changes)
