### PR TITLE
ROU-11287: [OSUI] - Defect with Skip to Content link

### DIFF
--- a/src/scripts/OutSystems/OSUI/Utils/Accessibility.ts
+++ b/src/scripts/OutSystems/OSUI/Utils/Accessibility.ts
@@ -99,6 +99,18 @@ namespace OutSystems.OSUI.Utils.Accessibility {
 	 * @param targetId
 	 */
 	export function SkipToContent(targetId: string): string {
+		// Method to remove tabindex from skipToContent at onBlur
+		function _skipToContentOnBlur(e: FocusEvent): void {
+			OSFramework.OSUI.Helper.AsyncInvocation(() => {
+				const target = e.target as HTMLElement;
+
+				if (target) {
+					OSFramework.OSUI.Helper.Dom.Attribute.Remove(target, 'tabindex');
+					target.removeEventListener(OSFramework.OSUI.GlobalEnum.HTMLEvent.Blur, _skipToContentOnBlur);
+				}
+			});
+		}
+
 		const result = OutSystems.OSUI.Utils.CreateApiResponse({
 			errorCode: ErrorCodes.Utilities.FailSkipToContent,
 			callback: () => {
@@ -110,7 +122,7 @@ namespace OutSystems.OSUI.Utils.Accessibility {
 					if (isFocusable === undefined) {
 						OSFramework.OSUI.Helper.Dom.Attribute.Set(target, 'tabindex', '0');
 						target.focus();
-						OSFramework.OSUI.Helper.Dom.Attribute.Remove(target, 'tabindex');
+						target.addEventListener(OSFramework.OSUI.GlobalEnum.HTMLEvent.Blur, _skipToContentOnBlur);
 					} else {
 						target.focus();
 					}


### PR DESCRIPTION
This PR is for fixing an accessibility issue on the skipToContent link.

### What was happening

- A tabIndex= "0" was added to the main content but removed, and that should only happen after the focus changes to another element.

### What was done

- remove tabIndex on a target blur listener;
- add blur function to remove tab index and listener;

### Test Steps

1. Reach skip to content link using TAB navigation and trigger it
2. Check the main-content element on the dom has tabindex=”0”
3. Use tab or mouse to navigate to other element
4. Check the main-content element on the dom doesn’t have tabindex anymore
5. Check the blur listeners of main-content element, it should have been removed

### Checklist

-   [x] tested locally
-   [x] documented the code
-   [x] clean all warnings and errors of eslint
-   [ ] requires changes in OutSystems (if so, provide a module with changes)
-   [ ] requires new sample page in OutSystems (if so, provide a module with changes)
