### PR TITLE
ROU-11690 : Application Content unviewable after undoing changes to data entered into DataGrid

### DIFF
--- a/src/scss/04-patterns/03-interaction/_animate.scss
+++ b/src/scss/04-patterns/03-interaction/_animate.scss
@@ -3,8 +3,8 @@
 /// @group Patterns-Animate
 /// Patterns - Interaction - Animate
 
-/// This selector has been added a not(.flatpicker-calendar) to avoid conflicts with the flatpickr calendar.
-.animate:not(.flatpicker-calendar) {
+/// This selector has been added a not(.flatpickr-calendar) to avoid conflicts with the flatpickr calendar.
+.animate:not(.flatpickr-calendar) {
 	animation-duration: 1000ms;
 	animation-fill-mode: both;
 	display: inline-block;


### PR DESCRIPTION
### What was happening
* After undoing (Ctrl/Cmd+Z) an undoable action like a cell value update or a column sort, a forceful scroll occurred, which could hide part of the UI above the DataGrid.
* This happened when not setting a fixed height for the Grid and using DatePickers, all inside Tabs.


### What was done
* Added an exception on `.animate` class to exclude flatpicker instances so we can solve the conflict
* A first iteration was done on OutSystems Data Grid side, where the `datagrid-container` was changed to have its height set to `inherit`.

### Test Steps
1. Add the Tabs component to a Screen
2. Add some elements like some Buttons to the beginning of the “Content” placeholder in one of the Tabs
3. Add the OS DataGrid after the elements you added in the previous step and set it up with some data
4. In Runtime, perform some action like changing Data, adding a Row, or sorting a column
5. Press Ctrl/Cmd+Z
6. Check that nothing gets broken


### Screenshots

![ROU-11690_Issue](https://github.com/user-attachments/assets/a2103535-161f-4e62-9b92-2f7cfa8795c3)



### Checklist
* [X] tested locally
* [ ] documented the code
* [X] clean all warnings and errors of eslint
* [X] requires changes in OutSystems 
* [X] requires new sample page in OutSystems

