### PR TITLE
ROU-11189: DropdownServerSide, FloatingActions and BottomSheet

### DIFF
--- a/src/scripts/OSFramework/OSUI/Pattern/BottomSheet/scss/_bottomsheet.scss
+++ b/src/scripts/OSFramework/OSUI/Pattern/BottomSheet/scss/_bottomsheet.scss
@@ -135,14 +135,16 @@
 				opacity: 0;
 				position: absolute;
 				transform: translateY(-2px);
-				transition: opacity 200ms ease, transform 200ms var(--osui-bottom-sheet-transition-function);
+				transition:
+					opacity 200ms ease,
+					transform 200ms var(--osui-bottom-sheet-transition-function);
 				top: 0;
 				width: 100%;
 				z-index: var(--layer-global-negative);
 			}
 
 			&:empty {
-				padding-bottom: none;
+				padding-bottom: unset;
 			}
 		}
 	}

--- a/src/scripts/OSFramework/OSUI/Pattern/Dropdown/ServerSide/DropdownServerSide.ts
+++ b/src/scripts/OSFramework/OSUI/Pattern/Dropdown/ServerSide/DropdownServerSide.ts
@@ -26,6 +26,8 @@ namespace OSFramework.OSUI.Patterns.Dropdown.ServerSide {
 		private _balloonSearchInputElement: HTMLElement;
 		// Store the HTML element for the DropdownBalloonSearch
 		private _balloonSearchInputWrapperElement: HTMLElement;
+		// Store the HTML element for the DropdownBalloonSearchIcon
+		private _balloonSearchInputIconWrapperElement: HTMLElement;
 		// Store a Flag property that will help dealing with the focus state at the close moment
 		private _closeDynamically = false;
 		// Custom Balloon Event
@@ -113,15 +115,21 @@ namespace OSFramework.OSUI.Patterns.Dropdown.ServerSide {
 		}
 
 		// Close when click outside of pattern
-		private _onBodyClick(): void {
+		private _onBodyClick(eventName: string, event: PointerEvent): void {
 			if (this._isOpen === false) {
 				return;
 			}
 
 			this._closeDynamically = true;
 
+			// Check if balloon can be closed
 			// If it's phone, always close, as it is on popup mode
-			if (Helper.DeviceInfo.IsPhone) {
+			// Also prevent closing when clicking at an element inside search icon placeholder
+			const canClose =
+				Helper.DeviceInfo.IsPhone &&
+				(event.target as HTMLElement).closest(`.${Enum.CssClass.BalloonSearchIcon}`) === null;
+
+			if (canClose) {
 				this._close();
 			}
 		}
@@ -651,6 +659,10 @@ namespace OSFramework.OSUI.Patterns.Dropdown.ServerSide {
 				this.selfElement,
 				Enum.CssClass.BalloonSearch
 			);
+			this._balloonSearchInputIconWrapperElement = Helper.Dom.ClassSelector(
+				this.selfElement,
+				Enum.CssClass.BalloonSearchIcon
+			);
 			this._balloonSearchInputElement = Helper.Dom.TagSelector(
 				this._balloonSearchInputWrapperElement,
 				GlobalEnum.HTMLElement.Input
@@ -696,6 +708,7 @@ namespace OSFramework.OSUI.Patterns.Dropdown.ServerSide {
 			this._balloonOptionsWrapperElement = undefined;
 			this._balloonSearchInputElement = undefined;
 			this._balloonSearchInputWrapperElement = undefined;
+			this._balloonSearchInputIconWrapperElement = undefined;
 			this._balloonElem = undefined;
 			this._selectValuesWrapper = undefined;
 		}

--- a/src/scripts/OSFramework/OSUI/Pattern/Dropdown/ServerSide/DropdownServerSide.ts
+++ b/src/scripts/OSFramework/OSUI/Pattern/Dropdown/ServerSide/DropdownServerSide.ts
@@ -26,8 +26,6 @@ namespace OSFramework.OSUI.Patterns.Dropdown.ServerSide {
 		private _balloonSearchInputElement: HTMLElement;
 		// Store the HTML element for the DropdownBalloonSearch
 		private _balloonSearchInputWrapperElement: HTMLElement;
-		// Store the HTML element for the DropdownBalloonSearchIcon
-		private _balloonSearchInputIconWrapperElement: HTMLElement;
 		// Store a Flag property that will help dealing with the focus state at the close moment
 		private _closeDynamically = false;
 		// Custom Balloon Event
@@ -659,10 +657,6 @@ namespace OSFramework.OSUI.Patterns.Dropdown.ServerSide {
 				this.selfElement,
 				Enum.CssClass.BalloonSearch
 			);
-			this._balloonSearchInputIconWrapperElement = Helper.Dom.ClassSelector(
-				this.selfElement,
-				Enum.CssClass.BalloonSearchIcon
-			);
 			this._balloonSearchInputElement = Helper.Dom.TagSelector(
 				this._balloonSearchInputWrapperElement,
 				GlobalEnum.HTMLElement.Input
@@ -708,7 +702,6 @@ namespace OSFramework.OSUI.Patterns.Dropdown.ServerSide {
 			this._balloonOptionsWrapperElement = undefined;
 			this._balloonSearchInputElement = undefined;
 			this._balloonSearchInputWrapperElement = undefined;
-			this._balloonSearchInputIconWrapperElement = undefined;
 			this._balloonElem = undefined;
 			this._selectValuesWrapper = undefined;
 		}

--- a/src/scripts/OSFramework/OSUI/Pattern/Dropdown/ServerSide/DropdownServerSideEnum.ts
+++ b/src/scripts/OSFramework/OSUI/Pattern/Dropdown/ServerSide/DropdownServerSideEnum.ts
@@ -20,6 +20,7 @@ namespace OSFramework.OSUI.Patterns.Dropdown.ServerSide.Enum {
 		BalloonFooter = 'osui-dropdown-serverside__balloon-footer',
 		BalloonHasNotSearchInput = 'osui-dropdown-serverside__balloon--has-not-search',
 		BalloonSearch = 'osui-dropdown-serverside__balloon-search',
+		BalloonSearchIcon = 'osui-dropdown-serverside__balloon-search-icon',
 		ErrorMessage = 'osui-dropdown-serverside-error-message',
 		IsDisabled = 'osui-dropdown-serverside--is-disabled',
 		IsOpened = 'osui-dropdown-serverside--is-opened',

--- a/src/scss/04-patterns/03-interaction/_floating-actions.scss
+++ b/src/scss/04-patterns/03-interaction/_floating-actions.scss
@@ -87,7 +87,7 @@
 		justify-content: flex-end;
 		margin-bottom: var(--space-base);
 		opacity: 0;
-		transform: translateY(--space-base) translateZ(0);
+		transform: translateY(var(--space-base)) translateZ(0);
 		transition: all 100ms ease-in;
 
 		// Service Studio Preview


### PR DESCRIPTION
This PR will fix some issues at DropdownServerSide, FloatingActions and BottomSheet patterns...

### What was happening

> **DropdownServerSide**
>> If Search Input gets typed text and an icon to clear the input is visible, once the clear input icon gets clicked it will close the Dropdown. This occurs only at phone devices.

> **FloatingActions**
>> CSS selector issue that was preventing intend animation occurs.

> **BottomSheet**
>> CSS invalid property usage.


### What was done

> **DropdownServerSide**
>> Once the click occurs logic was added to prevent the close.

> **FloatingActions**
>> Fixed CSS selector.

> **BottomSheet**
>> Fixed CSS selector.


Note:
This PR will also fix https://github.com/OutSystems/outsystems-ui/issues/989, and https://github.com/OutSystems/outsystems-ui/issues/990