### PR TITLE
ROU-10865: Dropdown Search/Tags Border disapears while searching

### DIFF
--- a/src/scripts/Providers/OSUI/Dropdown/VirtualSelect/scss/_virtualselect.scss
+++ b/src/scripts/Providers/OSUI/Dropdown/VirtualSelect/scss/_virtualselect.scss
@@ -387,8 +387,8 @@
 	/* use inner shadow to workaround the border issue that causes content to be blurry */
 	box-shadow: inset var(--border-color) 0 0 0 var(--border-size);
 	overflow: hidden;
-	/* needed in order to inner shadow (used as a border) be visible as border-bottom */
-	padding: 0 0 calc(2 * var(--border-size)) var(--border-size);
+	/* needed so the inner shadow (used as a border) be visible as border-bottom and border-right */
+	padding: 0 var(--border-size) calc(2 * var(--border-size)) var(--border-size);
 
 	// This is an override in order to fix an issue when inside a AlignCenter pattern
 	.vscomp-dropbox-close-button {


### PR DESCRIPTION
This PR is for fixing an issue that caused the right border of the dropbox to disappear in the Dropdown Search/Tags components. 

### What was happening

- This issue occurred when a search keyword caused the results to no longer display a scrollbar.


### What was done

- Changed the CSS class `.vscomp-dropbox` to contemplate the right padding as well - `padding: 0 var(--border-size) calc(2 * var(--border-size)) var(--border-size);`



### Test Steps

- Test Case 1:
    - Go to the Dropdown Search test page
    - Type “And“ (or any other keyword that causes the results to no longer display a scrollbar)
    - Check that now the border right is displayed

- Test Case 2:
    - Go to the Dropdown Tags test page
    - Type “And“ (or any other keyword that causes the results to no longer display a scrollbar)
    - Check that now the border right is displayed



### Screenshots
- Dropdown Search:
    - With Issue: 
    ![image](https://github.com/OutSystems/outsystems-ui/assets/29493222/cdbbb015-aca7-48d4-a943-2d8f3e16cf96)

    - Fixed: 
    ![image](https://github.com/OutSystems/outsystems-ui/assets/29493222/e07b00f2-eed2-49c0-b14f-e919cc4d89c7)



- Dropdown Tags:
    - With Issue: 
    ![image](https://github.com/OutSystems/outsystems-ui/assets/29493222/84b96cef-f574-477d-b8ff-a2bacfdf5054)

    - Fixed: 
    ![image](https://github.com/OutSystems/outsystems-ui/assets/29493222/49850b43-ee23-4b63-9dfb-d3670abf1f66)




### Checklist

-   [X] tested locally
-   [X] documented the code
-   [X] clean all warnings and errors of eslint
-   [ ] requires changes in OutSystems 
-   [ ] requires new sample page in OutSystems
