### PR TITLE
ROU-11295: Fix Tabs issue where getting focused while entering the screen

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,6 +67,6 @@
 		"typedoc-plugin-merge-modules": "^4.0.1",
 		"typedoc-umlclass": "^0.7.0",
 		"typescript": "^4.5.0",
-		"virtual-select-plugin": "^1.0.45"
+		"virtual-select-plugin": "^1.0.46"
 	}
 }

--- a/src/scripts/OSFramework/OSUI/Helper/Dates.ts
+++ b/src/scripts/OSFramework/OSUI/Helper/Dates.ts
@@ -52,7 +52,7 @@ namespace OSFramework.OSUI.Helper {
 			// Check if the given date is not a date object and if it's a valid date
 			if (typeof date === 'string') {
 				// Check if string could be parsed into a date - If it has an expected dateformat
-				if (isNaN(Date.parse(date))) {
+				if (Number.isNaN(Date.parse(date))) {
 					throw new Error(`The given date '${date}' it's not a valid date.`);
 				}
 				_date = new Date(Date.parse(date));
@@ -80,7 +80,7 @@ namespace OSFramework.OSUI.Helper {
 		 * @memberof Dates
 		 */
 		public static IsValid(date: string): boolean {
-			return !isNaN(Number(this.NormalizeDate(date)));
+			return !Number.isNaN(Number(this.NormalizeDate(date)));
 		}
 
 		/**

--- a/src/scripts/OSFramework/OSUI/Helper/Times.ts
+++ b/src/scripts/OSFramework/OSUI/Helper/Times.ts
@@ -28,7 +28,7 @@ namespace OSFramework.OSUI.Helper {
 		 * @memberof OSFramework.Helper.Times
 		 */
 		public static IsNull(time: string): boolean {
-			if (isNaN(Date.parse(time))) {
+			if (Number.isNaN(Date.parse(time))) {
 				// Check if the given time is not a time object and if it's a valid time
 				if (typeof time === Constants.JavaScriptTypes.String) {
 					const isValid = /^([0-1]?[0-9]|2[0-4]):([0-5][0-9])(:[0-5][0-9])?$/.test(time);

--- a/src/scripts/OSFramework/OSUI/Pattern/Tabs/Tabs.ts
+++ b/src/scripts/OSFramework/OSUI/Pattern/Tabs/Tabs.ts
@@ -185,7 +185,9 @@ namespace OSFramework.OSUI.Patterns.Tabs {
 				this._activeTabContentElement = newContentItem;
 			}
 
-			if (this._hasDragGestures) {
+			// Set focus on the new active header element when running on a device with drag gestures
+			// and the tabs are built to make sure if only runs after the tabs are built
+			if (this._hasDragGestures && this.isBuilt) {
 				this._activeTabHeaderElement.setFocus();
 			}
 
@@ -397,7 +399,7 @@ namespace OSFramework.OSUI.Patterns.Tabs {
 
 				// If at this moment the active item has no size (NaN), set an observer to run this method when its size is changed
 				// This happens, as an example, when there're tabs inside tabs, and inner one has no size when it's built, due to being on a non-active tab
-				if (isNaN(_finalSize) || _finalSize === 0) {
+				if (Number.isNaN(_finalSize) || _finalSize === 0) {
 					const resizeObserver = new ResizeObserver((entries) => {
 						for (const entry of entries) {
 							if (entry.contentBoxSize) {


### PR DESCRIPTION
### What was happening

- When entering a screen, the Tabs component received focus unexpectedly when navigating to a screen. 
This occurred when having content positioned above the Tabs causing the page to scroll and bringing the Tabs into focus.

https://github.com/user-attachments/assets/9b998c5b-73d8-43a9-a0cb-22a1227d1e4a

### What was done

- A new validation was added to make sure the logic for focusing Tabs headers only happens once Tabs are built.
- Fixed a Snyk finding where we should be using `Number.isNaN(...)` instead of `isNaN(...)`.

### Test Steps

1. Go to sample screen 1 by clicking on a link from the home screen
2. Check that the screen remains at the top
3. Scroll down to the Tabs
4. Change to another Tab by clicking on the header 
5. Check that the tab that was opened got focused as expected
6. Clicking on a button calling the client action `SetActiveTab`
7. Check that the target tab that was opened got focused as expected

### Screenshots

![Workaround](https://github.com/user-attachments/assets/8443fdc9-f587-4b26-ba46-71af9b640afb)


### Checklist

-   [X] tested locally
-   [X] documented the code
-   [X] clean all warnings and errors of eslint
-   [ ] requires changes in OutSystems (if so, provide a module with changes)
-   [ ] requires new sample page in OutSystems (if so, provide a module with changes)
