### PR TITLE
ROU-11563: DropdownServerSide - Fix layer position issues at studio.

### DIFF
--- a/src/scripts/OSFramework/OSUI/Pattern/Dropdown/ServerSide/scss/_dropdown-serverside.scss
+++ b/src/scripts/OSFramework/OSUI/Pattern/Dropdown/ServerSide/scss/_dropdown-serverside.scss
@@ -30,10 +30,11 @@ $balloonMobileTopMargin: 5vh;
 		// Service Studio Preview
 		& {
 			-servicestudio-left: initial;
+			-servicestudio-margin-top: 4px;
 			-servicestudio-max-height: 320px;
 			-servicestudio-opacity: 1;
-			-servicestudio-position: relative;
-			-servicestudio-top: calc(100% + 4px);
+			-servicestudio-position: relative !important;
+			-servicestudio-top: 0;
 			-servicestudio-width: 100%;
 		}
 	}
@@ -92,6 +93,12 @@ $balloonMobileTopMargin: 5vh;
 			position: relative;
 			transition: border 250ms ease-in-out;
 			width: 100%;
+
+			// Service Studio Preview
+			& {
+				-servicestudio-height: fit-content;
+				-servicestudio-min-height: 40px;
+			}
 		}
 
 		[data-expression] {

--- a/src/scripts/OSFramework/OSUI/Pattern/Tabs/scss/_tabs.scss
+++ b/src/scripts/OSFramework/OSUI/Pattern/Tabs/scss/_tabs.scss
@@ -254,6 +254,10 @@
 				div:empty {
 					-servicestudio-padding: var(--space-m);
 				}
+
+				.uieditor-if-branch-widget:has(> div:empty) {
+					-servicestudio-height: 0;
+				}
 			}
 
 			// This selector is used to prevent render issues on chrome, in some screen-sizes, due to overflow hidden and css snap


### PR DESCRIPTION
This PR Will fix a layer position issues when inside ServiceStudio.

### What was happening

- When inside certain type of elements due to position absolute under the context of the parent element, DropdownServerSideOptions was being shown behind another elements.

### What was done

- Changed from `position: absolute` into `position: relative` when inside Studio.
