### PR TITLE
ROU-11487: Fix event for when sidebar starts open

### DIFF
--- a/src/scripts/OSFramework/OSUI/Pattern/Sidebar/Sidebar.ts
+++ b/src/scripts/OSFramework/OSUI/Pattern/Sidebar/Sidebar.ts
@@ -202,17 +202,19 @@ namespace OSFramework.OSUI.Patterns.Sidebar {
 				//let's only change the property and trigger the OS event IF the pattern is already built.
 				this._isOpen = true;
 				this._triggerOnToggleEvent();
+			}
 
-				if (this._clickOutsideToClose || (this.configs.HasOverlay && this._clickOutsideToClose === undefined)) {
-					Event.DOMEvents.Listeners.GlobalListenerManager.Instance.addHandler(
-						Event.DOMEvents.Listeners.Type.BodyOnMouseDown,
-						this._eventOverlayMouseDown
-					);
-					Event.DOMEvents.Listeners.GlobalListenerManager.Instance.addHandler(
-						Event.DOMEvents.Listeners.Type.BodyOnClick,
-						this._eventOverlayClick
-					);
-				}
+			// The sidebar can be set to be open, when created (start open). And in this case, the events
+			// should be added, even if the pattern is not built yet.
+			if (this._clickOutsideToClose || (this.configs.HasOverlay && this._clickOutsideToClose === undefined)) {
+				Event.DOMEvents.Listeners.GlobalListenerManager.Instance.addHandler(
+					Event.DOMEvents.Listeners.Type.BodyOnMouseDown,
+					this._eventOverlayMouseDown
+				);
+				Event.DOMEvents.Listeners.GlobalListenerManager.Instance.addHandler(
+					Event.DOMEvents.Listeners.Type.BodyOnClick,
+					this._eventOverlayClick
+				);
 			}
 
 			this.selfElement.focus();


### PR DESCRIPTION
This PR is for fixing a misbehavior when the sidebar starts open.

### What was happening
- When the sidebar starts open
- And has overlay (meaning, can be closed with click outside of it)
- The events to intercept the click and close the sidebar were not being added:
![image](https://github.com/user-attachments/assets/a066a1b1-5ea9-423c-a031-04fbd150124e)
(notice, the private method `_openSidebar()` is invoked by the method `_setInitialCssClasses()` within the method `build()`)

### What was done
- The code that adds the event was removed from the _if_ that checks if the sidebar is already _built_:
![image](https://github.com/user-attachments/assets/0d822e15-08d3-40d7-88a0-d98b3bffe63e)

### Test Steps
1. Go to test page
2. Open the sidebar
3. Click on the overlay

### Screenshots
![sidebar close issue](https://github.com/user-attachments/assets/55edb96c-6bd1-4d3f-aa1b-41945c5dd76d)

### Checklist
-   [x] tested locally
-   [x] documented the code
-   [x] clean all warnings and errors of eslint
-   [ ] requires changes in OutSystems (if so, provide a module with changes)
-   [ ] requires new sample page in OutSystems (if so, provide a module with changes)
