### PR TITLE
ROU-11384: Adding new css variables to control progress animation speed

### DIFF
--- a/src/scripts/OSFramework/OSUI/Pattern/Progress/Bar/scss/_progressbar.scss
+++ b/src/scripts/OSFramework/OSUI/Pattern/Progress/Bar/scss/_progressbar.scss
@@ -25,12 +25,12 @@
 
 			&.animate {
 				&-entrance .osui-progress-bar__value:before {
-					transition-delay: 0.5s;
+					transition-delay: var(--progress-initial-speed, 0.5s);
 				}
 				&-entrance,
 				&-progress-change {
 					.osui-progress-bar__value:before {
-						transition-duration: 0.35s;
+						transition-duration: var(--progress-speed, 0.35s);
 					}
 				}
 			}

--- a/src/scripts/OSFramework/OSUI/Pattern/Progress/Circle/scss/_progresscircle.scss
+++ b/src/scripts/OSFramework/OSUI/Pattern/Progress/Circle/scss/_progresscircle.scss
@@ -53,11 +53,11 @@
 			&.animate {
 				&-entrance,
 				&-progress-change {
-					transition-duration: 0.35s;
+					transition-duration: var(--progress-speed, 0.35s);
 				}
 
 				&-entrance {
-					transition-delay: 0.5s;
+					transition-delay: var(--progress-initial-speed, 0.5s);
 				}
 			}
 		}

--- a/src/scripts/OSFramework/OSUI/Pattern/Progress/ProgressEnum.ts
+++ b/src/scripts/OSFramework/OSUI/Pattern/Progress/ProgressEnum.ts
@@ -24,6 +24,8 @@ namespace OSFramework.OSUI.Patterns.Progress.ProgressEnum {
 		ProgressColor = '--progress-color',
 		ProgressValue = '--progress-value',
 		ProgressGradient = '--progress-gradient',
+		ProgressInitialSpeed = '--progress-initial-speed',
+		ProgressSpeed = '--progress-speed',
 		Shape = '--shape',
 		Thickness = '--thickness',
 		TrailColor = '--trail-color',


### PR DESCRIPTION
This PR is for adding new css variables to enable the developer to override the speed animation of the Progress Bar + Circle.

### What was happening
- When the speed of updating the value of the progress was higher than 5 per second, the progress was stuck in 0%, until the end, or until the update speed slowed down.

### What was done
- Added 2 new css variables that will enable the developer to override the animation speed value, making it fluid
   - `--progress-initial-speed`
   - `--progress-speed`  

### Example of usage
```
.override-speed .osui-progress-bar {
    --progress-initial-speed: 0.1s;
}
```
![image](https://github.com/user-attachments/assets/f4fb3465-bfe1-45fc-bcb9-953dea06a0e4)


### Screenshots
![progress-bar-fix](https://github.com/user-attachments/assets/0521f622-1062-40ae-b364-fd1be45a5cb1)

### Checklist
-   [x] tested locally
-   [ ] documented the code
-   [ ] clean all warnings and errors of eslint
-   [ ] requires changes in OutSystems (if so, provide a module with changes)
-   [ ] requires new sample page in OutSystems (if so, provide a module with changes)
