### PR TITLE
ROU-11042: fix button-group validation message

### DIFF
--- a/src/scss/03-widgets/_button-group.scss
+++ b/src/scss/03-widgets/_button-group.scss
@@ -53,6 +53,11 @@
 			color: var(--color-neutral-0);
 		}
 	}
+
+	// Fix validation message position
+	&.not-valid {
+		position: relative;
+	}
 }
 
 /* Button Group when used inside Header Content Placeholder */

--- a/src/scss/03-widgets/_button-group.scss
+++ b/src/scss/03-widgets/_button-group.scss
@@ -57,6 +57,11 @@
 	// Fix validation message position
 	&.not-valid {
 		position: relative;
+
+		.validation-message {
+			bottom: -12px;
+			position: relative;
+		}
 	}
 }
 

--- a/src/scss/O11.OutSystemsUI.scss
+++ b/src/scss/O11.OutSystemsUI.scss
@@ -17,7 +17,7 @@ PS: This comment block will not be visible in the compiled version!
 =============================================================================== */
 
 /*!
-OutSystems UI 2.19.2 • O11 Platform
+OutSystems UI 2.19.3 • O11 Platform
 Website:
  • https://www.outsystems.com/outsystems-ui
 GitHub:

--- a/src/scss/ODC.OutSystemsUI.scss
+++ b/src/scss/ODC.OutSystemsUI.scss
@@ -17,7 +17,7 @@ PS: This comment block will not be visible in the compiled version!
 =============================================================================== */
 
 /*!
-OutSystems UI 2.19.2 • ODC Platform
+OutSystems UI 2.19.3 • ODC Platform
 Website:
  • https://www.outsystems.com/outsystems-ui
 GitHub:


### PR DESCRIPTION
This PR is for fixing the position of the ButtonGroup's validation message.

Before:
<img width="1234" alt="Screenshot 2024-08-22 at 11 33 23" src="https://github.com/user-attachments/assets/8d47ba41-3281-4301-ac26-1803fb5368d2">

After:
<img width="1216" alt="Screenshot 2024-08-22 at 11 32 39" src="https://github.com/user-attachments/assets/b1c937b9-7124-451c-bed3-87e4da65db1d">

### Checklist

-   [ ] tested locally
-   [ ] documented the code
-   [ ] clean all warnings and errors of eslint
-   [ ] requires changes in OutSystems (if so, provide a module with changes)
-   [ ] requires new sample page in OutSystems (if so, provide a module with changes)
