### PR TITLE
ROU-11512: notification - Unexpected behavior when using Notification with CloseAfterTime

### DIFF
--- a/src/scripts/OSFramework/OSUI/Pattern/Notification/Notification.ts
+++ b/src/scripts/OSFramework/OSUI/Pattern/Notification/Notification.ts
@@ -7,6 +7,8 @@ namespace OSFramework.OSUI.Patterns.Notification {
 		extends AbstractPattern<NotificationConfig>
 		implements INotification, Interface.ISwipeEvent
 	{
+		// Store the auto close timeout id
+		private _autoCloseTimeoutId: number;
 		// Store the click event with bind(this)
 		private _eventOnClick: GlobalCallbacks.Generic;
 		// Store the keypress event with bind(this)
@@ -45,10 +47,8 @@ namespace OSFramework.OSUI.Patterns.Notification {
 		 * @memberof Notification
 		 */
 		private _autoCloseNotification(): void {
-			Helper.ApplySetTimeOut(() => {
-				if (this._isOpen) {
-					this.hide();
-				}
+			this._autoCloseTimeoutId = Helper.ApplySetTimeOut(() => {
+				this.hide();
 			}, this.configs.CloseAfterTime);
 		}
 
@@ -304,6 +304,18 @@ namespace OSFramework.OSUI.Patterns.Notification {
 		}
 
 		/**
+		 *	Method to clear timeouts
+		 *
+		 * @protected
+		 * @memberof Notification
+		 */
+		protected clearTimeouts(): void {
+			if (this.configs.CloseAfterTime > 0) {
+				clearTimeout(this._autoCloseTimeoutId);
+			}
+		}
+
+		/**
 		 * Method to set the A11Y properties when the pattern is built.
 		 *
 		 * @protected
@@ -475,6 +487,9 @@ namespace OSFramework.OSUI.Patterns.Notification {
 				// Remove Callbacks
 				this.unsetCallbacks();
 
+				// Clear Timeouts
+				this.clearTimeouts();
+
 				// Remove unused HTML elements
 				this.unsetHtmlElements();
 
@@ -499,6 +514,7 @@ namespace OSFramework.OSUI.Patterns.Notification {
 		public hide(): void {
 			if (this._isOpen) {
 				this._hideNotification();
+				this.clearTimeouts();
 			}
 		}
 


### PR DESCRIPTION
This PR is to guarantee the autoclose of Notification works and respects the waiting time configured by the developer

### What was happening
- When the notification was configured with CloseAfterTime, and the user interrupted this logic via API or interaction, the timeout triggering the close was not clean. This was causing an issue once the notification was triggered again. At that moment the old timeout could continue and close the notification without respecting the CloseAfterTime time that should be refreshed in every opening. 

### What was done
- add logic to clean Notification autoclose timeout every time the user closes the notification.

### Test Steps
1. Go to Sample
2. Config Notification to CloseAfterTime 5000
3. Trigger and Close the notification repeatedly 
4. After a few cycles trigger it and wait for the auto close
5. The notification should close after the intended timeframe.

### Checklist

-   [x] tested locally
-   [x] documented the code
-   [x] clean all warnings and errors of eslint
-   [ ] requires changes in OutSystems (if so, provide a module with changes)
-   [ ] requires new sample page in OutSystems (if so, provide a module with changes)
