### PR TITLE
Fix memory leak in AbstractProviderPattern

### DIFF
--- a/src/scripts/OSFramework/OSUI/Pattern/AbstractProviderPattern.ts
+++ b/src/scripts/OSFramework/OSUI/Pattern/AbstractProviderPattern.ts
@@ -17,6 +17,8 @@ namespace OSFramework.OSUI.Patterns {
 		private _asyncInvocationId = 0;
 		// Holds the callback for the provider config applied event
 		private _platformEventProviderConfigsAppliedCallback: GlobalCallbacks.OSGeneric;
+		// Holds the callback for the redraw event
+		private _redrawCallback: GlobalCallbacks.Generic;
 		// Holds the provider
 		private _provider: P;
 		// Holds the provider info
@@ -161,9 +163,10 @@ namespace OSFramework.OSUI.Patterns {
 			};
 
 			// Force provider redraw/update when rtl is changed in runtime
+			this._redrawCallback = this.redraw.bind(this);
 			OSFramework.OSUI.Event.DOMEvents.Observers.GlobalObserverManager.Instance.addHandler(
 				Event.DOMEvents.Observers.ObserverEvent.RTL,
-				this.redraw.bind(this)
+				this._redrawCallback
 			);
 
 			super.build();
@@ -206,8 +209,9 @@ namespace OSFramework.OSUI.Patterns {
 		public dispose(): void {
 			OSFramework.OSUI.Event.DOMEvents.Observers.GlobalObserverManager.Instance.removeHandler(
 				Event.DOMEvents.Observers.ObserverEvent.RTL,
-				this.redraw.bind(this)
+				this._redrawCallback
 			);
+			this._redrawCallback = null;
 
 			super.dispose();
 		}


### PR DESCRIPTION
Calling Function.bind() during addHandler and removeHandler causes the two handlers to be different Function objects, and therefore the removeHandler would not remove the handler as intended. The map inside GlobalObserverManager storing all handlers would grow without bounds, keeping references to AbstractProviderPattern objects even after they have been disposed.


### What was happening

- Application memory was growing without bounds as user navigates between pages.

### What was done

- Changed the addHandler/removeHandler calls to use the same Function object, so removeHandler would remove the handler as intended.

### Test Steps

1. On an application that has multiple OutSystems UI patterns (we've detected this in the DatePicker pattern, but others are likely affected), have the user navigate between screens multiple times.
3. This will create and destroy patterns (e.g. DatePicker objects).
4. See the memory usage, always growing, pointing towards a memory leak.
5. With a memory profiler, we can see multiple provider instances (e.g. Flatpickr objects) still in memory, even though many of these instances were already destroyed by navigating away from the screen.

### Screenshots

N/A

### Checklist

-   [x] tested locally
-   [x] documented the code
-   [x] clean all warnings and errors of eslint
-   [ ] requires changes in OutSystems (if so, provide a module with changes)
-   [ ] requires new sample page in OutSystems (if so, provide a module with changes)
