### PR TITLE
ROU-11479: Update Virtual Select provider to v1.0.47

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# OutSystems UI · v2.21.1
+# OutSystems UI · v2.22.0
 
 ![GitHub License](https://img.shields.io/badge/License-BSD%203--Clause-blue.svg) ![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg)
 

--- a/gulp/ProjectSpecs/DefaultSpecs.js
+++ b/gulp/ProjectSpecs/DefaultSpecs.js
@@ -21,7 +21,7 @@ const constants = {
 
 // Store the default project specifications
 const specs = {
-    "version": "2.21.1",
+    "version": "2.22.0",
     "name": "OutSystems UI",
     "description": "",
     "url": "Website:\n • https://www.outsystems.com/outsystems-ui",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "outsystems-ui",
-	"version": "2.21.1",
+	"version": "2.22.0",
 	"description": "OutSystems UI Framework",
 	"license": "BSD-3-Clause",
 	"scripts": {

--- a/package.json
+++ b/package.json
@@ -67,6 +67,6 @@
 		"typedoc-plugin-merge-modules": "^4.0.1",
 		"typedoc-umlclass": "^0.7.0",
 		"typescript": "^4.5.0",
-		"virtual-select-plugin": "^1.0.46"
+		"virtual-select-plugin": "^1.0.47"
 	}
 }

--- a/src/scripts/OSFramework/OSUI/Constants.ts
+++ b/src/scripts/OSFramework/OSUI/Constants.ts
@@ -155,7 +155,7 @@ namespace OSFramework.OSUI.Constants {
 	export const OSPlatform = '<->platformType<->';
 
 	/* OSUI Version */
-	export const OSUIVersion = '2.21.1';
+	export const OSUIVersion = '2.22.0';
 
 	/* Constant to be used across project as the zero value*/
 	export const ZeroValue = 0;

--- a/src/scripts/Providers/OSUI/Dropdown/VirtualSelect/AbstractVirtualSelectEnum.ts
+++ b/src/scripts/Providers/OSUI/Dropdown/VirtualSelect/AbstractVirtualSelectEnum.ts
@@ -5,7 +5,7 @@ namespace Providers.OSUI.Dropdown.VirtualSelect.Enum {
 	 */
 	export enum ProviderInfo {
 		Name = 'VirtualSelect',
-		Version = '1.0.46',
+		Version = '1.0.47',
 	}
 
 	/**

--- a/src/scripts/Providers/OSUI/Dropdown/VirtualSelect/README.md
+++ b/src/scripts/Providers/OSUI/Dropdown/VirtualSelect/README.md
@@ -1,3 +1,3 @@
-# VirtualSelect · ![virtualselect version](https://img.shields.io/badge/version-v1.0.46-informational)
+# VirtualSelect · ![virtualselect version](https://img.shields.io/badge/version-v1.0.47-informational)
 
 All info about this Provider <a href="https://sa-si-dev.github.io/virtual-select/#/">here</a>.

--- a/src/scripts/Providers/OSUI/Dropdown/VirtualSelect/scss/_virtualselect_lib.scss
+++ b/src/scripts/Providers/OSUI/Dropdown/VirtualSelect/scss/_virtualselect_lib.scss
@@ -1,5 +1,5 @@
 /*!
- * Virtual Select v1.0.46
+ * Virtual Select v1.0.47
  * https://sa-si-dev.github.io/virtual-select
  * Licensed under MIT (https://github.com/sa-si-dev/virtual-select/blob/master/LICENSE)
  */


### PR DESCRIPTION
This PR is to update the VirtualSelect library to the latest version **v1.0.47**

### What was done

- Updated Virtual Select provider to **v1.0.47**
- Incremented OutSystems UI version to **v2.22.0**

### Checklist

-   [X] tested locally
-   [X] documented the code
-   [X] clean all warnings and errors of eslint
-   [X] requires changes in OutSystems (if so, provide a module with changes)
-   [ ] requires new sample page in OutSystems (if so, provide a module with changes)
