### PR TITLE
ROU-10919: Fixed how to get URL file extension for video component

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,6 @@
+# Editor configuration, see https://editorconfig.org
+[*]
+charset = utf-8
+end_of_line = lf
+indent_style = space
+indent_size = 2

--- a/src/scripts/OSFramework/OSUI/Helper/URL.ts
+++ b/src/scripts/OSFramework/OSUI/Helper/URL.ts
@@ -3,6 +3,20 @@ namespace OSFramework.OSUI.Helper {
 	// eslint-disable-next-line @typescript-eslint/naming-convention
 	export abstract class URL {
 		/**
+		 * Function that extracts the file extension from a given URL
+		 *
+		 * @static
+		 * @param {string} url
+		 * @return {*}  {(string | null)}
+		 * @memberof OSFramework.Helper.URL
+		 */
+		public static GetFileTypeFromURL(url: string): string | null {
+			// Use a regular expression to extract the file extension from the URL
+			const match = url.match(/\.([a-z0-9]+)(?:[?#]|$)/i);
+			return match ? match[1].toLowerCase() : null;
+		}
+
+		/**
 		 * Function that validates if a given URL is a valid image URL
 		 *
 		 * @param url

--- a/src/scripts/OSFramework/OSUI/Pattern/Video/Video.ts
+++ b/src/scripts/OSFramework/OSUI/Pattern/Video/Video.ts
@@ -143,7 +143,11 @@ namespace OSFramework.OSUI.Patterns.Video {
 		 */
 		private _setVideoSource(): void {
 			// Get the file extension from URL
-			const _urlFileExtension = this.configs.URL.split('.').pop();
+			const _urlFileExtension = OSUI.Helper.URL.GetFileTypeFromURL(this.configs.URL);
+
+			if (_urlFileExtension === null) {
+				console.warn(`The URL '${this.configs.URL}' is not a valid URL.`);
+			}
 
 			// Add class to video source element
 			OSUI.Helper.Dom.Styles.AddClass(this._videoSourceElement, Patterns.Video.Enum.CssClass.VideoSource);


### PR DESCRIPTION
This PR is for fixing an issue that caused the Video component not to play as expected.

### What was happening

- This occurred when using a URL from a resource within the app since the URL gets appended with a session hash, which prevented the video extension from being properly calculated.

![image](https://github.com/user-attachments/assets/312a40c3-fd12-49c4-a117-76bb08112458)


### What was done

- Created a method to properly calculate the file extension for a given URL despite the fact of having a session hash or not.

### Test Steps

1. Create a sample screen with an instance of video using a URL from a resource (e.g. `Resources.osuivideo_mp4.URL`) 
2. Check that the video works
3. Added an instance of video using a URL from an external source (e.g. `http://commondatastorage.googleapis.com/gtv-videos-bucket/sample/Sintel.mp4`)
4. Check that the video works


### Screenshots

![image](https://github.com/user-attachments/assets/1d41a56a-cff2-4ce3-a5d1-6084ed457ec8)


### Checklist

-   [ ] tested locally
-   [ ] documented the code
-   [ ] clean all warnings and errors of eslint
-   [ ] requires changes in OutSystems (if so, provide a module with changes)
-   [ ] requires new sample page in OutSystems (if so, provide a module with changes)
