### PR TITLE
ROU-10852: add range validation

### DIFF
--- a/src/scripts/Providers/OSUI/RangeSlider/NoUISlider/Utils.ts
+++ b/src/scripts/Providers/OSUI/RangeSlider/NoUISlider/Utils.ts
@@ -4,18 +4,20 @@ namespace Providers.OSUI.RangeSlider.NoUISlider.Utils {
 	function _setRangeValues(providerConfigs: RangeSliderProviderConfigs): RangeSliderProviderConfigs {
 		const _noUiSliderConfigs = providerConfigs;
 
-		// Check if the range key is empty. If true, remove from the array
-		if (_noUiSliderConfigs.range?.length <= 0) {
-			delete _noUiSliderConfigs.range;
-		} else {
-			const _rangeValues = {};
+		if (_noUiSliderConfigs.range) {
+			// Check if the range key is empty. If true, remove from the array
+			if (_noUiSliderConfigs.range.length <= 0) {
+				delete _noUiSliderConfigs.range;
+			} else {
+				const _rangeValues = {};
 
-			// Check the range values and cahnge to a single object
-			for (const element of _noUiSliderConfigs.range) {
-				_rangeValues[element.key] = element.value === undefined ? 0 : element.value;
+				// Check the range values and change to a single object
+				for (const element of _noUiSliderConfigs.range) {
+					_rangeValues[element.key] = element.value === undefined ? 0 : element.value;
+				}
+
+				_noUiSliderConfigs.range = _rangeValues;
 			}
-
-			_noUiSliderConfigs.range = _rangeValues;
 		}
 
 		return _noUiSliderConfigs;


### PR DESCRIPTION
This PR is for adding a range property validation before trying to manipulate it.

- In O11 this was never an issue, because empty structures objects always return an empty object range: {}.
- In ODC, this correctly returns nothing from the Platform, so we need to make sure the range exists, before doing anything with it.

### Checklist

-   [x] tested locally
-   [ ] documented the code
-   [ ] clean all warnings and errors of eslint
-   [ ] requires changes in OutSystems (if so, provide a module with changes)
-   [ ] requires new sample page in OutSystems (if so, provide a module with changes)
