### PR TITLE
ROU-10913: add display contents on enable item

### DIFF
--- a/src/scripts/OSFramework/OSUI/GlobalEnum.ts
+++ b/src/scripts/OSFramework/OSUI/GlobalEnum.ts
@@ -255,6 +255,7 @@ namespace OSFramework.OSUI.GlobalEnum {
 	export const InlineStyleValue = {
 		Display: {
 			block: 'block',
+			contents: 'contents',
 			inline: 'inline',
 			none: 'none',
 			unset: '',

--- a/src/scripts/OSFramework/OSUI/Pattern/Tabs/Tabs.ts
+++ b/src/scripts/OSFramework/OSUI/Pattern/Tabs/Tabs.ts
@@ -359,8 +359,12 @@ namespace OSFramework.OSUI.Patterns.Tabs {
 				const _transformValue = _isVertical
 					? _activeElement.offsetTop
 					: OutSystems.OSUI.Utils.GetIsRTL()
-					? -(this._tabsHeaderElement.offsetWidth - _activeElement.offsetLeft - _activeElement.offsetWidth)
-					: _activeElement.offsetLeft;
+						? -(
+								this._tabsHeaderElement.offsetWidth -
+								_activeElement.offsetLeft -
+								_activeElement.offsetWidth
+							)
+						: _activeElement.offsetLeft;
 
 				// Get the actual size of the current tabsHeader
 				const _elementRect = _activeElement.getBoundingClientRect();
@@ -431,7 +435,7 @@ namespace OSFramework.OSUI.Patterns.Tabs {
 				: (this.getChildByIndex(
 						this.configs.StartingTab,
 						Enum.ChildTypes.TabsContentItem
-				  ) as TabsContentItem.ITabsContentItem);
+					) as TabsContentItem.ITabsContentItem);
 
 			// Call the method to immediatelly set the single content as active,
 			// as it won't be needed to wait for more content items
@@ -804,7 +808,7 @@ namespace OSFramework.OSUI.Patterns.Tabs {
 				Helper.Dom.Styles.SetStyleAttribute(
 					_tabContentItemElement,
 					GlobalEnum.InlineStyle.Display,
-					GlobalEnum.InlineStyleValue.Display.block
+					GlobalEnum.InlineStyleValue.Display.contents
 				);
 
 				if (this._activeTabHeaderElement.selfElement === _tabHeaderItemElement) {


### PR DESCRIPTION
This PR is for fixing the toggle of the DisableTabItem API, to re-add display: contents instead of display: block.

### Checklist

-   [x] tested locally
-   [ ] documented the code
-   [ ] clean all warnings and errors of eslint
-   [ ] requires changes in OutSystems (if so, provide a module with changes)
-   [ ] requires new sample page in OutSystems (if so, provide a module with changes)
