### PR TITLE
ROU-10909: fix tooltip StartsOpen

### DIFF
--- a/src/scripts/OSFramework/OSUI/Pattern/Tooltip/Tooltip.ts
+++ b/src/scripts/OSFramework/OSUI/Pattern/Tooltip/Tooltip.ts
@@ -32,7 +32,7 @@ namespace OSFramework.OSUI.Patterns.Tooltip {
 		// Flag used to manage if it's _tooltipIconElem  has been MouseEnter
 		private _isIconMouseEnter = false;
 		// Flag used to manage if it's open or closed!
-		private _isOpen: boolean;
+		private _isOpen = false;
 		// Flag used to deal with onBodyClick and open api concurrency methods!
 		private _isOpenedByApi = false;
 		// Platform OnClose Callback
@@ -47,8 +47,6 @@ namespace OSFramework.OSUI.Patterns.Tooltip {
 
 		constructor(uniqueId: string, configs: JSON) {
 			super(uniqueId, new TooltipConfig(configs));
-
-			this._isOpen = this.configs.StartVisible;
 		}
 
 		// Method to handle the custom BalloonOnToggle callback
@@ -192,9 +190,8 @@ namespace OSFramework.OSUI.Patterns.Tooltip {
 			}
 
 			// Set default IsVisible cssClass property value
-			if (this._isOpen) {
-				Helper.Dom.Styles.AddClass(this.selfElement, Enum.CssClass.IsOpened);
-				Helper.Dom.Styles.AddClass(this._tooltipBalloonWrapperElem, Enum.CssClass.BalloonIsOpened);
+			if (this.configs.StartVisible) {
+				this._triggerOpen();
 			}
 		}
 
@@ -438,8 +435,8 @@ namespace OSFramework.OSUI.Patterns.Tooltip {
 			this.setHtmlElements();
 			this.setA11YProperties();
 			this._setUpEvents();
-			this._setCssClasses();
 			this._setBalloonFeature();
+			this._setCssClasses();
 			this.finishBuild();
 		}
 


### PR DESCRIPTION
This PR is for fixing the tooltip's parameter StartsOpen, as it got broken after the Balloon feature implementation.

Now, when the StartsOpen is true, the Balloon open method is called on build().

### Checklist

-   [x] tested locally
-   [ ] documented the code
-   [ ] clean all warnings and errors of eslint
-   [ ] requires changes in OutSystems (if so, provide a module with changes)
-   [ ] requires new sample page in OutSystems (if so, provide a module with changes)
