### PR TITLE
ROU-11631: Input and Textarea do not allow the text to be selected when the component is disabled V2

### DIFF
--- a/src/scss/03-widgets/_inputs-and-textareas.scss
+++ b/src/scss/03-widgets/_inputs-and-textareas.scss
@@ -40,7 +40,6 @@
 			background-color: var(--color-neutral-2);
 			border: var(--border-size-s) solid var(--color-neutral-4);
 			color: var(--color-neutral-6);
-			pointer-events: auto;
 		}
 	}
 


### PR DESCRIPTION
This PR is to remove the `pointer-events: auto` from the selector `.form-control[data-input][disabled], .form-control[data-textarea][disabled]` since it's not needed.

### Checklist

-   [X] tested locally
-   [X] documented the code
-   [X] clean all warnings and errors of eslint
-   [ ] requires changes in OutSystems (if so, provide a module with changes)
-   [ ] requires new sample page in OutSystems (if so, provide a module with changes)
