### PR TITLE
ROU-11663: Added iPhone 15 and 16 to iPhone devices list

### DIFF
--- a/src/scripts/OSFramework/OSUI/Helper/Device.ts
+++ b/src/scripts/OSFramework/OSUI/Helper/Device.ts
@@ -87,6 +87,18 @@ namespace OSFramework.OSUI.Helper {
 		{ width: 1284, height: 2778, description: 'iphone 14 plus' },
 		{ width: 1179, height: 2556, description: 'iphone 14 pro' },
 		{ width: 1290, height: 2796, description: 'iphone 14 pro max' },
+
+		// iPhone15
+		{ width: 1179, height: 2556, description: 'iphone 15' },
+		{ width: 1290, height: 2796, description: 'iphone 15 plus' },
+		{ width: 1179, height: 2556, description: 'iphone 15 pro' },
+		{ width: 1290, height: 2796, description: 'iphone 15 pro max' },
+
+		// iPhone16
+		{ width: 1179, height: 2556, description: 'iphone 16' },
+		{ width: 1290, height: 2796, description: 'iphone 16 plus' },
+		{ width: 1206, height: 2622, description: 'iphone 16 pro' },
+		{ width: 1320, height: 2868, description: 'iphone 16 pro max' },
 	];
 
 	export abstract class DeviceInfo {


### PR DESCRIPTION
### What was happening

- To keep our code base modern and updated we need to revisit the list of supported iPhone sizes used for adding the CSS class `iphonex`.

### What was done

- Added all iPhone 15 and 16 devices to the list of iPhone devices with the associated resolutions

### Test Steps

1. Open an app on an iPhone 15 or 16
2. Check that the `iphonex` is present


### Checklist

-   [X] tested locally
-   [ ] documented the code
-   [ ] clean all warnings and errors of eslint
-   [ ] requires changes in OutSystems (if so, provide a module with changes)
-   [ ] requires new sample page in OutSystems (if so, provide a module with changes)
