### PR TITLE
ROU-11183: Include OnOrientationChange logic on MenuReady/MenuDestroy

### DIFF
--- a/src/scripts/OSFramework/OSUI/Helper/Device.ts
+++ b/src/scripts/OSFramework/OSUI/Helper/Device.ts
@@ -142,7 +142,7 @@ namespace OSFramework.OSUI.Helper {
 		private static _getUserAgent(userAgent = ''): string {
 			let localUserAgent = userAgent;
 
-			if (userAgent.replace(' ', '') === '') {
+			if (userAgent.replace(/ /g, '') === '') {
 				if (sessionStorage.previewDevicesUserAgent) {
 					localUserAgent = sessionStorage.previewDevicesUserAgent;
 				} else {

--- a/src/scripts/OutSystems/OSUI/Utils/Menu.ts
+++ b/src/scripts/OutSystems/OSUI/Utils/Menu.ts
@@ -56,7 +56,7 @@ namespace OutSystems.OSUI.Utils.Menu {
 
 	// Method that add the OrientationChange handler, used only for TabletApps (Template_TabletApp > Menu)
 	const _addMenuOnOrientationChange = (callback: OSFramework.OSUI.GlobalCallbacks.Generic): void => {
-		if (callback !== undefined) {
+		if (callback && OSFramework.OSUI.Helper.DeviceInfo.IsTablet) {
 			_onOrientationChangeCallback = callback;
 			OSFramework.OSUI.Event.DOMEvents.Listeners.GlobalListenerManager.Instance.addHandler(
 				OSFramework.OSUI.Event.DOMEvents.Listeners.Type.OrientationChange,
@@ -114,8 +114,8 @@ namespace OutSystems.OSUI.Utils.Menu {
 
 	// OrientationChange handler
 	const _onOrientationChangeCallbackHandler = (callback: OSFramework.OSUI.GlobalCallbacks.Generic): void => {
-		if (callback !== undefined) {
-			setTimeout(function () {
+		if (callback) {
+			OSFramework.OSUI.Helper.ApplySetTimeOut(() => {
 				_onOrientationChangeCallback();
 			}, 300);
 		}
@@ -160,7 +160,7 @@ namespace OutSystems.OSUI.Utils.Menu {
 
 	// Method that removes the OrientationChange handler, used only for TabletApps (Template_TabletApp > Menu)
 	const _removeMenuOnOrientationChange = (): void => {
-		if (_onOrientationChangeCallback !== undefined) {
+		if (_onOrientationChangeCallback && OSFramework.OSUI.Helper.DeviceInfo.IsTablet) {
 			OSFramework.OSUI.Event.DOMEvents.Listeners.GlobalListenerManager.Instance.removeHandler(
 				OSFramework.OSUI.Event.DOMEvents.Listeners.Type.OrientationChange,
 				_onOrientationChangeCallbackHandler
@@ -317,17 +317,11 @@ namespace OutSystems.OSUI.Utils.Menu {
 		_setA11YAttributes();
 	};
 
-	/**
-	 * Method that add the OrientationChange handler, used only for TabletApps (Template_TabletApp > Menu)
-	 *
-	 * @export
-	 * @param {OSFramework.OSUI.GlobalCallbacks.Generic} callback
-	 */
-	export function AddMenuOnOrientationChangeHandler(callback: OSFramework.OSUI.GlobalCallbacks.Generic): void {
-		if (callback !== undefined) {
-			_addMenuOnOrientationChange(callback);
-		}
-	}
+	// Expose the_addMenuOnOrientationChange method, used only for TabletApps (Template_TabletApp > Menu)
+	export const addMenuOnOrientationChange = _addMenuOnOrientationChange;
+
+	// Expose the _removeMenuOnOrientationChange method, used only for TabletApps (Template_TabletApp > Menu)
+	export const removeMenuOnOrientationChange = _removeMenuOnOrientationChange;
 
 	/**
 	 * Checks if the menu can be draggable
@@ -458,9 +452,7 @@ namespace OutSystems.OSUI.Utils.Menu {
 			callback: () => {
 				_removeMenuOnResize();
 				// Remove the OrientationChange handler only for TabletApps
-				if (OSFramework.OSUI.Helper.DeviceInfo.IsTablet) {
-					_removeMenuOnOrientationChange();
-				}
+				_removeMenuOnOrientationChange();
 			},
 		});
 
@@ -480,22 +472,11 @@ namespace OutSystems.OSUI.Utils.Menu {
 				_updatePropsAndAttrs();
 				_addMenuOnResize();
 				// Add the OrientationChange handler only for TabletApps
-				if (OSFramework.OSUI.Helper.DeviceInfo.IsTablet) {
-					_addMenuOnOrientationChange(callback);
-				}
+				_addMenuOnOrientationChange(callback);
 			},
 		});
 
 		return result;
-	}
-
-	/**
-	 * Method that removes the OrientationChange handler
-	 *
-	 * @export
-	 */
-	export function RemoveMenuOnOrientationChangeHandler(): void {
-		_removeMenuOnOrientationChange();
 	}
 
 	/**
@@ -707,9 +688,9 @@ namespace OutSystems.OSUI.Utils.Menu {
 
 				if (_appProp.layout.element && menu) {
 					// Invoking setTimeout to schedule the callback to be run asynchronously
-					setTimeout(function () {
+					OSFramework.OSUI.Helper.AsyncInvocation(() => {
 						_addMenuEventListeners(true);
-					}, 0);
+					});
 				}
 			},
 		});

--- a/src/scripts/OutSystems/OSUI/Utils/Menu.ts
+++ b/src/scripts/OutSystems/OSUI/Utils/Menu.ts
@@ -319,11 +319,11 @@ namespace OutSystems.OSUI.Utils.Menu {
 
 	/**
 	 * Method that add the OrientationChange handler, used only for TabletApps (Template_TabletApp > Menu)
-	 * @deprecated
+	 *
 	 * @export
 	 * @param {OSFramework.OSUI.GlobalCallbacks.Generic} callback
 	 */
-	export function AddMenuOnOrientationChange(callback: OSFramework.OSUI.GlobalCallbacks.Generic): void {
+	export function AddMenuOnOrientationChangeHandler(callback: OSFramework.OSUI.GlobalCallbacks.Generic): void {
 		if (callback !== undefined) {
 			_addMenuOnOrientationChange(callback);
 		}
@@ -491,10 +491,10 @@ namespace OutSystems.OSUI.Utils.Menu {
 
 	/**
 	 * Method that removes the OrientationChange handler
-	 * @deprecated
+	 *
 	 * @export
 	 */
-	export function RemoveMenuOnOrientationChange(): void {
+	export function RemoveMenuOnOrientationChangeHandler(): void {
 		_removeMenuOnOrientationChange();
 	}
 

--- a/src/scripts/OutSystems/OSUI/Utils/Menu.ts
+++ b/src/scripts/OutSystems/OSUI/Utils/Menu.ts
@@ -114,7 +114,7 @@ namespace OutSystems.OSUI.Utils.Menu {
 
 	// OrientationChange handler
 	const _onOrientationChangeCallbackHandler = (callback: OSFramework.OSUI.GlobalCallbacks.Generic): void => {
-		if (callback) {
+		if (typeof callback === 'function') {
 			OSFramework.OSUI.Helper.ApplySetTimeOut(() => {
 				_onOrientationChangeCallback();
 			}, 300);

--- a/src/scripts/OutSystems/OSUI/Utils/Menu.ts
+++ b/src/scripts/OutSystems/OSUI/Utils/Menu.ts
@@ -32,7 +32,7 @@ namespace OutSystems.OSUI.Utils.Menu {
 	const _addMenuEventListeners = (hasTriggeredByAPI = false): void => {
 		// Ensure events will be removed when SetMenuListeners "API" has been triggered and before readding them again
 		if (hasTriggeredByAPI) {
-			_removeMenuEeventListeners();
+			_removeMenuEventListeners();
 		}
 		// Check if the keydown event should be added
 		const shouldKeyDownBeAdded =
@@ -144,14 +144,14 @@ namespace OutSystems.OSUI.Utils.Menu {
 		}
 
 		// Remove the menu event listeners since device type changed
-		_removeMenuEeventListeners();
+		_removeMenuEventListeners();
 
 		// ReAdd the menu event listeners
 		_addMenuEventListeners();
 	};
 
 	// Remove Menu Event Listeners
-	const _removeMenuEeventListeners = (): void => {
+	const _removeMenuEventListeners = (): void => {
 		if (_appProp.menu.hasEventListeners) {
 			_appProp.menu.hasEventListeners = false;
 			_appProp.menu.element.removeEventListener('keydown', _menuOnKeypress);
@@ -324,7 +324,9 @@ namespace OutSystems.OSUI.Utils.Menu {
 	 * @param {OSFramework.OSUI.GlobalCallbacks.Generic} callback
 	 */
 	export function AddMenuOnOrientationChange(callback: OSFramework.OSUI.GlobalCallbacks.Generic): void {
-		_addMenuOnOrientationChange(callback);
+		if (callback !== undefined) {
+			_addMenuOnOrientationChange(callback);
+		}
 	}
 
 	/**

--- a/src/scripts/osui.ts
+++ b/src/scripts/osui.ts
@@ -67,7 +67,7 @@ namespace osui.utils.menu {
 	 */
 	export function AddMenuOnOrientationChanged(callback: OSFramework.OSUI.GlobalCallbacks.Generic): void {
 		console.warn(
-			'osui.utils.menu.AddMenuOnOrientationChanged(), is deprecated. Please use the API `OutSystems.OSUI.Utils.Menu.OnReady(...)`.'
+			'osui.utils.menu.AddMenuOnOrientationChanged(...), is deprecated. Please use the API `OutSystems.OSUI.Utils.Menu.OnReady(...)`.'
 		);
 		return OutSystems.OSUI.Utils.Menu.AddMenuOnOrientationChange(callback);
 	}

--- a/src/scripts/osui.ts
+++ b/src/scripts/osui.ts
@@ -61,24 +61,24 @@ namespace osui {
 	}
 }
 
-namespace osui.utils.menu {
+namespace OutSystems.OSUI.Utils.Menu {
 	/**
-	 * @deprecated use 'OutSystems.OSUI.Utils.Menu.AddMenuOnOrientationChangeHandler(...)' instead.
+	 * @deprecated use 'OutSystems.OSUI.Utils.Menu.OnReady(...)' instead.
 	 */
-	export function AddMenuOnOrientationChanged(callback: OSFramework.OSUI.GlobalCallbacks.Generic): void {
+	export function AddMenuOnOrientationChange(callback: OSFramework.OSUI.GlobalCallbacks.Generic): void {
 		console.warn(
-			'osui.utils.menu.AddMenuOnOrientationChange(...), is deprecated. Please use the API `OutSystems.OSUI.Utils.Menu.AddMenuOnOrientationChangeHandler(...)`.'
+			'OutSystems.OSUI.Utils.Menu.AddMenuOnOrientationChange(...), is deprecated. Please use the API `OutSystems.OSUI.Utils.Menu.OnReady(...)`.'
 		);
-		return OutSystems.OSUI.Utils.Menu.AddMenuOnOrientationChangeHandler(callback);
+		return OutSystems.OSUI.Utils.Menu.addMenuOnOrientationChange(callback);
 	}
 
 	/**
-	 * @deprecated use 'OutSystems.OSUI.Utils.Menu.RemoveMenuOnOrientationChangeHandler()' instead.
+	 * @deprecated use 'OutSystems.OSUI.Utils.Menu.OnDestroy()' instead.
 	 */
 	export function RemoveMenuOnOrientationChange(): void {
 		console.warn(
-			'osui.utils.menu.RemoveMenuOnOrientationChangeHandler(), is deprecated. Please use the API `OutSystems.OSUI.Utils.Menu.RemoveMenuOnOrientationChangeHandler()`.'
+			'OutSystems.OSUI.Utils.Menu.RemoveMenuOnOrientationChange(), is deprecated. Please use the API `OutSystems.OSUI.Utils.Menu.OnDestroy()`.'
 		);
-		return OutSystems.OSUI.Utils.Menu.RemoveMenuOnOrientationChangeHandler();
+		return OutSystems.OSUI.Utils.Menu.removeMenuOnOrientationChange();
 	}
 }

--- a/src/scripts/osui.ts
+++ b/src/scripts/osui.ts
@@ -1,10 +1,16 @@
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 namespace osui {
+	/**
+	 * @deprecated use 'OutSystems.OSUI.GetVersion()' instead.
+	 */
 	export function GetVersion(): string {
 		console.warn('osui.GetVersion(), is deprecated. Please use the API `OutSystems.OSUI.GetVersion()`.');
 		return OutSystems.OSUI.GetVersion();
 	}
 
+	/**
+	 * @deprecated use 'OutSystems.OSUI.Utils.ToggleClass(...)' instead.
+	 */
 	export function ToggleClass(el: HTMLElement, state: unknown, className: string): void {
 		console.warn(
 			'osui.ToggleClass(...), is deprecated. Please use the API `OutSystems.OSUI.Utils.ToggleClass(...)`.'
@@ -12,6 +18,9 @@ namespace osui {
 		OutSystems.OSUI.Utils.ToggleClass(el, state, className);
 	}
 
+	/**
+	 * @deprecated use 'OutSystems.OSUI.GetVersion()' instead.
+	 */
 	export function GetClosest(elem: HTMLElement, selector: string): unknown {
 		console.warn(
 			'osui.GetClosest(...), is deprecated. Please use the API `OutSystems.OSUI.Utils.GetClosest(...)`.'
@@ -19,11 +28,17 @@ namespace osui {
 		return OutSystems.OSUI.Utils.GetClosest(elem, selector);
 	}
 
+	/**
+	 * @deprecated use 'OutSystems.OSUI.Utils.FixInputs(...)' instead.
+	 */
 	export function FixInputs(): void {
 		console.warn('osui.FixInputs(...), is deprecated. Please use the API `OutSystems.OSUI.Utils.FixInputs(...)`.');
 		OutSystems.OSUI.Utils.LayoutPrivate.FixInputs();
 	}
 
+	/**
+	 * @deprecated use 'OutSystems.OSUI.Utils.HasMasterDetail()' instead.
+	 */
 	export function HasMasterDetail(): boolean {
 		console.warn(
 			'osui.HasMasterDetail(), is deprecated. Please use the API `OutSystems.OSUI.Utils.HasMasterDetail()`.'
@@ -31,6 +46,9 @@ namespace osui {
 		return OutSystems.OSUI.Utils.HasMasterDetail();
 	}
 
+	/**
+	 * @deprecated use 'OutSystems.OSUI.Utils.HideOnScroll.Init()' instead.
+	 */
 	export function HideOnScroll(): unknown {
 		console.warn(
 			'osui.HideOnScroll(), is deprecated. Please use the API `OutSystems.OSUI.Utils.HideOnScroll.Init()`.'
@@ -40,5 +58,27 @@ namespace osui {
 				OutSystems.OSUI.Utils.HideOnScroll.Init();
 			},
 		};
+	}
+}
+
+namespace osui.utils.menu {
+	/**
+	 * @deprecated use 'OutSystems.OSUI.Utils.Menu.OnReady(...)' instead.
+	 */
+	export function AddMenuOnOrientationChanged(callback: OSFramework.OSUI.GlobalCallbacks.Generic): void {
+		console.warn(
+			'osui.utils.menu.AddMenuOnOrientationChanged(), is deprecated. Please use the API `OutSystems.OSUI.Utils.Menu.OnReady(...)`.'
+		);
+		return OutSystems.OSUI.Utils.Menu.AddMenuOnOrientationChange(callback);
+	}
+
+	/**
+	 * @deprecated use 'OutSystems.OSUI.Utils.Menu.OnDestroy()' instead.
+	 */
+	export function RemoveMenuOnOrientationChange(): void {
+		console.warn(
+			'osui.utils.menu.RemoveMenuOnOrientationChange(), is deprecated. Please use the API `OutSystems.OSUI.Utils.Menu.OnDestroy()`.'
+		);
+		return OutSystems.OSUI.Utils.Menu.RemoveMenuOnOrientationChange();
 	}
 }

--- a/src/scripts/osui.ts
+++ b/src/scripts/osui.ts
@@ -63,22 +63,22 @@ namespace osui {
 
 namespace osui.utils.menu {
 	/**
-	 * @deprecated use 'OutSystems.OSUI.Utils.Menu.OnReady(...)' instead.
+	 * @deprecated use 'OutSystems.OSUI.Utils.Menu.AddMenuOnOrientationChangeHandler(...)' instead.
 	 */
 	export function AddMenuOnOrientationChanged(callback: OSFramework.OSUI.GlobalCallbacks.Generic): void {
 		console.warn(
-			'osui.utils.menu.AddMenuOnOrientationChanged(...), is deprecated. Please use the API `OutSystems.OSUI.Utils.Menu.OnReady(...)`.'
+			'osui.utils.menu.AddMenuOnOrientationChange(...), is deprecated. Please use the API `OutSystems.OSUI.Utils.Menu.AddMenuOnOrientationChangeHandler(...)`.'
 		);
-		return OutSystems.OSUI.Utils.Menu.AddMenuOnOrientationChange(callback);
+		return OutSystems.OSUI.Utils.Menu.AddMenuOnOrientationChangeHandler(callback);
 	}
 
 	/**
-	 * @deprecated use 'OutSystems.OSUI.Utils.Menu.OnDestroy()' instead.
+	 * @deprecated use 'OutSystems.OSUI.Utils.Menu.RemoveMenuOnOrientationChangeHandler()' instead.
 	 */
 	export function RemoveMenuOnOrientationChange(): void {
 		console.warn(
-			'osui.utils.menu.RemoveMenuOnOrientationChange(), is deprecated. Please use the API `OutSystems.OSUI.Utils.Menu.OnDestroy()`.'
+			'osui.utils.menu.RemoveMenuOnOrientationChangeHandler(), is deprecated. Please use the API `OutSystems.OSUI.Utils.Menu.RemoveMenuOnOrientationChangeHandler()`.'
 		);
-		return OutSystems.OSUI.Utils.Menu.RemoveMenuOnOrientationChange();
+		return OutSystems.OSUI.Utils.Menu.RemoveMenuOnOrientationChangeHandler();
 	}
 }


### PR DESCRIPTION
### What was happening

- The app templates were released with some javascript nodes calling OutSystems UI framework APIs that the Developer doesn't know and that were only present in tablets and for older apps there's some manual work to be done.
- Since we now have `MenuReady` and `MenuDestroy` client actions, we should enclose this logic to avoid having JS nodes spread over the templates.

### What was done

- Included the Orientation Change logic on Menu `OnReady` (this method now receives a callback) and `OnDestroy`
- Deprecated `AddMenuOnOrientationChange` and `RemoveMenuOnOrientationChange`
- Fixed some typos on the `Menu.ts` file
- Added the comments and `@deprecate` symbol to all methods within `osui.ts` file and added a new namespace to fallback the deprecated methods
- Fixed an issue raised by Snyk on the function `_getUserAgent`

### Test Steps

- **Test 1 - Old Apps - Tablet**:
    - Go to a Tablet app
    - Switch between portrait and landscape 
    - Check that the handler is triggered and the `console.warn(...)` on the developer tools console and the listener added
    
- **Test 2 - Old Apps - Phone/Desktop**:
    - Go to a Phone app
    - Switch between portrait and landscape 
    -  Check that no handler is triggered, no message is logged on the developer tools console and no listener is added
    - Repeated the same steps for a Desktop app

- **Test 3 - New Apps - Tablet**:
    - Go to a Tablet app
    - Switch between portrait and landscape 
    - Check that the handler is triggered, no message is logged on the developer tools console and the listener is added
    
- **Test 4 - New Apps - Phone/Desktop**:
    - Go to a Phone app
    - Switch between portrait and landscape 
    - Check that no handler is triggered, no message is logged on the developer tools console and no listener is added
    - Repeated the same steps for a Desktop app

 
### Screenshots



### Checklist

-   [X] tested locally
-   [X] documented the code
-   [X] clean all warnings and errors of eslint
-   [X] requires changes in OutSystems 
-   [ ] requires new sample page in OutSystems 
