### PR TITLE
ROU-11016: Fix SetMenuIconListeners

### DIFF
--- a/src/scripts/OutSystems/OSUI/Utils/Menu.ts
+++ b/src/scripts/OutSystems/OSUI/Utils/Menu.ts
@@ -311,7 +311,7 @@ namespace OutSystems.OSUI.Utils.Menu {
 				if (menuIcon) {
 					const menuIconOnKeypress = function (e) {
 						//If enter or space use the menuIcon to validate
-						if (e.keyCode === '32' || e.keyCode === '13') {
+						if (e.keyCode === 32 || e.keyCode === 13) {
 							e.preventDefault();
 							e.stopPropagation();
 							ToggleSideMenu();


### PR DESCRIPTION
This PR is for fixing an issue that prevented MenuIcon from receiving the focus and triggering the associated action when navigating with the keyboard.

### What was happening

- This issue occurred when using the Tab key to reach the MenuIcon on phone or tablet-sized displays, and pressing Enter or Space did not activate the Menu Icon as expected.

### What was done

- Fixed the way the keyCodes were being (incorrectly) validated as strings instead of numbers. 

### Test Steps

1. Go to a sample screen with Menu Icon
2. Resize the screen to tablet or mobile display
3. Tab to the menu icon
4. Press enter and space key
5. Check that the menu opens

### Screenshots

- After the fix:

![MenuIconTabs](https://github.com/user-attachments/assets/60db910d-e8a4-464f-9223-b5a4ed8145a2)


### Checklist

-   [X] tested locally
-   [X] documented the code
-   [X] clean all warnings and errors of eslint
-   [ ] requires changes in OutSystems
-   [ ] requires new sample page in OutSystems
