### PR TITLE
ROU-11631: Input and Textarea do not allow the text to be selected when the component is disabled 

### DIFF
--- a/src/scss/03-widgets/_inputs-and-textareas.scss
+++ b/src/scss/03-widgets/_inputs-and-textareas.scss
@@ -40,7 +40,7 @@
 			background-color: var(--color-neutral-2);
 			border: var(--border-size-s) solid var(--color-neutral-4);
 			color: var(--color-neutral-6);
-			pointer-events: none;
+			pointer-events: auto;
 		}
 	}
 


### PR DESCRIPTION
### What was happening

- On a Screen with an Input or Textarea widget, it was not possible to select the text using the pointer when the `Enabled` property is `False`, ie, they are disabled.

### What was done

- Removed the `pointer-events: none` in the selector `.form-control[data-input][disabled], .form-control[data-textarea][disabled]`

### Test Steps

1. Go to a Screen with an Input or Textarea widget.
2. Set their Enabled property to False.
3. Check that now it is possible to select the text inside the Input/Textarea in runtime.

### Screenshots

![ROU11631_Fixed](https://github.com/user-attachments/assets/921d4ee0-f50e-4901-a4a6-2d7bd98740ad)


### Checklist

-   [X] tested locally
-   [X] documented the code
-   [X] clean all warnings and errors of eslint
-   [ ] requires changes in OutSystems (if so, provide a module with changes)
-   [ ] requires new sample page in OutSystems (if so, provide a module with changes)
