### PR TITLE
ROU-11521: the behavior of "ActiveSubMenu" differs in the OutSystems UI different versions

### DIFF
--- a/src/scripts/OutSystems/OSUI/Utils/Menu.ts
+++ b/src/scripts/OutSystems/OSUI/Utils/Menu.ts
@@ -516,7 +516,13 @@ namespace OutSystems.OSUI.Utils.Menu {
 								OSFramework.OSUI.Helper.Dom.ClassSelector(activeSubMenu, 'submenu-items') ||
 								OSFramework.OSUI.Helper.Dom.ClassSelector(activeSubMenu, 'osui-submenu__items');
 
-							const activeSubMenuItem = subMenuItem.children[ActiveSubItem] as HTMLElement;
+							const activeSubMenuItem = subMenuItem.querySelectorAll(
+								'[' +
+									OSFramework.OSUI.Constants.A11YAttributes.Role.AttrName +
+									"='" +
+									OSFramework.OSUI.Constants.A11YAttributes.Role.MenuItem +
+									"']"
+							)[ActiveSubItem] as HTMLElement;
 							if (activeSubMenuItem) {
 								OSFramework.OSUI.Helper.Dom.Styles.AddClass(activeSubMenuItem, 'active');
 							}


### PR DESCRIPTION
This PR is for fixing a bug on the Menu utils client action ("SetActiveMenuItems").

### What was happening
- The code was prepared to select the active item based on its index inside the parent, however since we implemented the focus trap, the submenu has more children that are not submenu items. 
- Because of this I changed the selector to be stronger than just the child index.   

### What was done

- Get Active SubItem using a strong selector pointing to the specific sub-items instead of the children list;

### Test Steps

1. Go to sample
2. On Page Ready fill the input with an index that exists inside the submenu

### Checklist

-   [x] tested locally
-   [x] documented the code
-   [x] clean all warnings and errors of eslint
-   [ ] requires changes in OutSystems (if so, provide a module with changes)
-   [ ] requires new sample page in OutSystems (if so, provide a module with changes)
