### PR TITLE
ROU-10923: DatePicker TodayButton didn't have tabindex=-1 when closed

### DIFF
--- a/src/scripts/Providers/OSUI/Datepicker/Flatpickr/AbstractFlatpickr.ts
+++ b/src/scripts/Providers/OSUI/Datepicker/Flatpickr/AbstractFlatpickr.ts
@@ -23,6 +23,8 @@ namespace Providers.OSUI.Datepicker.Flatpickr {
 		protected onSelectedCallbackEvent: OSFramework.OSUI.Patterns.DatePicker.Callbacks.OSOnChangeEvent;
 		// Property to store a custom callback called on OnClose Flatpickr event
 		public onCloseCustomCallback = undefined;
+		// Property to store a custom callback called on OnOpen Flatpickr event
+		public onOpenCustomCallback = undefined;
 
 		constructor(uniqueId: string, configs: C) {
 			super(uniqueId, configs);
@@ -32,6 +34,8 @@ namespace Providers.OSUI.Datepicker.Flatpickr {
 
 			// Set the default library Event handler that will be used to set on the provider configs
 			this.configs.OnClose = this.onDatePickerClose.bind(this);
+
+			this.configs.OnOpen = this.onDatePickerOpen.bind(this);
 		}
 
 		// Method used to set the needed HTML attributes
@@ -252,6 +256,28 @@ namespace Providers.OSUI.Datepicker.Flatpickr {
 				typeof this.onCloseCustomCallback === OSFramework.OSUI.Constants.JavaScriptTypes.Function
 			) {
 				this.onCloseCustomCallback(this.provider);
+			}
+		}
+
+		/**
+		 * Method used to add the custom callback to the OnOpen event and add the tabindex for the today button
+		 *
+		 * @protected
+		 * @memberof AbstractFlatpickr
+		 */
+		protected onDatePickerOpen(): void {
+			// Add the tabindex for the link inside the today button if it exists
+			if (this.configs.ShowTodayButton && this._todayButtonElem) {
+				OSFramework.OSUI.Helper.A11Y.TabIndexTrue(
+					this._todayButtonElem.querySelector(OSFramework.OSUI.GlobalEnum.HTMLElement.Link)
+				);
+			}
+			// Call the custom callback provided for users to add custom code when a datepicker opens
+			if (
+				this.onOpenCustomCallback !== undefined &&
+				typeof this.onOpenCustomCallback === OSFramework.OSUI.Constants.JavaScriptTypes.Function
+			) {
+				this.onOpenCustomCallback(this.provider);
 			}
 		}
 

--- a/src/scripts/Providers/OSUI/Datepicker/Flatpickr/AbstractFlatpickr.ts
+++ b/src/scripts/Providers/OSUI/Datepicker/Flatpickr/AbstractFlatpickr.ts
@@ -126,7 +126,14 @@ namespace Providers.OSUI.Datepicker.Flatpickr {
 
 			// Create the TodayBtn element
 			const todayBtn = document.createElement(OSFramework.OSUI.GlobalEnum.HTMLElement.Link);
-			OSFramework.OSUI.Helper.A11Y.TabIndexTrue(todayBtn);
+
+			// Set the tabindex for the today button
+			if (this.provider.isOpen) {
+				OSFramework.OSUI.Helper.A11Y.TabIndexTrue(todayBtn);
+			} else {
+				OSFramework.OSUI.Helper.A11Y.TabIndexFalse(todayBtn);
+			}
+
 			const langCode = l10ns.TodayBtn[this.configs.Lang] !== undefined ? this.configs.Lang : 'en';
 
 			todayBtn.innerHTML = l10ns.TodayBtn[langCode].title;

--- a/src/scripts/Providers/OSUI/Datepicker/Flatpickr/AbstractFlatpickr.ts
+++ b/src/scripts/Providers/OSUI/Datepicker/Flatpickr/AbstractFlatpickr.ts
@@ -280,13 +280,6 @@ namespace Providers.OSUI.Datepicker.Flatpickr {
 					this._todayButtonElem.querySelector(OSFramework.OSUI.GlobalEnum.HTMLElement.Link)
 				);
 			}
-			// Call the custom callback provided for users to add custom code when a datepicker opens
-			if (
-				this.onOpenCustomCallback !== undefined &&
-				typeof this.onOpenCustomCallback === OSFramework.OSUI.Constants.JavaScriptTypes.Function
-			) {
-				this.onOpenCustomCallback(this.provider);
-			}
 		}
 
 		/**

--- a/src/scripts/Providers/OSUI/Datepicker/Flatpickr/AbstractFlatpickr.ts
+++ b/src/scripts/Providers/OSUI/Datepicker/Flatpickr/AbstractFlatpickr.ts
@@ -240,9 +240,11 @@ namespace Providers.OSUI.Datepicker.Flatpickr {
 				this.onDateSelectedEvent(this.provider.selectedDates);
 			}
 
-			// Remove the tabindex from the today button if it exists
+			// Remove the tabindex from the link inside the today button if it exists
 			if (this.configs.ShowTodayButton && this._todayButtonElem) {
-				OSFramework.OSUI.Helper.A11Y.TabIndexFalse(this._todayButtonElem);
+				OSFramework.OSUI.Helper.A11Y.TabIndexFalse(
+					this._todayButtonElem.querySelector(OSFramework.OSUI.GlobalEnum.HTMLElement.Link)
+				);
 			}
 			// Call the custom callback provided for users to add custom code when a datepicker close
 			if (

--- a/src/scripts/Providers/OSUI/Datepicker/Flatpickr/AbstractFlatpickr.ts
+++ b/src/scripts/Providers/OSUI/Datepicker/Flatpickr/AbstractFlatpickr.ts
@@ -228,8 +228,8 @@ namespace Providers.OSUI.Datepicker.Flatpickr {
 		}
 
 		/**
-		 * Method used to update the datepicker value when the selected dates is empty
-		 * And to add the custom callback to the OnClose event
+		 * Method used to update the datepicker value when the selected dates are empty,
+		 * to add the custom callback to the OnClose event and remove the tabindex from the today button
 		 *
 		 * @protected
 		 * @memberof AbstractFlatpickr
@@ -240,6 +240,10 @@ namespace Providers.OSUI.Datepicker.Flatpickr {
 				this.onDateSelectedEvent(this.provider.selectedDates);
 			}
 
+			// Remove the tabindex from the today button if it exists
+			if (this.configs.ShowTodayButton && this._todayButtonElem) {
+				OSFramework.OSUI.Helper.A11Y.TabIndexFalse(this._todayButtonElem);
+			}
 			// Call the custom callback provided for users to add custom code when a datepicker close
 			if (
 				this.onCloseCustomCallback !== undefined &&

--- a/src/scripts/Providers/OSUI/Datepicker/Flatpickr/AbstractFlatpickr.ts
+++ b/src/scripts/Providers/OSUI/Datepicker/Flatpickr/AbstractFlatpickr.ts
@@ -35,6 +35,7 @@ namespace Providers.OSUI.Datepicker.Flatpickr {
 			// Set the default library Event handler that will be used to set on the provider configs
 			this.configs.OnClose = this.onDatePickerClose.bind(this);
 
+			// Set the default library Event handler that will be used to set on the provider configs
 			this.configs.OnOpen = this.onDatePickerOpen.bind(this);
 		}
 

--- a/src/scripts/Providers/OSUI/Datepicker/Flatpickr/AbstractFlatpickr.ts
+++ b/src/scripts/Providers/OSUI/Datepicker/Flatpickr/AbstractFlatpickr.ts
@@ -23,8 +23,6 @@ namespace Providers.OSUI.Datepicker.Flatpickr {
 		protected onSelectedCallbackEvent: OSFramework.OSUI.Patterns.DatePicker.Callbacks.OSOnChangeEvent;
 		// Property to store a custom callback called on OnClose Flatpickr event
 		public onCloseCustomCallback = undefined;
-		// Property to store a custom callback called on OnOpen Flatpickr event
-		public onOpenCustomCallback = undefined;
 
 		constructor(uniqueId: string, configs: C) {
 			super(uniqueId, configs);

--- a/src/scripts/Providers/OSUI/Datepicker/Flatpickr/AbstractFlatpickrConfig.ts
+++ b/src/scripts/Providers/OSUI/Datepicker/Flatpickr/AbstractFlatpickrConfig.ts
@@ -45,6 +45,9 @@ namespace Providers.OSUI.Datepicker.Flatpickr {
 		// Set the OnClose callback to be used whenever the Flatpickr close
 		public OnClose: OSFramework.OSUI.GlobalCallbacks.Generic;
 
+		// Set the OnOpen callback to be used whenever the Flatpickr opens
+		public OnOpen: OSFramework.OSUI.GlobalCallbacks.Generic;
+
 		constructor(config: JSON) {
 			super(config);
 
@@ -203,6 +206,7 @@ namespace Providers.OSUI.Datepicker.Flatpickr {
 				minDate: this._validateDate(this.MinDate),
 				onChange: this.OnChange,
 				onClose: this.OnClose,
+				onOpen: this.OnOpen,
 				time_24hr: this.TimeFormat === OSFramework.OSUI.Patterns.DatePicker.Enum.TimeFormatMode.Time24hFormat,
 				updateInputVal: false, // (*)
 				weekNumbers: this.ShowWeekNumbers,


### PR DESCRIPTION
### What was happening

- Issue where the "Today's" button in the DatePicker/DatePickerRange components did not have a `tabindex = -1` when the DatePicker was closed.
- This occurred when the ShowTodayButton option was set to True and the DatePicker/DatePickerRange instance was closed.

### What was done

- Changed the OnClose handler to set properly `tabindex = -1` when closing the DatePicker/DatePickerRange.
- Added a new OnOpen handler to set properly `tabindex = 0` when opening the DatePicker/DatePickerRange.
- Changed `addTodayBtn()` to set `tabindex = -1` when opened and `tabindex = 0` when closed.

### Test Steps

1. Go to the DatePicker sample screen
2. Enable ShowTodayButton
3. Clicked on Apply 
4. Open the DatePicker 
5. Check the today button works and has `tabindex = 0`
6. Close the Date Picker
7.  Check the Today button has `tabindex = -1`
8. Repeat the same test for DatePickerRange

### Checklist

-   [X] tested locally
-   [X] documented the code
-   [X] clean all warnings and errors of eslint
-   [ ] requires changes in OutSystems 
-   [ ] requires new sample page in OutSystems 