### PR TITLE
ROU-10927: Fixed DatePicker/Range inline having position-fixed rule breaking the UI expected when inline

### DIFF
--- a/src/scripts/Providers/OSUI/SharedProviderResources/Flatpickr/scss/_flatpickr.scss
+++ b/src/scripts/Providers/OSUI/SharedProviderResources/Flatpickr/scss/_flatpickr.scss
@@ -34,8 +34,8 @@
 		}
 	}
 
-	// Has Time
-	&.hasTime {
+	// Has Time and used inline
+	&.hasTime:not(.inline) {
 		/* This will implement a workaround:
 		* 	- When Time is present and a date is selected, library will set focus to the Time input,
 		*   If Time input is not inside at the screen boundaries, browser will force a document scroll in order
@@ -43,7 +43,9 @@
 		*   to a place where then it's not possible to came from.
 		**/
 		position: fixed;
-
+	}
+	// Has Time
+	&.hasTime {
 		.flatpickr-time {
 			border: var(--border-size-none);
 			height: 30px;


### PR DESCRIPTION
### What was happening

- Issue causing misalignment in the DatePicker/DatePickerRange components when used inline:

![image](https://github.com/user-attachments/assets/201c7082-04e8-4f80-8e30-d3b4208f0bc8)


### What was done

- Changed the CSS selector to cover the **inline** scenario

### Test Steps

-**Test 1:**
    - Open the "Tests_DatePicker" test page for the date picker
    - Set params in the "SetProviderConfigs" block with  "inline" = "true"
    - Click  on the button with the text "Apply Provider Configs"
    - Check the calendar is now inline and visible 
    - Switches "ParameterChange (Enable Today button)" to True
    - Check the Today’s button appears
    - Repeated the same test at "Tests_DatePickerRange"

-**Test 2 - Regression:**
    - Review test from where the issue was added `ROU-4542`
    - Open Sample screen
    - Set the browser window size as 1200x680
    - Click ApplyBtn
    - Set time as enabled
    - Click on DatePicker input
    - Select a Date on the DatePicker
    - Confirm window scroll does not occur and focus is getting done at the time input as well

### Screenshots

![image](https://github.com/user-attachments/assets/11af5aa2-8e71-4761-99f2-a849c8cb445f)



### Checklist

-   [X] tested locally
-   [X] documented the code
-   [X] clean all warnings and errors of eslint
-   [ ] requires changes in OutSystems 
-   [ ] requires new sample page in OutSystems
