### PR TITLE
ROU-11053: Fix SideMenu items losing focus while navigating using the keyboard

### DIFF
--- a/src/scripts/OutSystems/OSUI/Utils/Menu.ts
+++ b/src/scripts/OutSystems/OSUI/Utils/Menu.ts
@@ -2,6 +2,9 @@
 namespace OutSystems.OSUI.Utils.Menu {
 	// OrientationChange callback to be stored and removed on Destroy
 	let _onOrientationChangeCallback: OSFramework.OSUI.GlobalCallbacks.Generic;
+	// Focusable elements on the menu context sine it's different from the default constant that excludes disabled elements with tabindex=-1
+	const MenuFocusableElems =
+		'a[href]:not([disabled]), [tabindex=], button:not([disabled]), textarea:not([disabled]), input:not([disabled]), select:not([disabled])';
 
 	// OrientationChange handler
 	function _onOrientationChangeCallbackHandler(callback: OSFramework.OSUI.GlobalCallbacks.Generic): void {
@@ -220,7 +223,7 @@ namespace OutSystems.OSUI.Utils.Menu {
 					OSFramework.OSUI.Helper.Dom.Styles.ContainsClass(layout, 'menu--visible');
 
 				if (menu) {
-					let focusableEls = menu.querySelectorAll(OSFramework.OSUI.Constants.FocusableElems);
+					let focusableEls = menu.querySelectorAll(MenuFocusableElems);
 					focusableEls = [].slice.call(focusableEls);
 					if (isExpanded) {
 						menu.setAttribute('tabindex', '0');

--- a/src/scripts/OutSystems/OSUI/Utils/Menu.ts
+++ b/src/scripts/OutSystems/OSUI/Utils/Menu.ts
@@ -2,6 +2,8 @@
 namespace OutSystems.OSUI.Utils.Menu {
 	// OrientationChange callback to be stored and removed on Destroy
 	let _onOrientationChangeCallback: OSFramework.OSUI.GlobalCallbacks.Generic;
+	// OnResize callback to be stored and removed on Destroy
+	let _onResizeCallback: OSFramework.OSUI.GlobalCallbacks.Generic;
 	// Focusable elements on the menu context sine it's different from the default constant that excludes disabled elements with tabindex=-1
 	const MenuFocusableElems =
 		'a[href]:not([disabled]), [tabindex], button:not([disabled]), textarea:not([disabled]), input:not([disabled]), select:not([disabled])';
@@ -11,6 +13,15 @@ namespace OutSystems.OSUI.Utils.Menu {
 		if (callback !== undefined) {
 			setTimeout(function () {
 				_onOrientationChangeCallback();
+			}, 300);
+		}
+	}
+
+	// OnResize handler
+	function _onResizeCallbackHandler(callback: OSFramework.OSUI.GlobalCallbacks.Generic): void {
+		if (callback !== undefined) {
+			setTimeout(function () {
+				_onResizeCallback();
 			}, 300);
 		}
 	}
@@ -27,6 +38,22 @@ namespace OutSystems.OSUI.Utils.Menu {
 			OSFramework.OSUI.Event.DOMEvents.Listeners.GlobalListenerManager.Instance.addHandler(
 				OSFramework.OSUI.Event.DOMEvents.Listeners.Type.OrientationChange,
 				_onOrientationChangeCallbackHandler
+			);
+		}
+	}
+
+	/**
+	 * Method that add the OnResize handler
+	 *
+	 * @export
+	 * @param {OSFramework.OSUI.GlobalCallbacks.Generic} callback
+	 */
+	export function AddMenuOnResize(callback: OSFramework.OSUI.GlobalCallbacks.Generic): void {
+		if (callback !== undefined) {
+			_onResizeCallback = callback;
+			OSFramework.OSUI.Event.DOMEvents.Listeners.GlobalListenerManager.Instance.addHandler(
+				OSFramework.OSUI.Event.DOMEvents.Listeners.Type.WindowResize,
+				_onResizeCallbackHandler
 			);
 		}
 	}
@@ -136,6 +163,19 @@ namespace OutSystems.OSUI.Utils.Menu {
 				_onOrientationChangeCallbackHandler
 			);
 			_onOrientationChangeCallback = undefined;
+		}
+	}
+
+	/**
+	 * Method that removes the OnResize handler
+	 */
+	export function RemoveMenuOnResize(): void {
+		if (_onResizeCallback !== undefined) {
+			OSFramework.OSUI.Event.DOMEvents.Listeners.GlobalListenerManager.Instance.removeHandler(
+				OSFramework.OSUI.Event.DOMEvents.Listeners.Type.WindowResize,
+				_onResizeCallbackHandler
+			);
+			_onResizeCallback = undefined;
 		}
 	}
 

--- a/src/scripts/OutSystems/OSUI/Utils/Menu.ts
+++ b/src/scripts/OutSystems/OSUI/Utils/Menu.ts
@@ -4,7 +4,7 @@ namespace OutSystems.OSUI.Utils.Menu {
 	let _onOrientationChangeCallback: OSFramework.OSUI.GlobalCallbacks.Generic;
 	// Focusable elements on the menu context sine it's different from the default constant that excludes disabled elements with tabindex=-1
 	const MenuFocusableElems =
-		'a[href]:not([disabled]), [tabindex=], button:not([disabled]), textarea:not([disabled]), input:not([disabled]), select:not([disabled])';
+		'a[href]:not([disabled]), [tabindex], button:not([disabled]), textarea:not([disabled]), input:not([disabled]), select:not([disabled])';
 
 	// OrientationChange handler
 	function _onOrientationChangeCallbackHandler(callback: OSFramework.OSUI.GlobalCallbacks.Generic): void {

--- a/src/scripts/OutSystems/OSUI/Utils/Menu.ts
+++ b/src/scripts/OutSystems/OSUI/Utils/Menu.ts
@@ -359,10 +359,7 @@ namespace OutSystems.OSUI.Utils.Menu {
 						const isTabPressed = e.key === 'Tab' || e.keyCode === 9;
 						const isEscapedPressed = e.key === 'Escape' || e.keyCode === 27;
 						const isShiftKey = e.shiftKey;
-						const focusableEls = OSFramework.OSUI.Helper.Dom.TagSelectorAll(
-							menu,
-							OSFramework.OSUI.Constants.FocusableElems
-						);
+						const focusableEls = OSFramework.OSUI.Helper.Dom.TagSelectorAll(menu, MenuFocusableElems);
 
 						const firstFocusableEl = focusableEls[0] as HTMLElement;
 						const lastFocusableEl = focusableEls[focusableEls.length - 1] as HTMLElement;
@@ -382,7 +379,7 @@ namespace OutSystems.OSUI.Utils.Menu {
 
 						isExpanded = OSFramework.OSUI.Helper.Dom.Styles.ContainsClass(layout, 'menu-visible');
 
-						//If esc, Close Menu
+						//If ESC, Close Menu
 						if (isExpanded && isEscapedPressed) {
 							e.preventDefault();
 							e.stopPropagation();
@@ -451,9 +448,9 @@ namespace OutSystems.OSUI.Utils.Menu {
 		const result = OutSystems.OSUI.Utils.CreateApiResponse({
 			errorCode: ErrorCodes.Utilities.FailToggleSideMenu,
 			callback: () => {
-				const layout = document.querySelector('.layout');
-				const menu = document.querySelector('.app-menu-content') as HTMLElement;
-				const menuIcon = document.querySelector('.menu-icon') as HTMLElement;
+				const layout = OSFramework.OSUI.Helper.Dom.ClassSelector(document, 'layout');
+				const menu = OSFramework.OSUI.Helper.Dom.ClassSelector(document, 'app-menu-content');
+				const menuIcon = OSFramework.OSUI.Helper.Dom.ClassSelector(document, 'menu-icon');
 
 				if (layout && menu) {
 					let isExpanded = layout.classList.contains('menu-visible');

--- a/src/scripts/OutSystems/OSUI/Utils/Menu.ts
+++ b/src/scripts/OutSystems/OSUI/Utils/Menu.ts
@@ -417,7 +417,9 @@ namespace OutSystems.OSUI.Utils.Menu {
 							return;
 						}
 
-						isExpanded = OSFramework.OSUI.Helper.Dom.Styles.ContainsClass(layout, 'menu-visible');
+						isExpanded =
+							OSFramework.OSUI.Helper.Dom.Styles.ContainsClass(layout, 'menu-visible') ||
+							OSFramework.OSUI.Helper.Dom.Styles.ContainsClass(layout, 'menu--visible');
 
 						//If ESC, Close Menu
 						if (isExpanded && isEscapedPressed) {


### PR DESCRIPTION
This PR is for fixing an issue causing the SideMenu items to lose focus while navigating using the keyboard.

### What was happening

- There was an issue causing the SideMenu items to lose focus while navigating using the keyboard.

### What was done

- A new constant was created to get all focusable elements in the context of the Menu that were not getting elements with `tabindex=-1` and because of that, they were not getting their accessibility attributes updated.

### Test Steps

1. Go to a screen using Side Menu and resize it to a mobile/tablet size
2. Go to the Menu Icon using the Tab key
3. Open and close using Enter/Space
4. Check that once we open, close and open again we can now see all elements being properly reached

### Checklist

-   [X] tested locally
-   [X] documented the code
-   [X] clean all warnings and errors of eslint
-   [ ] requires changes in OutSystems 
-   [ ] requires new sample page in OutSystems
