### PR TITLE
ROU-11464: Input type Date and DateTime - Fix a date format issues.

### DIFF
--- a/src/scripts/OSFramework/OSUI/Constants.ts
+++ b/src/scripts/OSFramework/OSUI/Constants.ts
@@ -109,7 +109,7 @@ namespace OSFramework.OSUI.Constants {
 
 	/* To fix an issue when: 
 		- The user is using a device with an Arabic Language
-		- The application IS NOT usgin the Arabic Language
+		- The application IS NOT using the Arabic Language
 
 		That makes date type inputs to loose the date format and show the date in the wrong format,
 		We must force the text direction to RTL at the input in order to fix it.

--- a/src/scripts/OSFramework/OSUI/Constants.ts
+++ b/src/scripts/OSFramework/OSUI/Constants.ts
@@ -111,10 +111,10 @@ namespace OSFramework.OSUI.Constants {
 		- The user is using a device with an Arabic Language
 		- The application IS NOT using the Arabic Language
 
-		That makes date type inputs to loose the date format and show the date in the wrong format,
-		We must force the text direction to RTL at the input in order to fix it.
+		That makes date type inputs lose the date format and show the date in the wrong format,
+		We must force the text direction to RTL in the input in order to fix it.
 		
-		More info about this, at release note: ROU-11464
+		More info about this in the release notes of ROU-11464.
 	*/
 	export const IsRTLDeviceType = 'is-rtl-device';
 

--- a/src/scripts/OSFramework/OSUI/Constants.ts
+++ b/src/scripts/OSFramework/OSUI/Constants.ts
@@ -107,6 +107,17 @@ namespace OSFramework.OSUI.Constants {
 	/* cssClass to be checked if the RTL Feature is enabled */
 	export const IsRTLClass = 'is-rtl';
 
+	/* To fix an issue when: 
+		- The user is using a device with an Arabic Language
+		- The application IS NOT usgin the Arabic Language
+
+		That makes date type inputs to loose the date format and show the date in the wrong format,
+		We must force the text direction to RTL at the input in order to fix it.
+		
+		More info about this, at release note: ROU-11464
+	*/
+	export const IsRTLDeviceType = 'is-rtl-device';
+
 	/* Store JavaScript types*/
 	export const JavaScriptTypes = {
 		Undefined: 'undefined',

--- a/src/scripts/OSFramework/OSUI/Constants.ts
+++ b/src/scripts/OSFramework/OSUI/Constants.ts
@@ -108,7 +108,7 @@ namespace OSFramework.OSUI.Constants {
 	export const IsRTLClass = 'is-rtl';
 
 	/* To fix an issue when: 
-		- The user is using a device with an Arabic Language
+		- The user is using a device with the Arabic Language
 		- The application IS NOT using the Arabic Language
 
 		That makes date type inputs lose the date format and show the date in the wrong format,

--- a/src/scripts/OSFramework/OSUI/Helper/Device.ts
+++ b/src/scripts/OSFramework/OSUI/Helper/Device.ts
@@ -393,7 +393,7 @@ namespace OSFramework.OSUI.Helper {
 		}
 
 		/**
-		 * Getter that returns if the device is setted with an RTL language type
+		 * Getter that returns if the device is set with an RTL language type
 		 *
 		 * @readonly
 		 * @static

--- a/src/scripts/OSFramework/OSUI/Helper/Device.ts
+++ b/src/scripts/OSFramework/OSUI/Helper/Device.ts
@@ -263,6 +263,23 @@ namespace OSFramework.OSUI.Helper {
 		}
 
 		/**
+		 * Checks if the user device language is an RTL language type.
+		 *
+		 * @private
+		 * @static
+		 * @return {*}  {boolean}
+		 * @memberof DeviceInfo
+		 */
+		private static _isRtlLanguage(): boolean {
+			// List of RTL languages
+			const rtlLanguages = ['ar', 'he', 'fa', 'ur', 'ps', 'syr', 'yi', 'ku', 'dv', 'ps', 'sd', 'ug'];
+			// Get the device user language
+			const userLanguage = navigator.language.split('-')[0];
+
+			return rtlLanguages.includes(userLanguage);
+		}
+
+		/**
 		 * Checks if it's running inside Safari browser.
 		 *
 		 * @private
@@ -373,6 +390,18 @@ namespace OSFramework.OSUI.Helper {
 				DeviceInfo._isIphoneWithNotch = DeviceInfo._iphoneDetails !== undefined;
 			}
 			return DeviceInfo._isIphoneWithNotch;
+		}
+
+		/**
+		 * Getter that returns if the device is setted with an RTL language type
+		 *
+		 * @readonly
+		 * @static
+		 * @type {boolean}
+		 * @memberof DeviceInfo
+		 */
+		public static get IsRtlLang(): boolean {
+			return DeviceInfo._isRtlLanguage();
 		}
 
 		/**
@@ -516,8 +545,6 @@ namespace OSFramework.OSUI.Helper {
 			// retrieve it's position!
 			return notchPosition;
 		}
-
-		/******************** PUBLIC METHODS ********************/
 
 		/**
 		 * Gets in which browser the framework is running, based in the UserAgent information.

--- a/src/scripts/OutSystems/OSUI/Utils/LayoutPrivate.ts
+++ b/src/scripts/OutSystems/OSUI/Utils/LayoutPrivate.ts
@@ -153,6 +153,21 @@ namespace OutSystems.OSUI.Utils.LayoutPrivate {
 				}
 			}
 
+			/* To fix an issue when: 
+				- The user is using a device with an Arabic Language
+				- The application IS NOT usgin the Arabic Language
+
+				That makes date type inputs to loose the date format and show the date in the wrong format,
+				We must force the text direction to RTL at the input in order to fix it.
+				
+				More info about this, at release note: ROU-11464
+			*/
+			// Check if device is configured with RTL language
+			if (OSFramework.OSUI.Helper.DeviceInfo.IsRtlLang) {
+				// Add the RTL class to the DatePicker input
+				OSFramework.OSUI.Helper.Dom.Styles.AddClass(body, OSFramework.OSUI.Constants.IsRTLDeviceType);
+			}
+
 			// Set the orientation change event
 			LayoutPrivate.OnOrientationChange.Set();
 		}

--- a/src/scripts/OutSystems/OSUI/Utils/LayoutPrivate.ts
+++ b/src/scripts/OutSystems/OSUI/Utils/LayoutPrivate.ts
@@ -154,13 +154,13 @@ namespace OutSystems.OSUI.Utils.LayoutPrivate {
 			}
 
 			/* To fix an issue when: 
-				- The user is using a device with an Arabic Language
-				- The application IS NOT usgin the Arabic Language
+				- The user is using a device with the Arabic Language
+				- The application IS NOT using the Arabic Language
 
-				That makes date type inputs to loose the date format and show the date in the wrong format,
-				We must force the text direction to RTL at the input in order to fix it.
+				That makes date type inputs lose the date format and show the date in the wrong format,
+				We must force the text direction to RTL in the input in order to fix it.
 				
-				More info about this, at release note: ROU-11464
+				More info about this in the release notes of ROU-11464.
 			*/
 			// Check if device is configured with RTL language
 			if (OSFramework.OSUI.Helper.DeviceInfo.IsRtlLang) {

--- a/src/scss/01-foundations/_resets.scss
+++ b/src/scss/01-foundations/_resets.scss
@@ -184,13 +184,13 @@ input::-ms-clear {
 	input[type='date'],
 	input[type='datetime-local'] {
 		/* To fix an issue when: 
-			- The user is using a device with an Arabic Language
-			- The application IS NOT usgin the Arabic Language
+			- The user is using a device with the Arabic Language
+			- The application IS NOT using the Arabic Language
 
-			That makes date type inputs to loose the date format and show the date in the wrong format,
-			We must force the text direction to RTL at the input in order to fix it.
+			That makes date type inputs lose the date format and show the date in the wrong format,
+			We must force the text direction to RTL in the input in order to fix it.
 			
-			More info about this, at release note: ROU-11464
+			More info about this in the release notes of ROU-11464.
 		*/
 		direction: rtl;
 	}

--- a/src/scss/01-foundations/_resets.scss
+++ b/src/scss/01-foundations/_resets.scss
@@ -179,6 +179,23 @@ input::-ms-clear {
 	display: none;
 }
 
+///
+.is-rtl-device {
+	input[type='date'],
+	input[type='datetime-local'] {
+		/* To fix an issue when: 
+			- The user is using a device with an Arabic Language
+			- The application IS NOT usgin the Arabic Language
+
+			That makes date type inputs to loose the date format and show the date in the wrong format,
+			We must force the text direction to RTL at the input in order to fix it.
+			
+			More info about this, at release note: ROU-11464
+		*/
+		direction: rtl;
+	}
+}
+
 /* ============================================================================ */
 /* Button                                                                       */
 /* ============================================================================ */


### PR DESCRIPTION
This PR will fix an issue when: 
- The user is using a device with an Arabic Language
and
- The application **IS NOT** being set with Arabic Language

### What was happening

- It makes date type inputs to loose the date format and show the date in the wrong format,
<img width="321" alt="Screenshot 2025-01-27 at 17 01 58" src="https://github.com/user-attachments/assets/d6085bd3-fcdd-49e3-bd5a-ab115dd6986c" />


### What was done

- Added a body class selector and force the text direction to RTL to all type of date and datetime inputs at the screen.
<img width="326" alt="Screenshot 2025-01-27 at 17 02 11" src="https://github.com/user-attachments/assets/abd6415e-7e24-4e35-a78e-c55765afe13e" />

