### PR TITLE
ROU-11179: DatePicker - Fix an issue when used at certain time zones

### DIFF
--- a/src/scripts/OSFramework/OSUI/Helper/Dates.ts
+++ b/src/scripts/OSFramework/OSUI/Helper/Dates.ts
@@ -80,7 +80,30 @@ namespace OSFramework.OSUI.Helper {
 		 * @memberof Dates
 		 */
 		public static IsValid(date: string): boolean {
-			return !isNaN(Number(new Date(date)));
+			return !isNaN(Number(this.NormalizeDate(date)));
+		}
+
+		/**
+		 * Function used to normalize the OutSystems Dates
+		 *
+		 * @static
+		 * @param {string} date
+		 * @return {*}  {Date}
+		 * @memberof Dates
+		 */
+		public static NormalizeDate(date: string): Date {
+			// Store the current date
+			let currDate: Date;
+
+			// Check if the given date string is a ISO 8601 date format
+			if (date.indexOf('T') > -1) {
+				currDate = new Date(date);
+			} else {
+				// Dates are being sent from platform with '-' instead of '/'
+				currDate = new Date(date.replace(/-/g, '/'));
+			}
+
+			return currDate;
 		}
 
 		/**

--- a/src/scripts/Providers/OSUI/Datepicker/Flatpickr/SingleDate/FlatpickrSingleDate.ts
+++ b/src/scripts/Providers/OSUI/Datepicker/Flatpickr/SingleDate/FlatpickrSingleDate.ts
@@ -22,7 +22,9 @@ namespace Providers.OSUI.Datepicker.Flatpickr.SingleDate {
 					this.datePickerPlatformInputElem.value !== OSFramework.OSUI.Constants.EmptyString &&
 					OSFramework.OSUI.Helper.Dates.IsValid(this.datePickerPlatformInputElem.value)
 				) {
-					this.configs.InitialDate = new Date(this.datePickerPlatformInputElem.value);
+					this.configs.InitialDate = OSFramework.OSUI.Helper.Dates.NormalizeDate(
+						this.datePickerPlatformInputElem.value
+					);
 				} else {
 					// If the date isn't valid, the platform input value will be removed
 					clearPlatformInput = true;


### PR DESCRIPTION
This PR will fix an issue related with certain time zones.

### What was happening

- When used at Pacific time zone (for example) dates do not map to the given ones.
 
![Screenshot 2024-09-25 at 08 44 32](https://github.com/user-attachments/assets/0d2ae9e6-bae4-427d-ad21-0b4ed16376ed)

![Screenshot 2024-09-25 at 16 45 28](https://github.com/user-attachments/assets/446ca256-b9e9-40a2-a1a8-be7e4f0f2fb8)


### What was done

- This was related with the format of the given platform string date, containing "-" as separator instead of "/", new Date() JS function was returning a wrong date because of that.

![Screenshot 2024-09-25 at 09 02 30](https://github.com/user-attachments/assets/9da8e86c-80c1-47bc-8843-beb76dd63133)

