### PR TITLE
ROU-11549: DrodownServerSide - Fixed missing validation to also move balloon options.

### DIFF
--- a/src/scripts/OSFramework/OSUI/Pattern/Dropdown/ServerSide/DropdownServerSide.ts
+++ b/src/scripts/OSFramework/OSUI/Pattern/Dropdown/ServerSide/DropdownServerSide.ts
@@ -446,7 +446,7 @@ namespace OSFramework.OSUI.Patterns.Dropdown.ServerSide {
 			}
 		}
 
-		// Method that will check if the BalloonOptionsWrapper should be moved to outside of the pattern context
+		// Method that will check if the BalloonOptionsWrapper should be moved outside of the pattern context
 		private _shouldBalloonOptionsBeMoved(): boolean {
 			/* NOTE:
 				- When inside BottomSheet the BalloonOptionsWrapper should be moved to the content wrapper

--- a/src/scripts/OSFramework/OSUI/Pattern/Dropdown/ServerSide/DropdownServerSide.ts
+++ b/src/scripts/OSFramework/OSUI/Pattern/Dropdown/ServerSide/DropdownServerSide.ts
@@ -114,7 +114,7 @@ namespace OSFramework.OSUI.Patterns.Dropdown.ServerSide {
 
 		// Method to move Balloon Options Wrapper to outside of the pattern context
 		private _moveBalloonOptionsWrapper(): void {
-			// Check if BalloonOptions should be moved to outside of the pattern context
+			// Check if BalloonOptions should be moved outside of the pattern context
 			if (this._shouldBalloonOptionsBeMoved()) {
 				// Get the content element where to move the BalloonOptionsWrapper
 				const contentElem = Helper.Dom.ClassSelector(document, GlobalEnum.CssClassElements.Content);

--- a/src/scripts/OSFramework/OSUI/Pattern/Dropdown/ServerSide/DropdownServerSide.ts
+++ b/src/scripts/OSFramework/OSUI/Pattern/Dropdown/ServerSide/DropdownServerSide.ts
@@ -114,13 +114,8 @@ namespace OSFramework.OSUI.Patterns.Dropdown.ServerSide {
 
 		// Method to move Balloon Options Wrapper to outside of the pattern context
 		private _moveBalloonOptionsWrapper(): void {
-			/* NOTE:
-				- When inside BottomSheet the BalloonOptionsWrapper should be moved to the content wrapper
-				due to position issues related with fixed position of the balloon against BottomSheet fixed position.
-				More info at Release Note: ROU-11549
-			 */
-			// Ensure DropdownServerSide is inside at BottomSheet
-			if (Helper.DeviceInfo.IsPhone && this.selfElement.closest(Enum.InsidePattern.BottomSheet)) {
+			// Check if BalloonOptions should be moved to outside of the pattern context
+			if (this._shouldBalloonOptionsBeMoved()) {
 				// Get the content element where to move the BalloonOptionsWrapper
 				const contentElem = Helper.Dom.ClassSelector(document, GlobalEnum.CssClassElements.Content);
 				// Move the DropdownServerSide ballon element to the content element
@@ -448,6 +443,26 @@ namespace OSFramework.OSUI.Patterns.Dropdown.ServerSide {
 					Event.DOMEvents.Listeners.Type.BalloonOnToggle,
 					this._eventBalloonOnToggle
 				);
+			}
+		}
+
+		// Method that will check if the BalloonOptionsWrapper should be moved to outside of the pattern context
+		private _shouldBalloonOptionsBeMoved(): boolean {
+			/* NOTE:
+				- When inside BottomSheet the BalloonOptionsWrapper should be moved to the content wrapper
+				due to position issues related with fixed position of the balloon against BottomSheet fixed position.
+				More info at Release Note: ROU-11549
+			 */
+			// Ensure DropdownServerSide is inside at BottomSheet, Notification or Sidebar
+			if (
+				Helper.DeviceInfo.IsPhone &&
+				(this.selfElement.closest(Enum.InsidePattern.BottomSheet) ||
+					this.selfElement.closest(Enum.InsidePattern.Notification) ||
+					this.selfElement.closest(Enum.InsidePattern.Sidebar))
+			) {
+				return true;
+			} else {
+				return false;
 			}
 		}
 

--- a/src/scripts/OSFramework/OSUI/Pattern/Dropdown/ServerSide/DropdownServerSide.ts
+++ b/src/scripts/OSFramework/OSUI/Pattern/Dropdown/ServerSide/DropdownServerSide.ts
@@ -453,7 +453,7 @@ namespace OSFramework.OSUI.Patterns.Dropdown.ServerSide {
 				due to position issues related with fixed position of the balloon against BottomSheet fixed position.
 				More info at Release Note: ROU-11549
 			 */
-			// Ensure DropdownServerSide is inside at BottomSheet, Notification or Sidebar
+			// Check if the DropdownServerSide is inside a BottomSheet, Notification, or Sidebar
 			if (
 				Helper.DeviceInfo.IsPhone &&
 				(this.selfElement.closest(Enum.InsidePattern.BottomSheet) ||

--- a/src/scripts/OSFramework/OSUI/Pattern/Dropdown/ServerSide/DropdownServerSideEnum.ts
+++ b/src/scripts/OSFramework/OSUI/Pattern/Dropdown/ServerSide/DropdownServerSideEnum.ts
@@ -57,6 +57,8 @@ namespace OSFramework.OSUI.Patterns.Dropdown.ServerSide.Enum {
 	 */
 	export enum InsidePattern {
 		BottomSheet = '.osui-bottom-sheet',
+		Notification = '.osui-notification',
+		Sidebar = '.osui-sidebar',
 	}
 
 	/**


### PR DESCRIPTION
This PR will add the ability to DropdownServerSide options balloon container be also moved to outside of it's context when inside Notification and/or SideBar Patterns.

### What was happening

- Position issues, when inside Notification and/or SideBar patterns.

### What was done

- Added extra validation to move balloon options to outside of pattern context.
