### PR TITLE
ROU-11113: DatePicker - Fix DatePicker and DatePickerRange hidden input visibility

### DIFF
--- a/src/scripts/OSFramework/OSUI/Pattern/DatePicker/scss/_datepicker.scss
+++ b/src/scripts/OSFramework/OSUI/Pattern/DatePicker/scss/_datepicker.scss
@@ -31,16 +31,16 @@
 			color: var(--color-neutral-6);
 			pointer-events: none;
 		}
-	}
-	
-	// Hide the platform input which is set as hidden by the library and we're change it into the expected type, however we do not want it visible since library will add a clone to better deal with the selected dates.
-	// We cannot use the provider class since the provider class will not be taken into consideration on the input widget react lifecycle
-	& > span > input:first-of-type {
-		display: none;
 
-		// Make the platform input visible in Service Studio
-		& {
-			-servicestudio-display: inline-flex !important;
+		// Hide the platform input which is set as hidden by the library and we're change it into the expected type, however we do not want it visible since library will add a clone to better deal with the selected dates.
+		// We cannot use the provider class since the provider class will not be taken into consideration on the input widget react lifecycle
+		&:first-of-type {
+			display: none;
+
+			// Make the platform input visible in Service Studio
+			& {
+				-servicestudio-display: inline-flex !important;
+			}
 		}
 	}
 


### PR DESCRIPTION
### What was happening
- Hidden input (added through OutSystems platform) was being visible when DatePicker or DatePickerRange was used inside an InputWithIcon pattern.

### What was done
- Updated the selector in order to remove the context to get that first input.

### Screenshots
> Before the fix
> ![Screenshot 2024-08-29 at 14 26 08](https://github.com/user-attachments/assets/16c5583b-69c9-41d4-b68b-d90c58f5bc36)

> After the fix
> ![Screenshot 2024-08-29 at 14 26 19](https://github.com/user-attachments/assets/ccdc7fce-67cb-48b4-876f-7120f7a5551f)
