### PR TITLE
[ROU-11342]: RadioButton - Fixed styling issue when HighContrast mode is on.

### DIFF
--- a/src/scss/03-widgets/_radio-button.scss
+++ b/src/scss/03-widgets/_radio-button.scss
@@ -153,7 +153,7 @@
 
 		&:focus:before {
 			background-color: var(--color-primary);
-			border: 1px solid var(--color-focus-inner);
+			border-color: var(--color-focus-inner);
 			box-shadow: none;
 		}
 
@@ -163,12 +163,6 @@
 
 		&:hover:before {
 			border-color: var(--color-neutral-8);
-		}
-
-		&:focus:before {
-			background-color: var(--color-primary);
-			border: 1px solid var(--color-focus-inner);
-			box-shadow: none;
 		}
 	}
 

--- a/src/scss/O11.OutSystemsUI.scss
+++ b/src/scss/O11.OutSystemsUI.scss
@@ -17,7 +17,7 @@ PS: This comment block will not be visible in the compiled version!
 =============================================================================== */
 
 /*!
-OutSystems UI 2.20.2 • O11 Platform
+OutSystems UI 2.21.0 • O11 Platform
 Website:
  • https://www.outsystems.com/outsystems-ui
 GitHub:

--- a/src/scss/ODC.OutSystemsUI.scss
+++ b/src/scss/ODC.OutSystemsUI.scss
@@ -17,7 +17,7 @@ PS: This comment block will not be visible in the compiled version!
 =============================================================================== */
 
 /*!
-OutSystems UI 2.20.2 • ODC Platform
+OutSystems UI 2.21.0 • ODC Platform
 Website:
  • https://www.outsystems.com/outsystems-ui
 GitHub:


### PR DESCRIPTION
This PR will fix a styling issue at RadioButton widget.

### What was happening
- When HighContrast mod was on and HasAccessibility features layout attribute was set to True, RadioButton styling was not being set as it should.
- Only happening at Windows.

### What was done
- Redefined the css selector into a specific selector instead of the usage of a shorthand one.

### Screenshots
![radioButtonIssue](https://github.com/user-attachments/assets/fc580d01-43cf-4b72-8a04-9262ab0646c0)

