### PR TITLE
ROU-11743: Improving the usage of handlers, documentation, and code

### DIFF
--- a/src/scripts/OSFramework/OSUI/Behaviors/FocusTrap.ts
+++ b/src/scripts/OSFramework/OSUI/Behaviors/FocusTrap.ts
@@ -18,7 +18,9 @@ namespace OSFramework.OSUI.Behaviors {
 		private _canTargetContainOtherPatts = false;
 		private _firstFocusableElement: HTMLElement;
 		private _focusBottomCallback: GlobalCallbacks.Generic;
+		private _focusBottomHandlerCallback: GlobalCallbacks.Generic;
 		private _focusTopCallback: GlobalCallbacks.Generic;
+		private _focusTopHandlerCallback: GlobalCallbacks.Generic;
 		private _focusableElements: HTMLElement[];
 		private _hasBeenPassThoughFirstOne = false;
 		private _lastFocusableElement: HTMLElement;
@@ -104,21 +106,23 @@ namespace OSFramework.OSUI.Behaviors {
 		private _removeEventListeners(): void {
 			this._predictableBottomElement.removeEventListener(
 				GlobalEnum.HTMLEvent.Focus,
-				this._focusBottomHandler.bind(this)
+				this._focusBottomHandlerCallback
 			);
-			this._predictableTopElement.removeEventListener(
-				GlobalEnum.HTMLEvent.Focus,
-				this._focusTopHandler.bind(this)
-			);
+			this._predictableTopElement.removeEventListener(GlobalEnum.HTMLEvent.Focus, this._focusTopHandlerCallback);
+		}
+
+		private _setCallbacks(): void {
+			this._focusBottomHandlerCallback = this._focusBottomHandler.bind(this);
+			this._focusTopHandlerCallback = this._focusTopHandler.bind(this);
 		}
 
 		// Method to add the event listeners to the created elements
 		private _setEventListeners(): void {
 			this._predictableBottomElement.addEventListener(
 				GlobalEnum.HTMLEvent.Focus,
-				this._focusBottomHandler.bind(this)
+				this._focusBottomHandlerCallback
 			);
-			this._predictableTopElement.addEventListener(GlobalEnum.HTMLEvent.Focus, this._focusTopHandler.bind(this));
+			this._predictableTopElement.addEventListener(GlobalEnum.HTMLEvent.Focus, this._focusTopHandlerCallback);
 		}
 
 		// Method to set the focusable elements to be used
@@ -203,9 +207,9 @@ namespace OSFramework.OSUI.Behaviors {
 		// Method that unsets all the callback defined
 		private _unsetCallbacks(): void {
 			this._focusBottomCallback = undefined;
-			this._focusBottomHandler = undefined;
 			this._focusTopCallback = undefined;
-			this._focusTopHandler = undefined;
+			this._focusBottomHandlerCallback = undefined;
+			this._focusTopHandlerCallback = undefined;
 		}
 
 		/**

--- a/src/scripts/OSFramework/OSUI/Event/GestureEvents/SwipeEvent.ts
+++ b/src/scripts/OSFramework/OSUI/Event/GestureEvents/SwipeEvent.ts
@@ -23,15 +23,7 @@ namespace OSFramework.OSUI.Event.GestureEvent {
 			super(target);
 		}
 
-		/**
-		 * Method to set on GestureEnd callback, as this one needs an exception to detect the final direction swiped
-		 *
-		 * @private
-		 * @param {number} offsetX
-		 * @param {number} offsetY
-		 * @param {number} timeTaken
-		 * @memberof OSFramework.Event.GestureEvent.SwipeEvent
-		 */
+		// Method to set on GestureEnd callback, as this one needs an exception to detect the final direction swiped
 		private _onGestureEnd(offsetX: number, offsetY: number, timeTaken: number): void {
 			// CHeck if this a swipe
 			if (

--- a/src/scripts/OSFramework/OSUI/Helper/Dates.ts
+++ b/src/scripts/OSFramework/OSUI/Helper/Dates.ts
@@ -1,9 +1,7 @@
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 namespace OSFramework.OSUI.Helper {
 	export abstract class Dates {
-		/**
-		 * Format of data as set in service center.
-		 */
+		// Format of data as set in service center.
 		private static _serverFormat = '';
 
 		/**

--- a/src/scripts/OSFramework/OSUI/Helper/Device.ts
+++ b/src/scripts/OSFramework/OSUI/Helper/Device.ts
@@ -114,15 +114,7 @@ namespace OSFramework.OSUI.Helper {
 		private static _operatingSystem = GlobalEnum.MobileOS.Unknown;
 
 		/******************** PRIVATE METHODS ********************/
-		/**
-		 * Gets the operating system based on the user agent.
-		 *
-		 * @private
-		 * @static
-		 * @param {string} [userAgent='']
-		 * @return {*}  {GlobalEnum.MobileOS}
-		 * @memberof OSFramework.Helper.DeviceInfo
-		 */
+		// Gets the operating system based on the user agent.
 		private static _getOperatingSystem(userAgent = ''): GlobalEnum.MobileOS {
 			const userAgentLocal = DeviceInfo._getUserAgent(userAgent);
 			let localOs = GlobalEnum.MobileOS.Unknown;
@@ -142,15 +134,7 @@ namespace OSFramework.OSUI.Helper {
 			return localOs;
 		}
 
-		/**
-		 * Cleans the userAgent passed by the developer, or returns the one from the window.
-		 *
-		 * @private
-		 * @static
-		 * @param {string} [userAgent='']
-		 * @return {*}
-		 * @memberof OSFramework.Helper.DeviceInfo
-		 */
+		// Cleans the userAgent passed by the developer, or returns the one from the window.
 		private static _getUserAgent(userAgent = ''): string {
 			let localUserAgent = userAgent;
 
@@ -165,28 +149,12 @@ namespace OSFramework.OSUI.Helper {
 			return localUserAgent.toLowerCase();
 		}
 
-		/**
-		 * Checks if it's running inside chrome browser.
-		 *
-		 * @private
-		 * @static
-		 * @param {string} ua
-		 * @return {*}  {boolean}
-		 * @memberof OSFramework.Helper.DeviceInfo
-		 */
+		// Checks if it's running inside chrome browser.
 		private static _isChrome(ua: string): boolean {
 			return ua.includes(UAKeyword.chrome) || ua.includes(UAKeyword.crios);
 		}
 
-		/**
-		 * Checks if it's running inside Edge browser.
-		 *
-		 * @private
-		 * @static
-		 * @param {string} ua
-		 * @return {*}  {boolean}
-		 * @memberof OSFramework.Helper.DeviceInfo
-		 */
+		// Checks if it's running inside Edge browser.
 		private static _isEdge(ua: string): boolean {
 			return (
 				ua.includes(UAKeyword.edge) ||
@@ -196,15 +164,7 @@ namespace OSFramework.OSUI.Helper {
 			);
 		}
 
-		/**
-		 * Checks if it's running inside Firefox browser.
-		 *
-		 * @private
-		 * @static
-		 * @param {string} ua
-		 * @return {*}  {boolean}
-		 * @memberof OSFramework.Helper.DeviceInfo
-		 */
+		// Checks if it's running inside Firefox browser.
 		private static _isFirefox(ua: string): boolean {
 			return ua.includes(UAKeyword.firefox) || ua.includes(UAKeyword.fxios);
 		}
@@ -223,15 +183,7 @@ namespace OSFramework.OSUI.Helper {
 			return ua.includes(UAKeyword.trident) || ua.includes(UAKeyword.msie);
 		}
 
-		/**
-		 * Checks if it's running inside Kindle browser.
-		 *
-		 * @private
-		 * @static
-		 * @param {string} ua
-		 * @return {*}  {boolean}
-		 * @memberof OSFramework.Helper.DeviceInfo
-		 */
+		// Checks if it's running inside Kindle browser.
 		private static _isKindle(ua: string): boolean {
 			return (
 				ua.includes(UAKeyword.kindle) ||
@@ -248,40 +200,17 @@ namespace OSFramework.OSUI.Helper {
 			);
 		}
 
-		/**
-		 * Checks if it's running inside MIUI browser.
-		 *
-		 * @private
-		 * @static
-		 * @param {string} ua
-		 * @return {*}  {boolean}
-		 * @memberof OSFramework.Helper.DeviceInfo
-		 */
+		// Checks if it's running inside MIUI browser.
 		private static _isMiui(ua: string): boolean {
 			return ua.includes(UAKeyword.miuibrowser);
 		}
 
-		/**
-		 * Checks if it's running inside Opera browser.
-		 *
-		 * @private
-		 * @static
-		 * @param {string} ua
-		 * @return {*}  {boolean}
-		 * @memberof OSFramework.Helper.DeviceInfo
-		 */
+		// Checks if it's running inside Opera browser.
 		private static _isOpera(ua: string): boolean {
 			return ua.includes(UAKeyword.opr) || ua.includes(UAKeyword.opera) || ua.includes(UAKeyword.opios);
 		}
 
-		/**
-		 * Checks if the user device language is an RTL language type.
-		 *
-		 * @private
-		 * @static
-		 * @return {*}  {boolean}
-		 * @memberof DeviceInfo
-		 */
+		// Checks if the user device language is an RTL language type.
 		private static _isRtlLanguage(): boolean {
 			// List of RTL languages
 			const rtlLanguages = ['ar', 'he', 'fa', 'ur', 'ps', 'syr', 'yi', 'ku', 'dv', 'ps', 'sd', 'ug'];
@@ -291,61 +220,37 @@ namespace OSFramework.OSUI.Helper {
 			return rtlLanguages.includes(userLanguage);
 		}
 
-		/**
-		 * Checks if it's running inside Safari browser.
-		 *
-		 * @private
-		 * @static
-		 * @param {string} ua
-		 * @return {*}  {boolean}
-		 * @memberof OSFramework.Helper.DeviceInfo
-		 */
+		// Checks if it's running inside Safari browser.
 		private static _isSafari(ua: string): boolean {
 			return ua.includes(UAKeyword.safari);
 		}
 
-		/**
-		 * Checks if it's running inside Samsung browser.
-		 *
-		 * @private
-		 * @static
-		 * @param {string} ua
-		 * @return {*}  {boolean}
-		 * @memberof OSFramework.Helper.DeviceInfo
-		 */
+		// Checks if it's running inside Samsung browser.
 		private static _isSamsung(ua: string): boolean {
 			return ua.includes(UAKeyword.samsungbrowser);
 		}
 
-		/**
-		 *  Checks if it's running inside UC browser.
-		 *
-		 * @private
-		 * @static
-		 * @param {string} ua
-		 * @return {*}  {boolean}
-		 * @memberof OSFramework.Helper.DeviceInfo
-		 */
+		// Checks if it's running inside UC browser.
 		// eslint-disable-next-line @typescript-eslint/naming-convention
 		private static _isUC(ua: string): boolean {
 			return ua.includes(UAKeyword.ucbrowser);
 		}
 
-		/**
-		 * Checks if it's running inside Yandex browser.
-		 *
-		 * @private
-		 * @static
-		 * @param {string} ua
-		 * @return {*}  {boolean}
-		 * @memberof OSFramework.Helper.DeviceInfo
-		 */
+		// Checks if it's running inside Yandex browser.
 		private static _isYandex(ua: string): boolean {
 			return ua.includes(UAKeyword.yabrowser);
 		}
 
 		/******************** PUBLIC GETTERS ********************/
 
+		/**
+		 * Getter that returns if the application is running in a device with accessibility enabled.
+		 *
+		 * @readonly
+		 * @static
+		 * @type {boolean}
+		 * @memberof DeviceInfo
+		 */
 		public static get HasAccessibilityEnabled(): boolean {
 			return Helper.Dom.ClassSelector(document.body, Constants.HasAccessibilityClass) !== undefined;
 		}
@@ -460,6 +365,14 @@ namespace OSFramework.OSUI.Helper {
 			return DeviceInfo._isNativeApp;
 		}
 
+		/**
+		 * Getter that returns if the application is running inside a native shell and the device is Android.
+		 *
+		 * @readonly
+		 * @static
+		 * @type {boolean}
+		 * @memberof DeviceInfo
+		 */
 		public static get IsAndroid(): boolean {
 			if (DeviceInfo._isAndroid === undefined) {
 				DeviceInfo._isAndroid = Dom.Styles.ContainsClass(document.body, GlobalEnum.MobileOS.Android);
@@ -467,6 +380,14 @@ namespace OSFramework.OSUI.Helper {
 			return DeviceInfo._isAndroid;
 		}
 
+		/**
+		 * Getter that returns if the application is running inside a native shell and the device is iOS.
+		 *
+		 * @readonly
+		 * @static
+		 * @type {boolean}
+		 * @memberof DeviceInfo
+		 */
 		public static get IsIos(): boolean {
 			if (DeviceInfo._isIos === undefined) {
 				DeviceInfo._isIos = Dom.Styles.ContainsClass(document.body, GlobalEnum.MobileOS.IOS);

--- a/src/scripts/OSFramework/OSUI/Helper/Language.ts
+++ b/src/scripts/OSFramework/OSUI/Helper/Language.ts
@@ -1,9 +1,7 @@
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 namespace OSFramework.OSUI.Helper {
 	export abstract class Language {
-		/**
-		 * App Language
-		 */
+		// App Language
 		private static _lang = Constants.Language.code;
 
 		/**

--- a/src/scripts/OSFramework/OSUI/Pattern/AbstractConfiguration.ts
+++ b/src/scripts/OSFramework/OSUI/Pattern/AbstractConfiguration.ts
@@ -13,8 +13,7 @@ namespace OSFramework.OSUI.Patterns {
 		constructor(config: JSON) {
 			for (const key in config) {
 				if (config[key] !== undefined) {
-					// eslint-disable-next-line @typescript-eslint/no-explicit-any
-					this[key] = this.validateDefault(key, config[key]) as any;
+					this[key] = this.validateDefault(key, config[key]);
 				}
 			}
 		}

--- a/src/scripts/OSFramework/OSUI/Pattern/AccordionItem/AccordionItem.ts
+++ b/src/scripts/OSFramework/OSUI/Pattern/AccordionItem/AccordionItem.ts
@@ -42,14 +42,7 @@ namespace OSFramework.OSUI.Patterns.AccordionItem {
 			this._isOpen = this.configs.StartsExpanded;
 		}
 
-		/**
-		 * Getter that obtains the element that should be the clicking place to toggle the accordion.
-		 *
-		 * @readonly
-		 * @private
-		 * @type {HTMLElement}
-		 * @memberof AccordionItem
-		 */
+		// Getter that obtains the element that should be the clicking place to toggle the accordion.
 		private get _elementWithEvents(): HTMLElement {
 			let elementWithEvent = this._accordionItemTitleElem;
 			if (this.configs.ToggleWithIcon) {
@@ -62,15 +55,7 @@ namespace OSFramework.OSUI.Patterns.AccordionItem {
 			return elementWithEvent;
 		}
 
-		/**
-		 * Getter that obtains the previous element that was the clicking place. Useful to remove
-		 * events and A11Y attributes.
-		 *
-		 * @readonly
-		 * @private
-		 * @type {HTMLElement}
-		 * @memberof AccordionItem
-		 */
+		// Getter that obtains the previous element that was the clicking place. Useful to remove events and A11Y attributes.
 		private get _previousElementWithEvents(): HTMLElement {
 			let elementWithEvent = this._accordionItemTitleElem;
 			if (!this.configs.ToggleWithIcon) {
@@ -83,14 +68,7 @@ namespace OSFramework.OSUI.Patterns.AccordionItem {
 			return elementWithEvent;
 		}
 
-		/**
-		 * Method to handle the click event
-		 *
-		 * @private
-		 * @param {MouseEvent} event
-		 * @return {*}  {void}
-		 * @memberof AccordionItem
-		 */
+		// Method to handle the click event
 		private _accordionOnClickHandler(event: MouseEvent): void {
 			if (this._allowTitleEvents) {
 				if (
@@ -109,12 +87,7 @@ namespace OSFramework.OSUI.Patterns.AccordionItem {
 			}
 		}
 
-		/**
-		 * Method to add the event listeners
-		 *
-		 * @private
-		 * @memberof AccordionItem
-		 */
+		// Method to add the event listeners
 		private _addEvents(): void {
 			const elem = this._elementWithEvents;
 
@@ -122,13 +95,7 @@ namespace OSFramework.OSUI.Patterns.AccordionItem {
 			elem.addEventListener(GlobalEnum.HTMLEvent.keyDown, this._eventOnkeyPress);
 		}
 
-		/**
-		 * Method to handle async animation
-		 *
-		 * @private
-		 * @param {boolean} isExpand
-		 * @memberof AccordionItem
-		 */
+		// Method to handle async animation
 		private _animationAsync(isExpand: boolean): void {
 			const finalHeight = isExpand ? this._expandedHeight : this._collapsedHeight;
 
@@ -164,12 +131,7 @@ namespace OSFramework.OSUI.Patterns.AccordionItem {
 			this._onToggleCallback();
 		}
 
-		/**
-		 * Method that toogles the clickable area between the whole title (default) and the icon.
-		 *
-		 * @private
-		 * @memberof AccordionItem
-		 */
+		// Method that toogles the clickable area between the whole title (default) and the icon.
 		private _changeClikableTargetArea(): void {
 			if (this._previousElementWithEvents !== this._elementWithEvents) {
 				Helper.Dom.Styles.RemoveClass(this._previousElementWithEvents, Enum.CssClass.PatternClickArea);
@@ -182,12 +144,7 @@ namespace OSFramework.OSUI.Patterns.AccordionItem {
 			}
 		}
 
-		/**
-		 * Method to handle the tabindex values
-		 *
-		 * @private
-		 * @memberof AccordionItem
-		 */
+		// Method to handle the tabindex values
 		private _handleTabIndex(): void {
 			const titleTabindexValue = this.configs.IsDisabled
 				? Constants.A11YAttributes.States.TabIndexHidden
@@ -205,14 +162,7 @@ namespace OSFramework.OSUI.Patterns.AccordionItem {
 			}
 		}
 
-		/**
-		 * Method to handle Keyboardpress event
-		 *
-		 * @private
-		 * @param {KeyboardEvent} event
-		 * @return {*}  {void}
-		 * @memberof AccordionItem
-		 */
+		// Method to handle Keyboardpress event
 		private _onKeyboardPress(event: KeyboardEvent): void {
 			const isEscapedKey = event.key === GlobalEnum.Keycodes.Escape;
 			const isEnterOrSpaceKey =
@@ -234,12 +184,7 @@ namespace OSFramework.OSUI.Patterns.AccordionItem {
 			}
 		}
 
-		/**
-		 * Method to handle the keyboard interactions
-		 *
-		 * @private
-		 * @memberof AccordionItem
-		 */
+		// Method to handle the keyboard interactions
 		private _onToggleCallback(): void {
 			this.triggerPlatformEventCallback(this._platformEventOnToggle, this._isOpen);
 		}
@@ -251,18 +196,14 @@ namespace OSFramework.OSUI.Patterns.AccordionItem {
 			Helper.Dom.Attribute.Remove(prevElementWithEvent, Constants.A11YAttributes.TabIndex);
 		}
 
-		/**
-		 * Method to remove the event listeners
-		 *
-		 * @private
-		 * @memberof AccordionItem
-		 */
+		// Method to remove the event listeners
 		private _removeEvents(): void {
 			const elem = this._previousElementWithEvents;
 			elem.removeEventListener(GlobalEnum.HTMLEvent.Click, this._eventOnClick);
 			elem.removeEventListener(GlobalEnum.HTMLEvent.keyDown, this._eventOnkeyPress);
 		}
 
+		// Method to set the A11Y properties
 		private _setA11ToogleElement(): void {
 			const elem = this._elementWithEvents;
 
@@ -273,12 +214,7 @@ namespace OSFramework.OSUI.Patterns.AccordionItem {
 			Helper.A11Y.RoleButton(elem);
 		}
 
-		/**
-		 * Method to set the parent Info, if an accordion wrapper is being used
-		 *
-		 * @private
-		 * @memberof AccordionItem
-		 */
+		// Method to set the parent Info, if an accordion wrapper is being used
 		private _setAccordionParent(): void {
 			// Get parent info
 			this.setParentInfo(
@@ -293,12 +229,7 @@ namespace OSFramework.OSUI.Patterns.AccordionItem {
 			}
 		}
 
-		/**
-		 * Method that changes the icon's position
-		 *
-		 * @private
-		 * @memberof AccordionItem
-		 */
+		// Method that changes the icon's position
 		private _setIconPosition(): void {
 			//If the page we're on is RTL, the icon's position has to change accordingly.
 			if (this.configs.IconPosition === GlobalEnum.Direction.Right) {
@@ -310,12 +241,7 @@ namespace OSFramework.OSUI.Patterns.AccordionItem {
 			}
 		}
 
-		/**
-		 * Method that changes the icon's type (Caret, Plus/Minus, Custom)
-		 *
-		 * @private
-		 * @memberof AccordionItem
-		 */
+		// Method that changes the icon's type (Caret, Plus/Minus, Custom)
 		private _setIconType(): void {
 			switch (this.configs.Icon) {
 				case Enum.IconType.PlusMinus:
@@ -342,12 +268,7 @@ namespace OSFramework.OSUI.Patterns.AccordionItem {
 			}
 		}
 
-		/**
-		 * Method to handle the IsDisabled state
-		 *
-		 * @private
-		 * @memberof AccordionItem
-		 */
+		// Method to handle the IsDisabled state
 		private _setIsDisabledState(): void {
 			if (this.configs.IsDisabled) {
 				Helper.Dom.Styles.AddClass(this.selfElement, Enum.CssClass.PatternDisabled);
@@ -373,12 +294,7 @@ namespace OSFramework.OSUI.Patterns.AccordionItem {
 			this._handleTabIndex();
 		}
 
-		/**
-		 * Method to handle the onTransitionEnd on accordion toggle animation
-		 *
-		 * @private
-		 * @memberof AccordionItem
-		 */
+		// Method to handle the onTransitionEnd on accordion toggle animation
 		private _transitionEndHandler(): void {
 			if (this._accordionItemContentElem) {
 				Helper.Dom.Styles.RemoveClass(this._accordionItemContentElem, Enum.CssClass.PatternAnimating);

--- a/src/scripts/OSFramework/OSUI/Pattern/AnimatedLabel/AnimatedLabel.ts
+++ b/src/scripts/OSFramework/OSUI/Pattern/AnimatedLabel/AnimatedLabel.ts
@@ -31,12 +31,7 @@ namespace OSFramework.OSUI.Patterns.AnimatedLabel {
 			this._isLabelFocus = false;
 		}
 
-		/**
-		 * Method to add Pattern Events
-		 *
-		 * @private
-		 * @memberof AnimatedLabel
-		 */
+		// Method to add Pattern Events
 		private _addEvents(): void {
 			this._inputElement.addEventListener(GlobalEnum.HTMLEvent.Blur, this._eventBlur);
 			this._inputElement.addEventListener(GlobalEnum.HTMLEvent.Focus, this._eventFocus);
@@ -46,52 +41,28 @@ namespace OSFramework.OSUI.Patterns.AnimatedLabel {
 			}
 		}
 
-		/**
-		 * Method to set callback to the event onAnimationStart
-		 *
-		 * @private
-		 * @param {AnimationEvent} e
-		 * @memberof AnimatedLabel
-		 */
+		// Method to set callback to the event onAnimationStart
 		private _inputAnimationStartCallback(e: AnimationEvent): void {
 			if (e.animationName === Enum.AnimationEvent.OnAutoFillStart) {
 				this._inputStateToggle(true);
 			}
 		}
 
-		/**
-		 * Method to set callback to the event "blur" of the input
-		 *
-		 * @private
-		 * @param {UIEvent} evt
-		 * @memberof AnimatedLabel
-		 */
+		// Method to set callback to the event "blur" of the input
 		private _inputBlurCallback(evt: UIEvent): void {
 			if (evt.type === GlobalEnum.HTMLEvent.Blur) {
 				this._inputStateToggle(false);
 			}
 		}
 
-		/**
-		 * Method to set callback to the event "focus" of the input
-		 *
-		 * @private
-		 * @param {UIEvent} evt
-		 * @memberof AnimatedLabel
-		 */
+		// Method to set callback to the event "focus" of the input
 		private _inputFocusCallback(evt: UIEvent): void {
 			if (evt.type === GlobalEnum.HTMLEvent.Focus) {
 				this._inputStateToggle(true);
 			}
 		}
 
-		/**
-		 * Method to set callback to the event "keydown" of the input
-		 *
-		 * @private
-		 * @param {KeyboardEvent} evt
-		 * @memberof AnimatedLabel
-		 */
+		// Method to set callback to the event "keydown" of the input
 		private _inputKeyDownCallback(evt: KeyboardEvent): void {
 			if (evt.type === GlobalEnum.HTMLEvent.keyDown && this._inputElement.type === 'number') {
 				const invalidChars = ['-', '+', 'e', 'E'];
@@ -101,14 +72,7 @@ namespace OSFramework.OSUI.Patterns.AnimatedLabel {
 			}
 		}
 
-		/**
-		 * Method that implements the toggle of the state of the input.
-		 * It can either add or remove the class "active" of the input.
-		 *
-		 * @private
-		 * @param {boolean} [isFocus=false]
-		 * @memberof AnimatedLabel
-		 */
+		// Method that implements the toggle of the state of the input. vIt can either add or remove the class "active" of the input.
 		private _inputStateToggle(isFocus = false): void {
 			if (this.isBuilt) {
 				// In this flag, we are checking if the input has value.
@@ -135,12 +99,7 @@ namespace OSFramework.OSUI.Patterns.AnimatedLabel {
 			}
 		}
 
-		/**
-		 * Method to remove Pattern Events
-		 *
-		 * @private
-		 * @memberof AnimatedLabel
-		 */
+		// Method to remove Pattern Events
 		private _removeEvents(): void {
 			this._inputElement.removeEventListener(GlobalEnum.HTMLEvent.Blur, this._eventBlur);
 			this._inputElement.removeEventListener(GlobalEnum.HTMLEvent.Focus, this._eventFocus);

--- a/src/scripts/OSFramework/OSUI/Pattern/BottomSheet/BottomSheet.ts
+++ b/src/scripts/OSFramework/OSUI/Pattern/BottomSheet/BottomSheet.ts
@@ -68,12 +68,7 @@ namespace OSFramework.OSUI.Patterns.BottomSheet {
 			super(uniqueId, new BottomSheetConfig(configs));
 		}
 
-		/**
-		 * Method to add Focus Trap to Pattern
-		 *
-		 * @private
-		 * @memberof BottomSheet
-		 */
+		// Method to add Focus Trap to Pattern
 		private _handleFocusBehavior(): void {
 			const opts = {
 				focusTargetElement: this._parentSelf,
@@ -85,12 +80,7 @@ namespace OSFramework.OSUI.Patterns.BottomSheet {
 			this._focusManagerInstance = new Behaviors.FocusManager();
 		}
 
-		/**
-		 * Method to handle the creation of the GestureEvents
-		 *
-		 * @private
-		 * @memberof BottomSheet
-		 */
+		// Method to handle the creation of the GestureEvents
 		private _handleGestureEvents(): void {
 			if (!Helper.DeviceInfo.IsDesktop) {
 				// Create and save gesture event instance. Created here and not on constructor,
@@ -102,13 +92,7 @@ namespace OSFramework.OSUI.Patterns.BottomSheet {
 			}
 		}
 
-		/**
-		 * Method to handle the Shape config css variable
-		 *
-		 * @private
-		 * @param {GlobalEnum.ShapeTypes} shape
-		 * @memberof BottomSheet
-		 */
+		// Method to handle the Shape config css variable
 		private _handleShape(shape: GlobalEnum.ShapeTypes): void {
 			Helper.Dom.Styles.SetStyleAttribute(
 				this.selfElement,
@@ -117,12 +101,7 @@ namespace OSFramework.OSUI.Patterns.BottomSheet {
 			);
 		}
 
-		/**
-		 * Method to be called as callback on scroll event, to toggle class on BottomSheet when it has scroll active
-		 *
-		 * @private
-		 * @memberof BottomSheet
-		 */
+		// Method to be called as callback on scroll event, to toggle class on BottomSheet when it has scroll active
 		private _onContentScrollCallback(): void {
 			if (this._bottomSheetContentElem.scrollTop === 0) {
 				Helper.Dom.Styles.RemoveClass(this.selfElement, Enum.CssClass.HasSCroll);
@@ -131,15 +110,7 @@ namespace OSFramework.OSUI.Patterns.BottomSheet {
 			}
 		}
 
-		/**
-		 * Method to handle the start of a gesture
-		 *
-		 * @private
-		 * @param {number} offsetX
-		 * @param {number} offsetY
-		 * @param {number} timeTaken
-		 * @memberof BottomSheet
-		 */
+		// Method to handle the start of a gesture
 		private _onGestureEnd(offsetX: number, offsetY: number, timeTaken: number): void {
 			this._animateOnDragInstance.onDragEnd(
 				offsetX,
@@ -150,29 +121,12 @@ namespace OSFramework.OSUI.Patterns.BottomSheet {
 			);
 		}
 
-		/**
-		 * Method to handle the gesture move
-		 *
-		 * @private
-		 * @param {number} x
-		 * @param {number} y
-		 * @param {number} offsetX
-		 * @param {number} offsetY
-		 * @param {TouchEvent} evt
-		 * @memberof BottomSheet
-		 */
+		// Method to handle the gesture move
 		private _onGestureMove(x: number, y: number, offsetX: number, offsetY: number, evt: TouchEvent): void {
 			this._animateOnDragInstance.onDragMove(offsetX, offsetY, x, y, evt);
 		}
 
-		/**
-		 * Method to handle the end of a gesture
-		 *
-		 * @private
-		 * @param {number} x
-		 * @param {number} y
-		 * @memberof BottomSheet
-		 */
+		// Method to handle the end of a gesture
 		private _onGestureStart(x: number, y: number): void {
 			this._animateOnDragInstance.onDragStart(
 				true,
@@ -184,13 +138,7 @@ namespace OSFramework.OSUI.Patterns.BottomSheet {
 			);
 		}
 
-		/**
-		 * Method to call open or close, based on e.key and behaviour applied
-		 *
-		 * @private
-		 * @param {KeyboardEvent} e
-		 * @memberof BottomSheet
-		 */
+		// Method to call open or close, based on e.key and behaviour applied
 		private _onkeypressCallback(e: KeyboardEvent): void {
 			switch (e.key) {
 				case GlobalEnum.Keycodes.Escape:
@@ -211,13 +159,7 @@ namespace OSFramework.OSUI.Patterns.BottomSheet {
 			}
 		}
 
-		/**
-		 * Method to toggle the open/close the BottomSheet
-		 *
-		 * @private
-		 * @param {boolean} isOpen
-		 * @memberof BottomSheet
-		 */
+		// Method to toggle the open/close the BottomSheet
 		private _toggleBottomSheet(isOpen: boolean): void {
 			// Cancel animation if active
 			if (this._animateOnDragInstance?.dragParams.SpringAnimation) {
@@ -260,13 +202,7 @@ namespace OSFramework.OSUI.Patterns.BottomSheet {
 			this._triggerOnToggleEvent();
 		}
 
-		/**
-		 * Method that toggles the showHandler config
-		 *
-		 * @private
-		 * @param {boolean} ShowHandler
-		 * @memberof BottomSheet
-		 */
+		// Method that toggles the showHandler config
 		private _toggleHandler(ShowHandler: boolean): void {
 			if (ShowHandler) {
 				Helper.Dom.Styles.AddClass(this.selfElement, Enum.CssClass.HasHandler);
@@ -275,12 +211,7 @@ namespace OSFramework.OSUI.Patterns.BottomSheet {
 			}
 		}
 
-		/**
-		 * Method that triggers the OnToggle event
-		 *
-		 * @private
-		 * @memberof BottomSheet
-		 */
+		// Method that triggers the OnToggle event
 		private _triggerOnToggleEvent(): void {
 			this.triggerPlatformEventCallback(this._platformEventOnToggle, this._isOpen);
 		}

--- a/src/scripts/OSFramework/OSUI/Pattern/DatePicker/AbstractDatePicker.ts
+++ b/src/scripts/OSFramework/OSUI/Pattern/DatePicker/AbstractDatePicker.ts
@@ -4,7 +4,6 @@ namespace OSFramework.OSUI.Patterns.DatePicker {
 		extends AbstractProviderPattern<P, C>
 		implements IDatePicker
 	{
-		// eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/explicit-module-boundary-types
 		constructor(uniqueId: string, configs: C) {
 			super(uniqueId, configs);
 		}

--- a/src/scripts/OSFramework/OSUI/Pattern/Dropdown/ServerSide/DropdownServerSide.ts
+++ b/src/scripts/OSFramework/OSUI/Pattern/Dropdown/ServerSide/DropdownServerSide.ts
@@ -495,7 +495,7 @@ namespace OSFramework.OSUI.Patterns.Dropdown.ServerSide {
 				GlobalEnum.HTMLEvent.keyDown,
 				this._eventOnkeyboardPress
 			);
-			Event.DOMEvents.Listeners.GlobalListenerManager.Instance.addHandler(
+			Event.DOMEvents.Listeners.GlobalListenerManager.Instance.removeHandler(
 				Event.DOMEvents.Listeners.Type.BalloonOnToggle,
 				this._eventBalloonOnToggle
 			);

--- a/src/scripts/OSFramework/OSUI/Pattern/FlipContent/FlipContent.ts
+++ b/src/scripts/OSFramework/OSUI/Pattern/FlipContent/FlipContent.ts
@@ -4,9 +4,7 @@ namespace OSFramework.OSUI.Patterns.FlipContent {
 	 * Defines the interface for OutSystemsUI Patterns
 	 */
 	export class FlipContent extends AbstractPattern<FlipContentConfig> implements IFlipContent {
-		// eslint-disable-next-line @typescript-eslint/no-explicit-any
 		private _eventClick: GlobalCallbacks.Generic;
-		// eslint-disable-next-line @typescript-eslint/no-explicit-any
 		private _eventKeydown: GlobalCallbacks.Generic;
 		//The Flip Content content wrapper
 		private _flipWrapperElement: HTMLElement;

--- a/src/scripts/OSFramework/OSUI/Pattern/FlipContent/FlipContent.ts
+++ b/src/scripts/OSFramework/OSUI/Pattern/FlipContent/FlipContent.ts
@@ -16,13 +16,7 @@ namespace OSFramework.OSUI.Patterns.FlipContent {
 			super(uniqueId, new FlipContentConfig(configs));
 		}
 
-		/**
-		 * Method to toggle pattern on keypress
-		 *
-		 * @private
-		 * @param {KeyboardEvent} e
-		 * @memberof FlipContent
-		 */
+		// Method to toggle pattern on keypress
 		private _keydownCallback(e: KeyboardEvent): void {
 			//If ENTER or SPACE use toggle to validate & If ESC is pressed then we need to close Flip
 			if (
@@ -36,23 +30,13 @@ namespace OSFramework.OSUI.Patterns.FlipContent {
 			}
 		}
 
-		/**
-		 * Method to remove the event listeners
-		 *
-		 * @private
-		 * @memberof FlipContent
-		 */
+		//  Method to remove the event listeners
 		private _removeEvents(): void {
 			this.selfElement.removeEventListener(GlobalEnum.HTMLEvent.keyDown, this._eventKeydown);
 			this._flipWrapperElement.removeEventListener(GlobalEnum.HTMLEvent.Click, this._eventClick);
 		}
 
-		/**
-		 * Method to set the handlers and the classes for when the FlipSelf is active or not
-		 *
-		 * @private
-		 * @memberof FlipContent
-		 */
+		// Method to set the handlers and the classes for when the FlipSelf is active or not
 		private _setEventHandlers(): void {
 			if (this.configs.FlipSelf) {
 				this.selfElement.addEventListener(GlobalEnum.HTMLEvent.keyDown, this._eventKeydown);
@@ -67,24 +51,14 @@ namespace OSFramework.OSUI.Patterns.FlipContent {
 			}
 		}
 
-		/**
-		 * Method to toggle FlipContent, if is to start flipped
-		 *
-		 * @private
-		 * @memberof FlipContent
-		 */
+		// Method to toggle FlipContent, if is to start flipped
 		private _setStartsFlipped() {
 			if (this.isBuilt === false) {
 				this._toggleClasses();
 			}
 		}
 
-		/**
-		 * Method to set the classes on the pattern's first render, toggle click & parameters changed
-		 *
-		 * @private
-		 * @memberof FlipContent
-		 */
+		// Method to set the classes on the pattern's first render, toggle click & parameters changed
 		private _toggleClasses(): void {
 			if (this.configs.IsFlipped) {
 				Helper.Dom.Styles.AddClass(this.selfElement, Enum.CssClass.PatternIsFlipped);
@@ -93,22 +67,12 @@ namespace OSFramework.OSUI.Patterns.FlipContent {
 			}
 		}
 
-		/**
-		 * Method to trigger the toggle event on the platform
-		 *
-		 * @private
-		 * @memberof FlipContent
-		 */
+		// Method to trigger the toggle event on the platform
 		private _triggerPlatformEvent(): void {
 			this.triggerPlatformEventCallback(this._platformEventOnToggle, this.configs.IsFlipped);
 		}
 
-		/**
-		 * Method to update the A11Y attributes
-		 *
-		 * @private
-		 * @memberof FlipContent
-		 */
+		// Method to update the A11Y attributes
 		private _updateA11yProperties(): void {
 			if (this.configs.FlipSelf) {
 				Helper.A11Y.AriaAtomicTrue(this.selfElement);

--- a/src/scripts/OSFramework/OSUI/Pattern/Gallery/Gallery.ts
+++ b/src/scripts/OSFramework/OSUI/Pattern/Gallery/Gallery.ts
@@ -13,12 +13,7 @@ namespace OSFramework.OSUI.Patterns.Gallery {
 			super(uniqueId, new GalleryConfig(configs));
 		}
 
-		/**
-		 * Function used to set the Gallery's items gap
-		 *
-		 * @private
-		 * @memberof OSFramework.Patterns.Gallery.Gallery
-		 */
+		// Function used to set the Gallery's items gap
 		private _setItemsGap(): void {
 			Helper.Dom.Styles.SetStyleAttribute(
 				this.selfElement,
@@ -27,12 +22,7 @@ namespace OSFramework.OSUI.Patterns.Gallery {
 			);
 		}
 
-		/**
-		 * Function used to set the Gallery's number of items per row in Desktop
-		 *
-		 * @private
-		 * @memberof OSFramework.Patterns.Gallery.Gallery
-		 */
+		// Function used to set the Gallery's number of items per row in Desktop
 		private _setRowItemsDesktop(): void {
 			//The number must be greater than 0
 			if (this.configs.RowItemsDesktop < Enum.Properties.MinRowItemsAllowed) {
@@ -56,12 +46,7 @@ namespace OSFramework.OSUI.Patterns.Gallery {
 			);
 		}
 
-		/**
-		 * Function used to set the Gallery's number of items per row in Phone
-		 *
-		 * @private
-		 * @memberof OSFramework.Patterns.Gallery.Gallery
-		 */
+		// Function used to set the Gallery's number of items per row in Phone
 		private _setRowItemsPhone(): void {
 			//The number must be greater than 0
 			if (this.configs.RowItemsPhone < Enum.Properties.MinRowItemsAllowed) {
@@ -84,12 +69,7 @@ namespace OSFramework.OSUI.Patterns.Gallery {
 			);
 		}
 
-		/**
-		 * Function used to set the Gallery's number of items per row in Tablet
-		 *
-		 * @private
-		 * @memberof OSFramework.Patterns.Gallery.Gallery
-		 */
+		// Function used to set the Gallery's number of items per row in Tablet
 		private _setRowItemsTablet(): void {
 			//The number must be greater than 0
 			if (this.configs.RowItemsTablet < Enum.Properties.MinRowItemsAllowed) {

--- a/src/scripts/OSFramework/OSUI/Pattern/InlineSvg/InlineSvg.ts
+++ b/src/scripts/OSFramework/OSUI/Pattern/InlineSvg/InlineSvg.ts
@@ -15,12 +15,7 @@ namespace OSFramework.OSUI.Patterns.InlineSvg {
 			super(uniqueId, new InlineSvgConfig(configs));
 		}
 
-		/**
-		 * Method that will set the given SVG code into the pattern container.
-		 *
-		 * @private
-		 * @memberof InlineSvg
-		 */
+		// Method that will set the given SVG code into the pattern container.
 		private _setSvgCode(): void {
 			if (this.configs.SVGCode !== '' && !Helper.SVG.IsValid(this.configs.SVGCode)) {
 				this.selfElement.innerHTML = '';

--- a/src/scripts/OSFramework/OSUI/Pattern/MonthPicker/AbstractMonthPicker.ts
+++ b/src/scripts/OSFramework/OSUI/Pattern/MonthPicker/AbstractMonthPicker.ts
@@ -4,7 +4,6 @@ namespace OSFramework.OSUI.Patterns.MonthPicker {
 		extends AbstractProviderPattern<P, C>
 		implements IMonthPicker
 	{
-		// eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/explicit-module-boundary-types
 		constructor(uniqueId: string, configs: C) {
 			super(uniqueId, configs);
 		}

--- a/src/scripts/OSFramework/OSUI/Pattern/MonthPicker/AbstractMonthPicker.ts
+++ b/src/scripts/OSFramework/OSUI/Pattern/MonthPicker/AbstractMonthPicker.ts
@@ -9,7 +9,7 @@ namespace OSFramework.OSUI.Patterns.MonthPicker {
 			super(uniqueId, configs);
 		}
 
-		// Common methods that all Carousels must implement!
+		// Common methods that all MonthPickers must implement!
 		public abstract clear(): void;
 		public abstract close(): void;
 		public abstract onRender(): void;

--- a/src/scripts/OSFramework/OSUI/Pattern/Notification/Notification.ts
+++ b/src/scripts/OSFramework/OSUI/Pattern/Notification/Notification.ts
@@ -40,36 +40,20 @@ namespace OSFramework.OSUI.Patterns.Notification {
 			this._isOpen = this.configs.StartsOpen;
 		}
 
-		/**
-		 * Method to close Notification after wait the time defined
-		 *
-		 * @private
-		 * @memberof Notification
-		 */
+		// Method to close Notification after wait the time defined
 		private _autoCloseNotification(): void {
 			this._autoCloseTimeoutId = Helper.ApplySetTimeOut(() => {
 				this.hide();
 			}, this.configs.CloseAfterTime);
 		}
 
-		/**
-		 * Method to trigger the notification at toggle behaviour
-		 *
-		 * @private
-		 * @param {MouseEvent} e
-		 * @memberof Notification
-		 */
+		// Method to trigger the notification at toggle behaviour
 		private _clickCallback(e: MouseEvent): void {
 			e.preventDefault();
 			this.hide();
 		}
 
-		/**
-		 * Method to add Focus Trap to Pattern
-		 *
-		 * @private
-		 * @memberof Notification
-		 */
+		// Method to add Focus Trap to Pattern
 		private _handleFocusBehavior(): void {
 			const opts = {
 				focusTargetElement: this._parentSelf,
@@ -80,12 +64,7 @@ namespace OSFramework.OSUI.Patterns.Notification {
 			this._focusManagerInstance = new Behaviors.FocusManager();
 		}
 
-		/**
-		 * Method to handle the creation of the GestureEvents
-		 *
-		 * @private
-		 * @memberof Notification
-		 */
+		// Method to handle the creation of the GestureEvents
 		private _handleGestureEvents(): void {
 			if (Helper.DeviceInfo.IsNative) {
 				// Create and save gesture event instance. Created here and not on constructor,
@@ -102,12 +81,7 @@ namespace OSFramework.OSUI.Patterns.Notification {
 			}
 		}
 
-		/**
-		 * Method to hide Notification
-		 *
-		 * @private
-		 * @memberof Notification
-		 */
+		// Method to hide Notification
 		private _hideNotification(): void {
 			this._isOpen = false;
 
@@ -135,13 +109,7 @@ namespace OSFramework.OSUI.Patterns.Notification {
 			}
 		}
 
-		/**
-		 * Method to call open or close, based ok e.key and behavior applied
-		 *
-		 * @private
-		 * @param {KeyboardEvent} e
-		 * @memberof Notification
-		 */
+		// Method to call open or close, based ok e.key and behavior applied
 		private _keypressCallback(e: KeyboardEvent): void {
 			const isEscapedPressed = e.key === GlobalEnum.Keycodes.Escape;
 
@@ -151,23 +119,13 @@ namespace OSFramework.OSUI.Patterns.Notification {
 			}
 		}
 
-		/**
-		 * Method to remove all the assigned events
-		 *
-		 * @private
-		 * @memberof Notification
-		 */
+		// Method to remove all the assigned events
 		private _removeEvents(): void {
 			this.selfElement.removeEventListener(this._eventType, this._eventOnClick);
 			this.selfElement.removeEventListener(GlobalEnum.HTMLEvent.keyDown, this._eventOnKeypress);
 		}
 
-		/**
-		 * Method to show Notification
-		 *
-		 * @private
-		 * @memberof Notification
-		 */
+		// Method to show Notification
 		private _showNotification(): void {
 			this._focusManagerInstance.storeLastFocusedElement();
 			this._isOpen = true;
@@ -198,23 +156,12 @@ namespace OSFramework.OSUI.Patterns.Notification {
 			}
 		}
 
-		/**
-		 * Method to trigger the OnToggle event
-		 *
-		 * @private
-		 * @param {boolean} isOpen
-		 * @memberof Notification
-		 */
+		// Method to trigger the OnToggle event
 		private _triggerOnToggleEvent(isOpen: boolean): void {
 			this.triggerPlatformEventCallback(this._platformEventOnToggle, isOpen);
 		}
 
-		/**
-		 * Method to set the cssClasses that should be assigned to the element on it's initialization
-		 *
-		 * @private
-		 * @memberof Notification
-		 */
+		// Method to set the cssClasses that should be assigned to the element on it's initialization
 		private _updateA11yProperties(): void {
 			Helper.Dom.Attribute.Set(
 				this.selfElement,
@@ -234,13 +181,7 @@ namespace OSFramework.OSUI.Patterns.Notification {
 			Helper.A11Y.SetElementsTabIndex(this._isOpen, this._focusTrapInstance.focusableElements);
 		}
 
-		/**
-		 * Method to update time to apply on AutoClose
-		 *
-		 * @private
-		 * @param {number} value
-		 * @memberof Notification
-		 */
+		// Method to update time to apply on AutoClose
 		private _updateCloseAfterTime(value: number): void {
 			this.configs.CloseAfterTime = value;
 			if (this._isOpen) {
@@ -248,13 +189,7 @@ namespace OSFramework.OSUI.Patterns.Notification {
 			}
 		}
 
-		/**
-		 * Method to update time to apply on AutoClose
-		 *
-		 * @private
-		 * @param {boolean} value
-		 * @memberof Notification
-		 */
+		// Method to update time to apply on AutoClose
 		private _updateInteractToClose(value: boolean): void {
 			if (this.configs.InteractToClose !== value) {
 				this.configs.InteractToClose = value;
@@ -268,13 +203,7 @@ namespace OSFramework.OSUI.Patterns.Notification {
 			}
 		}
 
-		/**
-		 * Method to update position
-		 *
-		 * @private
-		 * @param {string} position
-		 * @memberof Notification
-		 */
+		// Method to update position
 		private _updatePosition(position: string): void {
 			// Only change classes if are different
 			if (this.configs.Position !== position) {
@@ -287,13 +216,7 @@ namespace OSFramework.OSUI.Patterns.Notification {
 			}
 		}
 
-		/**
-		 * Method to update width
-		 *
-		 * @private
-		 * @param {string} width
-		 * @memberof Notification
-		 */
+		// Method to update width
 		private _updateWidth(width: string): void {
 			this.configs.Width = width;
 			if (width !== '') {

--- a/src/scripts/OSFramework/OSUI/Pattern/Notification/Notification.ts
+++ b/src/scripts/OSFramework/OSUI/Pattern/Notification/Notification.ts
@@ -109,7 +109,7 @@ namespace OSFramework.OSUI.Patterns.Notification {
 			}
 		}
 
-		// Method to call open or close, based ok e.key and behavior applied
+		// Method to call open or close, based on e.key and behavior applied
 		private _keypressCallback(e: KeyboardEvent): void {
 			const isEscapedPressed = e.key === GlobalEnum.Keycodes.Escape;
 

--- a/src/scripts/OSFramework/OSUI/Pattern/Notification/Notification.ts
+++ b/src/scripts/OSFramework/OSUI/Pattern/Notification/Notification.ts
@@ -363,8 +363,7 @@ namespace OSFramework.OSUI.Patterns.Notification {
 		 * @param {unknown} propertyValue
 		 * @memberof OSFramework.Patterns.Notification.Notification
 		 */
-		// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any
-		public changeProperty(propertyName: string, propertyValue: any): void {
+		public changeProperty(propertyName: string, propertyValue: unknown): void {
 			const _oldNotificationPosition = this.configs.Position;
 
 			super.changeProperty(propertyName, propertyValue);
@@ -373,10 +372,10 @@ namespace OSFramework.OSUI.Patterns.Notification {
 				// Check which property changed and call respective method to update it
 				switch (propertyName) {
 					case Enum.Properties.InteractToClose:
-						this._updateInteractToClose(propertyValue);
+						this._updateInteractToClose(propertyValue as boolean);
 						break;
 					case Enum.Properties.CloseAfterTime:
-						this._updateCloseAfterTime(propertyValue);
+						this._updateCloseAfterTime(propertyValue as number);
 						break;
 					case Enum.Properties.StartsOpen:
 						console.warn(
@@ -387,7 +386,7 @@ namespace OSFramework.OSUI.Patterns.Notification {
 						this._updatePosition(_oldNotificationPosition);
 						break;
 					case Enum.Properties.Width:
-						this._updateWidth(propertyValue);
+						this._updateWidth(propertyValue as string);
 						break;
 					case GlobalEnum.CommonPatternsProperties.ExtendedClass:
 						Helper.Dom.Styles.ExtendedClass(

--- a/src/scripts/OSFramework/OSUI/Pattern/Progress/AbstractProgress.ts
+++ b/src/scripts/OSFramework/OSUI/Pattern/Progress/AbstractProgress.ts
@@ -10,7 +10,6 @@ namespace OSFramework.OSUI.Patterns.Progress {
 		protected progressElem: HTMLElement;
 		protected progressType: ProgressEnum.ProgressTypes;
 
-		// eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/explicit-module-boundary-types
 		constructor(uniqueId: string, configs: C) {
 			super(uniqueId, configs);
 		}

--- a/src/scripts/OSFramework/OSUI/Pattern/Progress/AbstractProgressConfiguration.ts
+++ b/src/scripts/OSFramework/OSUI/Pattern/Progress/AbstractProgressConfiguration.ts
@@ -9,10 +9,5 @@ namespace OSFramework.OSUI.Patterns.Progress {
 		public Shape: string;
 		public Thickness: number;
 		public TrailColor: string;
-
-		// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any
-		constructor(config: any) {
-			super(config);
-		}
 	}
 }

--- a/src/scripts/OSFramework/OSUI/Pattern/Progress/Bar/ProgressBar.ts
+++ b/src/scripts/OSFramework/OSUI/Pattern/Progress/Bar/ProgressBar.ts
@@ -3,8 +3,7 @@
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 namespace OSFramework.OSUI.Patterns.Progress.Bar {
 	export class Bar extends Progress.AbstractProgress<ProgressBarConfig> {
-		// eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/explicit-module-boundary-types
-		constructor(uniqueId: string, configs: any) {
+		constructor(uniqueId: string, configs: unknown) {
 			super(uniqueId, new ProgressBarConfig(configs));
 			this.progressType = ProgressEnum.ProgressTypes.Bar;
 		}

--- a/src/scripts/OSFramework/OSUI/Pattern/Progress/Bar/ProgressBarConfig.ts
+++ b/src/scripts/OSFramework/OSUI/Pattern/Progress/Bar/ProgressBarConfig.ts
@@ -2,10 +2,5 @@
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 namespace OSFramework.OSUI.Patterns.Progress.Bar {
-	export class ProgressBarConfig extends Progress.ProgressConfiguration {
-		// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any
-		constructor(config: any) {
-			super(config);
-		}
-	}
+	export class ProgressBarConfig extends Progress.ProgressConfiguration {}
 }

--- a/src/scripts/OSFramework/OSUI/Pattern/Progress/Circle/ProgressCircle.ts
+++ b/src/scripts/OSFramework/OSUI/Pattern/Progress/Circle/ProgressCircle.ts
@@ -35,8 +35,7 @@ namespace OSFramework.OSUI.Patterns.Progress.Circle {
 			r: Enum.DefaultValues.RadialRadius,
 		};
 
-		// eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/explicit-module-boundary-types
-		constructor(uniqueId: string, configs: any) {
+		constructor(uniqueId: string, configs: unknown) {
 			super(uniqueId, new ProgressCircleConfig(configs));
 		}
 

--- a/src/scripts/OSFramework/OSUI/Pattern/Progress/Circle/ProgressCircleConfig.ts
+++ b/src/scripts/OSFramework/OSUI/Pattern/Progress/Circle/ProgressCircleConfig.ts
@@ -2,10 +2,5 @@
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 namespace OSFramework.OSUI.Patterns.Progress.Circle {
-	export class ProgressCircleConfig extends Progress.ProgressConfiguration {
-		// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any
-		constructor(config: any) {
-			super(config);
-		}
-	}
+	export class ProgressCircleConfig extends Progress.ProgressConfiguration {}
 }

--- a/src/scripts/OSFramework/OSUI/Pattern/Rating/Rating.ts
+++ b/src/scripts/OSFramework/OSUI/Pattern/Rating/Rating.ts
@@ -344,7 +344,7 @@ namespace OSFramework.OSUI.Patterns.Rating {
 			this._toggleRatingInputsEvents(!this.configs.IsEdit && !this._disabled);
 		}
 
-		// Method to retunr the list of rating placeholders with the updated id attribute
+		// Method to return the list of rating placeholders with the updated id attribute
 		private _updateClonePlaceholdersAttrs(ratingIndex: number): string {
 			// Store the ourterHTML of the placeholders
 			let placeholdersOuterHTML = '';

--- a/src/scripts/OSFramework/OSUI/Pattern/Rating/Rating.ts
+++ b/src/scripts/OSFramework/OSUI/Pattern/Rating/Rating.ts
@@ -29,12 +29,7 @@ namespace OSFramework.OSUI.Patterns.Rating {
 			super(uniqueId, new RatingConfig(configs));
 		}
 
-		/**
-		 * Method that will iterate on the RatingScale, to crate an item for each one
-		 *
-		 * @private
-		 * @memberof Rating
-		 */
+		// Method that will iterate on the RatingScale, to crate an item for each one
 		private _createItems(): void {
 			// Check if the the we should limit the amount of items
 			if (this.configs.RatingScale > Enum.Properties.MaxRatingScale) {
@@ -52,26 +47,12 @@ namespace OSFramework.OSUI.Patterns.Rating {
 			}
 		}
 
-		/**
-		 * Method to get the rating decimal value
-		 *
-		 * @private
-		 * @param {number} value
-		 * @return {*}  {number}
-		 * @memberof Rating
-		 */
+		// Method to get the rating decimal value
 		private _getDecimalValue(value: number): number {
 			return Math.round((value - Math.floor(value)) * 100) / 100;
 		}
 
-		/**
-		 * Method to get if the valie is-half
-		 *
-		 * @private
-		 * @param {number} value
-		 * @return {*}  {boolean}
-		 * @memberof Rating
-		 */
+		// Method to get if the valie is-half
 		private _getIsHalfValue(value: number): boolean {
 			const decimalValue = this._getDecimalValue(value);
 			// If bigger than 0.3 and lower than 0.7 means it should be represented as a half value.
@@ -79,24 +60,13 @@ namespace OSFramework.OSUI.Patterns.Rating {
 			return !!(decimalValue >= 0.3 && decimalValue <= 0.7);
 		}
 
-		/**
-		 * Method to get the rating value
-		 *
-		 * @private
-		 * @return {*}  {number}
-		 * @memberof Rating
-		 */
+		// Method to get the rating value
 		private _getValue(): number {
 			const inputChecked = Helper.Dom.TagSelector(this.selfElement, 'input:checked') as HTMLInputElement;
 			return parseInt(inputChecked.value);
 		}
 
-		/**
-		 * Method that handles the placeholders content storage and DOM lifecycle
-		 *
-		 * @private
-		 * @memberof Rating
-		 */
+		// Method that handles the placeholders content storage and DOM lifecycle
 		private _handlePlaceholders(): void {
 			// Store the placholders content to cloned after
 			this._clonedPlaceholders = Array.from(this._ratingIconStatesElem.children) as HTMLElement[];
@@ -105,13 +75,7 @@ namespace OSFramework.OSUI.Patterns.Rating {
 			this._ratingIconStatesElem.remove();
 		}
 
-		/**
-		 * Method used to set the keyboard keydown event
-		 *
-		 * @private
-		 * @param {KeyboardEvent} e event
-		 * @memberof Rating
-		 */
+		// Method used to set the keyboard keydown event
 		private _ratingInputOnKeyup(e: KeyboardEvent): void {
 			// Ensure keys pressed are arrows
 			if (
@@ -128,13 +92,7 @@ namespace OSFramework.OSUI.Patterns.Rating {
 			}
 		}
 
-		/**
-		 * Method that handles the click event and set the new value, by checking the input:checked
-		 *
-		 * @private
-		 * @param {MouseEvent}
-		 * @memberof Rating
-		 */
+		// Method that handles the click event and set the new value, by checking the input:checked
 		private _ratingOnClick(e: MouseEvent): void {
 			const currentTarget = e.target as HTMLElement;
 			// Remove the is-half when clicking, as a click will never result in a half value
@@ -158,13 +116,7 @@ namespace OSFramework.OSUI.Patterns.Rating {
 			}
 		}
 
-		/**
-		 * Method called on createItems() to render the correct HTML structure for each item
-		 *
-		 * @private
-		 * @param {number} index
-		 * @memberof Rating
-		 */
+		// Method called on createItems() to render the correct HTML structure for each item
 		private _renderItem(index: number): void {
 			// if not first input, which is hidden, add the html stored form the placeholders
 			const labelHTML = index !== 0 ? this._updateClonePlaceholdersAttrs(index) : '';
@@ -186,12 +138,7 @@ namespace OSFramework.OSUI.Patterns.Rating {
 			this._ratingFieldsetElem.innerHTML += input + label;
 		}
 
-		/**
-		 * Method that will add the needed events
-		 *
-		 * @private
-		 * @memberof Rating
-		 */
+		// Method that will add the needed events
 		private _setEvents(): void {
 			if (this.configs.IsEdit) {
 				// Otherwise, if there is no event already added and the param IsEdit is true, add new event
@@ -202,13 +149,7 @@ namespace OSFramework.OSUI.Patterns.Rating {
 			this._toggleRatingInputsEvents(!this.configs.IsEdit);
 		}
 
-		/**
-		 * Method to toggle fieldset disbaled status
-		 *
-		 * @private
-		 * @param {boolean} isDisabled
-		 * @memberof Rating
-		 */
+		// Method to toggle fieldset disbaled status
 		private _setFieldsetDisabledStatus(isDisabled: boolean): void {
 			const isFieldsetDisabled = Helper.Dom.Attribute.Get(
 				this._ratingFieldsetElem,
@@ -226,12 +167,7 @@ namespace OSFramework.OSUI.Patterns.Rating {
 			}
 		}
 
-		/**
-		 * Method to set the cssClasses that should be assigned to the element on it's initialization
-		 *
-		 * @private
-		 * @memberof Rating
-		 */
+		// Method to set the cssClasses that should be assigned to the element on it's initialization
 		private _setInitialCssClasses(): void {
 			// Set IsHalf class
 			if (this._isHalfValue) {
@@ -249,23 +185,12 @@ namespace OSFramework.OSUI.Patterns.Rating {
 			}
 		}
 
-		/**
-		 * Method to set the initial and local properties values
-		 *
-		 * @private
-		 * @memberof Rating
-		 */
+		// Method to set the initial and local properties values
 		private _setInitialPropertiesValues(): void {
 			this._ratingInputName = 'rating-' + this.uniqueId;
 		}
 
-		/**
-		 * Method to set disabled status
-		 *
-		 * @private
-		 * @param {boolean} isDisabled
-		 * @memberof Rating
-		 */
+		// Method to set disabled status
 		private _setIsDisabled(isDisabled: boolean): void {
 			this._disabled = isDisabled;
 			this._setFieldsetDisabledStatus(isDisabled);
@@ -277,12 +202,7 @@ namespace OSFramework.OSUI.Patterns.Rating {
 			}
 		}
 
-		/**
-		 * Method to set the IsEdit option
-		 *
-		 * @private
-		 * @memberof Rating
-		 */
+		// Method to set the IsEdit option
 		private _setIsEdit(): void {
 			// Toggle the is-edit class
 			if (this.configs.IsEdit) {
@@ -299,12 +219,7 @@ namespace OSFramework.OSUI.Patterns.Rating {
 			}
 		}
 
-		/**
-		 * Method to set a RatingScale - The amout of stars pattern will have
-		 *
-		 * @private
-		 * @memberof Rating
-		 */
+		// Method to set a RatingScale - The amout of stars pattern will have
 		private _setScale(): void {
 			// Clean (if already exist) old Stars inside pattern
 			this._ratingFieldsetElem.innerHTML = '';
@@ -314,13 +229,7 @@ namespace OSFramework.OSUI.Patterns.Rating {
 			this._setValue();
 		}
 
-		/**
-		 * Method to set the Rating Size
-		 *
-		 * @private
-		 * @param {string} oldSize
-		 * @memberof Rating
-		 */
+		// Method to set the Rating Size
 		private _setSize(oldSize: string): void {
 			// Reset current class
 			if (oldSize !== '') {
@@ -333,14 +242,7 @@ namespace OSFramework.OSUI.Patterns.Rating {
 			}
 		}
 
-		/**
-		 * Method to set a rating value
-		 *
-		 * @private
-		 * @param {boolean} [triggerEvent=false]
-		 * @return {*}  {void}
-		 * @memberof Rating
-		 */
+		// Method to set a rating value
 		private _setValue(triggerEvent = false): void {
 			// Check if passed value is decimal
 			this._decimalValue = this._getDecimalValue(this.configs.RatingValue);
@@ -411,10 +313,6 @@ namespace OSFramework.OSUI.Patterns.Rating {
 		 * Method used to manage the Rating inputs events, they will be only set when IsEdit=False
 		 * - This is needed in order to grant keyboard behaves like ckick, in order to avoid user be able
 		 * to select any star by using keyboard navigation when IsEdit=False!
-		 *
-		 * @private
-		 * @param {boolean} add Flag to indicates if events should be added or removed.
-		 * @memberof Rating
 		 */
 		private _toggleRatingInputsEvents(add: boolean): void {
 			// Get the list of inputs
@@ -429,25 +327,14 @@ namespace OSFramework.OSUI.Patterns.Rating {
 			}
 		}
 
-		/**
-		 * Method that triggers the OnSelect event
-		 *
-		 * @private
-		 * @param {number} value
-		 * @memberof Rating
-		 */
+		// Method that triggers the OnSelect event
 		private _triggerOnSelectEvent(value: number): void {
 			if (this._platformEventOnSelect !== undefined) {
 				this.triggerPlatformEventCallback(this._platformEventOnSelect, value);
 			}
 		}
 
-		/**
-		 * Method to remove the event listeners
-		 *
-		 * @private
-		 * @memberof Rating
-		 */
+		// Method to remove the event listeners
 		private _unsetEvents(): void {
 			if ((this.selfElement && this.configs.IsEdit === false) || this._disabled) {
 				this.selfElement.removeEventListener(GlobalEnum.HTMLEvent.Click, this._eventOnRatingClick);
@@ -457,14 +344,7 @@ namespace OSFramework.OSUI.Patterns.Rating {
 			this._toggleRatingInputsEvents(!this.configs.IsEdit && !this._disabled);
 		}
 
-		/**
-		 * Method to retunr the list of rating placeholders with the updated id attribute
-		 *
-		 * @private
-		 * @param {number} ratingIndex
-		 * @return {*}  {string}
-		 * @memberof Rating
-		 */
+		// Method to retunr the list of rating placeholders with the updated id attribute
 		private _updateClonePlaceholdersAttrs(ratingIndex: number): string {
 			// Store the ourterHTML of the placeholders
 			let placeholdersOuterHTML = '';

--- a/src/scripts/OSFramework/OSUI/Pattern/Sidebar/Sidebar.ts
+++ b/src/scripts/OSFramework/OSUI/Pattern/Sidebar/Sidebar.ts
@@ -179,7 +179,7 @@ namespace OSFramework.OSUI.Patterns.Sidebar {
 			Helper.A11Y.SetElementsTabIndex(this._isOpen, this._focusTrapInstance.focusableElements);
 		}
 
-		// Method to close Sidebar on an overlay click
+		// Method to close a Sidebar with a click on the overlay
 		private _overlayClickCallback(_args: string, e: MouseEvent): void {
 			// If the sidebar is opened and the mouse down event occured outside the sidebar, close it.
 			if (

--- a/src/scripts/OSFramework/OSUI/Pattern/Sidebar/Sidebar.ts
+++ b/src/scripts/OSFramework/OSUI/Pattern/Sidebar/Sidebar.ts
@@ -44,12 +44,7 @@ namespace OSFramework.OSUI.Patterns.Sidebar {
 			this._currentDirectionCssClass = Enum.CssClass.ClassModifier + this.configs.Direction;
 		}
 
-		/**
-		 * Method to close Sidebar
-		 *
-		 * @private
-		 * @memberof Sidebar
-		 */
+		// Method to close Sidebar
 		private _closeSidebar(): void {
 			this._isOpen = false;
 
@@ -81,12 +76,7 @@ namespace OSFramework.OSUI.Patterns.Sidebar {
 			this._focusManagerInstance.setFocusToStoredElement();
 		}
 
-		/**
-		 * Method to add Focus Trap to Pattern
-		 *
-		 * @private
-		 * @memberof Sidebar
-		 */
+		// Method to add Focus Trap to Pattern
 		private _handleFocusBehavior(): void {
 			const opts = {
 				focusTargetElement: this._parentSelf,
@@ -104,12 +94,7 @@ namespace OSFramework.OSUI.Patterns.Sidebar {
 			}
 		}
 
-		/**
-		 * Method to handle the creation of the GestureEvents
-		 *
-		 * @private
-		 * @memberof Sidebar
-		 */
+		// Method to handle the creation of the GestureEvents
 		private _handleGestureEvents(): void {
 			if (Helper.DeviceInfo.IsNative) {
 				// Create and save gesture event instance. Created here and not on constructor,
@@ -127,15 +112,7 @@ namespace OSFramework.OSUI.Patterns.Sidebar {
 			}
 		}
 
-		/**
-		 * Method to handle the start of a gesture
-		 *
-		 * @private
-		 * @param {number} offsetX
-		 * @param {number} offsetY
-		 * @param {number} timeTaken
-		 * @memberof Sidebar
-		 */
+		// Method to handle the start of a gesture
 		private _onGestureEnd(offsetX: number, offsetY: number, timeTaken: number): void {
 			this._animateOnDragInstance.onDragEnd(offsetX, offsetY, timeTaken, this._toggle.bind(this));
 
@@ -144,17 +121,7 @@ namespace OSFramework.OSUI.Patterns.Sidebar {
 			}
 		}
 
-		/**
-		 * Method to handle the gesture move
-		 *
-		 * @private
-		 * @param {number} x
-		 * @param {number} y
-		 * @param {number} offsetX
-		 * @param {number} offsetY
-		 * @param {TouchEvent} evt
-		 * @memberof Sidebar
-		 */
+		// Method to handle the gesture move
 		private _onGestureMove(x: number, y: number, offsetX: number, offsetY: number, evt: TouchEvent): void {
 			this._animateOnDragInstance.onDragMove(offsetX, offsetY, x, y, evt);
 
@@ -163,14 +130,7 @@ namespace OSFramework.OSUI.Patterns.Sidebar {
 			}
 		}
 
-		/**
-		 * Method to handle the end of a gesture
-		 *
-		 * @private
-		 * @param {number} x
-		 * @param {number} y
-		 * @memberof Sidebar
-		 */
+		// Method to handle the end of a gesture
 		private _onGestureStart(x: number, y: number): void {
 			this._animateOnDragInstance.onDragStart(
 				false,
@@ -182,12 +142,7 @@ namespace OSFramework.OSUI.Patterns.Sidebar {
 			);
 		}
 
-		/**
-		 * Method to open Sidebar
-		 *
-		 * @private
-		 * @memberof Sidebar
-		 */
+		// Method to open Sidebar
 		private _openSidebar() {
 			Helper.Dom.Styles.AddClass(this.selfElement, Enum.CssClass.IsOpen);
 			Helper.A11Y.TabIndexTrue(this.selfElement);
@@ -224,14 +179,7 @@ namespace OSFramework.OSUI.Patterns.Sidebar {
 			Helper.A11Y.SetElementsTabIndex(this._isOpen, this._focusTrapInstance.focusableElements);
 		}
 
-		/**
-		 * Method to close Sidebar on an overlay click
-		 *
-		 * @private
-		 * @param {string} _args
-		 * @param {MouseEvent} e
-		 * @memberof Sidebar
-		 */
+		// Method to close Sidebar on an overlay click
 		private _overlayClickCallback(_args: string, e: MouseEvent): void {
 			// If the sidebar is opened and the mouse down event occured outside the sidebar, close it.
 			if (
@@ -247,11 +195,6 @@ namespace OSFramework.OSUI.Patterns.Sidebar {
 		/**
 		 * Method to check if the mouse down event happened outside the sidebar
 		 * This is required to cover the cases when selecting text and moving the cursor to the sidebar's overlay.
-		 *
-		 * @private
-		 * @param {string} _args
-		 * @param {MouseEvent} e
-		 * @memberof Sidebar
 		 */
 		private _overlayMouseDownCallback(_args: string, e: MouseEvent): void {
 			const targetElem = e.target as HTMLElement;
@@ -265,12 +208,7 @@ namespace OSFramework.OSUI.Patterns.Sidebar {
 			}
 		}
 
-		/**
-		 * Method to remove the event listeners
-		 *
-		 * @private
-		 * @memberof Sidebar
-		 */
+		// Method to remove the event listeners
 		private _removeEvents(): void {
 			this.selfElement.removeEventListener(GlobalEnum.HTMLEvent.keyDown, this._eventSidebarKeypress);
 			Event.DOMEvents.Listeners.GlobalListenerManager.Instance.removeHandler(
@@ -283,12 +221,7 @@ namespace OSFramework.OSUI.Patterns.Sidebar {
 			);
 		}
 
-		/**
-		 * Method to set the Sidebar opening/closing direction
-		 *
-		 * @private
-		 * @memberof Sidebar
-		 */
+		// Method to set the Sidebar opening/closing direction
 		private _setDirection(): void {
 			// Reset direction class
 			if (this._currentDirectionCssClass !== '') {
@@ -298,12 +231,7 @@ namespace OSFramework.OSUI.Patterns.Sidebar {
 			Helper.Dom.Styles.AddClass(this.selfElement, this._currentDirectionCssClass);
 		}
 
-		/**
-		 * Method to sets the Sidebar overlay
-		 *
-		 * @private
-		 * @memberof Sidebar
-		 */
+		// Method to sets the Sidebar overlay
 		private _setHasOverlay(): void {
 			const alreadyHasOverlayClass = Helper.Dom.Styles.ContainsClass(this.selfElement, Enum.CssClass.HasOverlay);
 
@@ -314,12 +242,7 @@ namespace OSFramework.OSUI.Patterns.Sidebar {
 			}
 		}
 
-		/**
-		 * Method to set the cssClasses that should be assigned to the element on it's initialization
-		 *
-		 * @private
-		 * @memberof Sidebar
-		 */
+		// Method to set the cssClasses that should be assigned to the element on it's initialization
 		private _setInitialCssClasses(): void {
 			this._setDirection();
 			this._setWidth();
@@ -330,23 +253,12 @@ namespace OSFramework.OSUI.Patterns.Sidebar {
 			}
 		}
 
-		/**
-		 * Method to set the Sidebar width
-		 *
-		 * @private
-		 * @memberof Sidebar
-		 */
+		// Method to set the Sidebar width
 		private _setWidth(): void {
 			Helper.Dom.Styles.SetStyleAttribute(this.selfElement, Enum.CssProperty.Width, this.configs.Width);
 		}
 
-		/**
-		 * Method that will handle the tab navigation and sidebar closing on Escape
-		 *
-		 * @private
-		 * @param {KeyboardEvent} e
-		 * @memberof Sidebar
-		 */
+		// Method that will handle the tab navigation and sidebar closing on Escape
 		private _sidebarKeypressCallback(e: KeyboardEvent): void {
 			const isEscapedPressed = e.key === GlobalEnum.Keycodes.Escape;
 
@@ -358,12 +270,7 @@ namespace OSFramework.OSUI.Patterns.Sidebar {
 			e.stopPropagation();
 		}
 
-		/**
-		 * Method to toggle the Sidebar
-		 *
-		 * @private
-		 * @memberof Sidebar
-		 */
+		// Method to toggle the Sidebar
 		private _toggle(): void {
 			if (this._isOpen) {
 				this.close();
@@ -372,13 +279,7 @@ namespace OSFramework.OSUI.Patterns.Sidebar {
 			}
 		}
 
-		/**
-		 * Method to toggle gestures on Sidebar
-		 *
-		 * @private
-		 * @param {boolean} enableSwipes
-		 * @memberof Sidebar
-		 */
+		// Method to toggle gestures on Sidebar
 		private _toggleGesturesSidebar(enableSwipes: boolean): void {
 			if (enableSwipes && this._hasGestureEvents === false) {
 				if (this._gestureEventInstance === undefined) {
@@ -389,12 +290,7 @@ namespace OSFramework.OSUI.Patterns.Sidebar {
 			}
 		}
 
-		/**
-		 * Method that triggers the OnToggle event
-		 *
-		 * @private
-		 * @memberof Sidebar
-		 */
+		// Method that triggers the OnToggle event
 		private _triggerOnToggleEvent(): void {
 			this.triggerPlatformEventCallback(this._platformEventOnToggle, this._isOpen);
 		}

--- a/src/scripts/OSFramework/OSUI/Pattern/Sidebar/Sidebar.ts
+++ b/src/scripts/OSFramework/OSUI/Pattern/Sidebar/Sidebar.ts
@@ -181,7 +181,7 @@ namespace OSFramework.OSUI.Patterns.Sidebar {
 
 		// Method to close a Sidebar with a click on the overlay
 		private _overlayClickCallback(_args: string, e: MouseEvent): void {
-			// If the sidebar is opened and the mouse down event occured outside the sidebar, close it.
+			// If the sidebar is opened and the mouse down event occurred outside the sidebar, close it.
 			if (
 				this._isOpen &&
 				this._clickedOutsideElement &&

--- a/src/scripts/OSFramework/OSUI/Pattern/Submenu/Submenu.ts
+++ b/src/scripts/OSFramework/OSUI/Pattern/Submenu/Submenu.ts
@@ -421,10 +421,7 @@ namespace OSFramework.OSUI.Patterns.Submenu {
 
 				this._focusManagerInstance.setFocusToStoredElement();
 
-				this._submenuLinksElement.removeEventListener(
-					GlobalEnum.HTMLEvent.keyDown,
-					this._eventBalloonKeypress.bind(this)
-				);
+				this._submenuLinksElement.removeEventListener(GlobalEnum.HTMLEvent.keyDown, this._eventBalloonKeypress);
 
 				// Trigger the _platformEventOnToggleCallback callback!
 				this.triggerPlatformEventCallback(this._platformEventOnToggleCallback, false);
@@ -467,10 +464,7 @@ namespace OSFramework.OSUI.Patterns.Submenu {
 				);
 			}
 
-			this._submenuLinksElement.addEventListener(
-				GlobalEnum.HTMLEvent.keyDown,
-				this._eventBalloonKeypress.bind(this)
-			);
+			this._submenuLinksElement.addEventListener(GlobalEnum.HTMLEvent.keyDown, this._eventBalloonKeypress);
 
 			// Make async the method call
 			Helper.AsyncInvocation(this._show.bind(this));

--- a/src/scripts/OSFramework/OSUI/Pattern/Tabs/Tabs.ts
+++ b/src/scripts/OSFramework/OSUI/Pattern/Tabs/Tabs.ts
@@ -745,7 +745,7 @@ namespace OSFramework.OSUI.Patterns.Tabs {
 			);
 		}
 
-		// Function that will update the list of enabled tabs headers
+		// Method to update the list of enabled tab headers
 		private _updateListOfEnabledTabsHeader(): void {
 			this._tabsHeadersEnabled = (
 				this.getChildItems(Enum.ChildTypes.TabsHeaderItem) as Patterns.TabsHeaderItem.ITabsHeaderItem[]

--- a/src/scripts/OSFramework/OSUI/Pattern/Tabs/Tabs.ts
+++ b/src/scripts/OSFramework/OSUI/Pattern/Tabs/Tabs.ts
@@ -53,13 +53,8 @@ namespace OSFramework.OSUI.Patterns.Tabs {
 				Helper.DeviceInfo.IsNative && this.configs.TabsOrientation === GlobalEnum.Orientation.Horizontal;
 		}
 
-		/**
-		 * Method that it's called whenever a new TabsContentItem is rendered
-		 *
-		 * @private
-		 * @param {Patterns.TabsContentItem.TabsContentItem} tabsContentChildItem
-		 * @memberof Tabs
-		 */
+		// Method that it's called whenever a new TabsContentItem is rendered
+
 		private _addContentItem(tabsContentChildItem: Patterns.TabsContentItem.TabsContentItem): void {
 			if (this.getChild(tabsContentChildItem.uniqueId)) {
 				throw new Error(
@@ -91,12 +86,7 @@ namespace OSFramework.OSUI.Patterns.Tabs {
 			}
 		}
 
-		/**
-		 * Add event listener for arrow navigation
-		 *
-		 * @private
-		 * @memberof Tabs
-		 */
+		// Add event listener for arrow navigation
 		private _addEvents(): void {
 			this.selfElement.addEventListener(GlobalEnum.HTMLEvent.keyDown, this._eventOnHeaderKeypress);
 
@@ -115,13 +105,7 @@ namespace OSFramework.OSUI.Patterns.Tabs {
 			}
 		}
 
-		/**
-		 * Method that it's called whenever a new TabsHeaderItem is rendered
-		 *
-		 * @private
-		 * @param {Patterns.TabsHeaderItem.TabsHeaderItem} tabsHeaderChildItem
-		 * @memberof Tabs
-		 */
+		// Method that it's called whenever a new TabsHeaderItem is rendered
 		private _addHeaderItem(tabsHeaderChildItem: Patterns.TabsHeaderItem.TabsHeaderItem): void {
 			if (this.getChild(tabsHeaderChildItem.uniqueId)) {
 				throw new Error(
@@ -162,14 +146,7 @@ namespace OSFramework.OSUI.Patterns.Tabs {
 			}
 		}
 
-		/**
-		 * Method to change the active content item
-		 *
-		 * @private
-		 * @param {number} newTabIndex
-		 * @param {boolean} triggeredByObserver
-		 * @memberof Tabs
-		 */
+		// Method to change the active content item
 		private _changeActiveContentItem(newTabIndex: number, triggeredByObserver: boolean): void {
 			// Get the contentItem, based on the newTabIndex
 			const newContentItem = this.getChildByIndex(
@@ -198,13 +175,7 @@ namespace OSFramework.OSUI.Patterns.Tabs {
 			}
 		}
 
-		/**
-		 * Method to change the active header item
-		 *
-		 * @private
-		 * @param {TabsHeaderItem.ITabsHeaderItem} newHeaderItem
-		 * @memberof Tabs
-		 */
+		// Method to change the active header item
 		private _changeActiveHeaderItem(newHeaderItem: TabsHeaderItem.ITabsHeaderItem): void {
 			// Remove old headerItem as active
 			if (this._activeTabHeaderElement) {
@@ -218,14 +189,7 @@ namespace OSFramework.OSUI.Patterns.Tabs {
 			}
 		}
 
-		/**
-		 * Method to determine the next target index on changeTab method
-		 *
-		 * @private
-		 * @param {number} tabIndex
-		 * @return {*}  {number}
-		 * @memberof Tabs
-		 */
+		// Method to determine the next target index on changeTab method
 		private _getTargetIndex(tabIndex: number): number {
 			let newTabIndex;
 
@@ -243,14 +207,7 @@ namespace OSFramework.OSUI.Patterns.Tabs {
 			return newTabIndex;
 		}
 
-		/**
-		 * Method that handles the Keypress Event, for tabs navigation using arrows
-		 *
-		 * @private
-		 * @param {KeyboardEvent} e
-		 * @return {*}  {void}
-		 * @memberof Tabs
-		 */
+		// Method that handles the Keypress Event, for tabs navigation using arrows
 		private _handleKeypressEvent(e: KeyboardEvent): void {
 			let currentTabHeader: number;
 			let targetHeaderItemIndex: number;
@@ -325,23 +282,13 @@ namespace OSFramework.OSUI.Patterns.Tabs {
 			}
 		}
 
-		/**
-		 * Method to adjust the tabs css active item on resize or orientation-change
-		 *
-		 * @private
-		 * @memberof Tabs
-		 */
+		// Method to adjust the tabs css active item on resize or orientation-change
 		private _handleOnResizeEvent(): void {
 			this._scrollToTargetContent(this._activeTabContentElement);
 			Helper.AsyncInvocation(this._handleTabIndicator.bind(this));
 		}
 
-		/**
-		 * Method that handles the indicator size and transition
-		 *
-		 * @private
-		 * @memberof Tabs
-		 */
+		// Method that handles the indicator size and transition
 		private _handleTabIndicator(): void {
 			if (this._activeTabHeaderElement?.selfElement) {
 				// Check if it comes form a disabled tab, to remove the disable class
@@ -414,12 +361,7 @@ namespace OSFramework.OSUI.Patterns.Tabs {
 			}
 		}
 
-		/**
-		 * Method to make neccessary preparations for header and content items, that can't be done on their scope
-		 *
-		 * @private
-		 * @memberof Tabs
-		 */
+		// Method to make neccessary preparations for header and content items, that can't be done on their scope
 		private _prepareHeaderAndContentItems(): void {
 			// Set if the Tabs has only one Content
 			this._hasSingleContent = this.getChildItems(Enum.ChildTypes.TabsContentItem).length === 1;
@@ -455,13 +397,7 @@ namespace OSFramework.OSUI.Patterns.Tabs {
 			this._updateListOfEnabledTabsHeader();
 		}
 
-		/**
-		 * Method that it's called whenever a new TabsContentItem is destroyed
-		 *
-		 * @private
-		 * @param {string} childContentId
-		 * @memberof Tabs
-		 */
+		// Method that it's called whenever a new TabsContentItem is destroyed
 		private _removeContentItem(childContentId: string): void {
 			const childContentItem = this.getChild(childContentId) as TabsContentItem.ITabsContentItem;
 			let auxIndex: number;
@@ -502,12 +438,7 @@ namespace OSFramework.OSUI.Patterns.Tabs {
 			}
 		}
 
-		/**
-		 * Remove Pattern Events
-		 *
-		 * @private
-		 * @memberof Tabs
-		 */
+		// Remove Pattern Events
 		private _removeEvents(): void {
 			this._tabsHeaderElement.removeEventListener(GlobalEnum.HTMLEvent.keyDown, this._eventOnHeaderKeypress);
 
@@ -526,13 +457,7 @@ namespace OSFramework.OSUI.Patterns.Tabs {
 			}
 		}
 
-		/**
-		 * Method that it's called whenever a new TabsHeaderItem is destroyed
-		 *
-		 * @private
-		 * @param {string} childHeaderId
-		 * @memberof Tabs
-		 */
+		// Method that it's called whenever a new TabsHeaderItem is destroyed
 		private _removeHeaderItem(childHeaderId: string): void {
 			const auxIndex = this.getChildIndex(childHeaderId);
 			const wasActive = this.getChild(childHeaderId).IsActive;
@@ -573,13 +498,7 @@ namespace OSFramework.OSUI.Patterns.Tabs {
 			}
 		}
 
-		/**
-		 * Method to scroll to new target content item
-		 *
-		 * @private
-		 * @param {Patterns.TabsContentItem.ITabsContentItem} newContentItem
-		 * @memberof Tabs
-		 */
+		// Method to scroll to new target content item
 		private _scrollToTargetContent(newContentItem: Patterns.TabsContentItem.ITabsContentItem): void {
 			if (newContentItem) {
 				// Scroll to new content item
@@ -591,13 +510,7 @@ namespace OSFramework.OSUI.Patterns.Tabs {
 			}
 		}
 
-		/**
-		 * Method to set if the Tabs AutoHeight
-		 *
-		 * @private
-		 * @param {boolean} hasAutoHeight
-		 * @memberof Tabs
-		 */
+		// Method to set if the Tabs AutoHeight
 		private _setContentAutoHeight(hasAutoHeight: boolean): void {
 			if (this._hasDragGestures === false) {
 				if (hasAutoHeight) {
@@ -612,12 +525,7 @@ namespace OSFramework.OSUI.Patterns.Tabs {
 			}
 		}
 
-		/**
-		 * Method to set an IntersectionObserver when drag gestures are enable, to detect the activeItem on drag
-		 *
-		 * @private
-		 * @memberof Tabs
-		 */
+		// Method to set an IntersectionObserver when drag gestures are enable, to detect the activeItem on drag
 		private _setDragObserver(): void {
 			// Observer options
 			const observerOptions = {
@@ -648,25 +556,13 @@ namespace OSFramework.OSUI.Patterns.Tabs {
 			});
 		}
 
-		/**
-		 * Method to set the CSS variable that holds the number of header items
-		 *
-		 * @private
-		 * @param {number} itemsLength
-		 * @memberof Tabs
-		 */
+		// Method to set the CSS variable that holds the number of header items
 		private _setHeaderItemsCustomProperty(itemsLength: number): void {
 			// Create css variable
 			Helper.Dom.Styles.SetStyleAttribute(this.selfElement, Enum.CssProperty.TabsHeaderItems, itemsLength);
 		}
 
-		/**
-		 * Method to set the Tabs Height
-		 *
-		 * @private
-		 * @param {string} height
-		 * @memberof Tabs
-		 */
+		// Method to set the Tabs Height
 		private _setHeight(height: string): void {
 			// Set tabs overflow based on height
 			const tabsOverflow =
@@ -683,12 +579,7 @@ namespace OSFramework.OSUI.Patterns.Tabs {
 			);
 		}
 
-		/**
-		 * Method to set the initial options on screen load
-		 *
-		 * @private
-		 * @memberof Tabs
-		 */
+		// Method to set the initial options on screen load
 		private _setInitialOptions(): void {
 			// Call necessary methods that avoid layout shift first
 			// Set the --tabs-header-items css variable
@@ -706,13 +597,7 @@ namespace OSFramework.OSUI.Patterns.Tabs {
 			}
 		}
 
-		/**
-		 * Method to set if the Tabs are justified
-		 *
-		 * @private
-		 * @param {boolean} isJustified
-		 * @memberof Tabs
-		 */
+		// Method to set if the Tabs are justified
 		private _setIsJustified(isJustified: boolean): void {
 			if (isJustified) {
 				Helper.Dom.Styles.AddClass(this.selfElement, Enum.CssClasses.IsJustified);
@@ -726,13 +611,7 @@ namespace OSFramework.OSUI.Patterns.Tabs {
 			}
 		}
 
-		/**
-		 * Method to set the Tabs Orientation
-		 *
-		 * @private
-		 * @param {GlobalEnum.Orientation} orientation
-		 * @memberof Tabs
-		 */
+		// Method to set the Tabs Orientation
 		private _setOrientation(orientation: GlobalEnum.Orientation): void {
 			Helper.Dom.Styles.RemoveClass(this.selfElement, Enum.CssClasses.Modifier + this._currentOrientation);
 			Helper.Dom.Styles.AddClass(this.selfElement, Enum.CssClasses.Modifier + orientation);
@@ -746,13 +625,7 @@ namespace OSFramework.OSUI.Patterns.Tabs {
 			}
 		}
 
-		/**
-		 * Method to set the Tabs Position
-		 *
-		 * @private
-		 * @param {GlobalEnum.Direction} position
-		 * @memberof Tabs
-		 */
+		// Method to set the Tabs Position
 		private _setPosition(position: GlobalEnum.Direction): void {
 			Helper.Dom.Styles.RemoveClass(this.selfElement, Enum.CssClasses.Modifier + this._currentVerticalPositon);
 			Helper.Dom.Styles.AddClass(this.selfElement, Enum.CssClasses.Modifier + position);
@@ -760,14 +633,7 @@ namespace OSFramework.OSUI.Patterns.Tabs {
 			this._currentVerticalPositon = position;
 		}
 
-		/**
-		 * Toggle TableHeaderItem disbaled status
-		 *
-		 * @private
-		 * @param {string} childHeaderId
-		 * @param {boolean} isDisabled
-		 * @memberof Tabs
-		 */
+		// Toggle TableHeaderItem disbaled status
 		private _setTabHeaderItemDisabledStatus(childHeaderId: string, isDisabled: boolean): void {
 			const _tabHeaderItemElement = Helper.Dom.GetElementByUniqueId(childHeaderId);
 			const _tabItemIndex = this.getChildIndex(childHeaderId);
@@ -819,13 +685,7 @@ namespace OSFramework.OSUI.Patterns.Tabs {
 			}
 		}
 
-		/**
-		 * Method to change between tabs
-		 *
-		 * @private
-		 * @param {string} childHeaderId
-		 * @memberof Tabs
-		 */
+		// Method to change between tabs
 		private _tabHeaderItemHasBeenClicked(childHeaderId: string): void {
 			const newHeaderItem = this.getChild(childHeaderId) as TabsHeaderItem.ITabsHeaderItem;
 
@@ -838,36 +698,19 @@ namespace OSFramework.OSUI.Patterns.Tabs {
 			this.changeTab(this.getChildIndex(childHeaderId), newHeaderItem, true);
 		}
 
-		/**
-		 * Method that triggers the OnTabsChange event
-		 *
-		 * @private
-		 * @param {number} activeTab
-		 * @memberof Tabs
-		 */
+		// Method that triggers the OnTabsChange event
 		private _triggerOnChangeEvent(activeTab: number): void {
 			if (this._platformEventTabsOnChange !== undefined) {
 				this.triggerPlatformEventCallback(this._platformEventTabsOnChange, activeTab);
 			}
 		}
 
-		/**
-		 * Method to remove the drag Observer on each contentItem
-		 *
-		 * @private
-		 * @memberof Tabs
-		 */
+		// Method to remove the drag Observer on each contentItem
 		private _unsetDragObserver(): void {
 			this._dragObserver.disconnect();
 		}
 
-		/**
-		 * Method that handles the connection between HeaderItems and ContentItem, related to data-tab and aria-controls/labbeledby
-		 *
-		 * @private
-		 * @param {boolean} [updateDataTab=true]
-		 * @memberof Tabs
-		 */
+		// Method that handles the connection between HeaderItems and ContentItem, related to data-tab and aria-controls/labbeledby
 		private _updateItemsConnection(updateDataTab = true): void {
 			// By default look to the first content item.
 			let currentContentItem = this.getChildByIndex(
@@ -902,12 +745,7 @@ namespace OSFramework.OSUI.Patterns.Tabs {
 			);
 		}
 
-		/**
-		 * Function that will update the list of enabled tabs headers
-		 *
-		 * @private
-		 * @memberof Tabs
-		 */
+		// Function that will update the list of enabled tabs headers
 		private _updateListOfEnabledTabsHeader(): void {
 			this._tabsHeadersEnabled = (
 				this.getChildItems(Enum.ChildTypes.TabsHeaderItem) as Patterns.TabsHeaderItem.ITabsHeaderItem[]

--- a/src/scripts/OSFramework/OSUI/Pattern/Tabs/Tabs.ts
+++ b/src/scripts/OSFramework/OSUI/Pattern/Tabs/Tabs.ts
@@ -633,7 +633,7 @@ namespace OSFramework.OSUI.Patterns.Tabs {
 			this._currentVerticalPositon = position;
 		}
 
-		// Toggle TableHeaderItem disbaled status
+		// Toggles the TableHeaderItem disabled status
 		private _setTabHeaderItemDisabledStatus(childHeaderId: string, isDisabled: boolean): void {
 			const _tabHeaderItemElement = Helper.Dom.GetElementByUniqueId(childHeaderId);
 			const _tabItemIndex = this.getChildIndex(childHeaderId);

--- a/src/scripts/OSFramework/OSUI/Pattern/TabsHeaderItem/TabsHeaderItem.ts
+++ b/src/scripts/OSFramework/OSUI/Pattern/TabsHeaderItem/TabsHeaderItem.ts
@@ -20,43 +20,29 @@ namespace OSFramework.OSUI.Patterns.TabsHeaderItem {
 			super(uniqueId, new TabsHeaderItemConfig(configs));
 		}
 
-		/**
-		 * Method to handle the click event
-		 *
-		 * @private
-		 * @memberof TabsHeaderItem
-		 */
+		// Method to handle the click event
 		private _handleClickEvent(): void {
 			if (this._isActive === false) {
 				this.notifyParent(Tabs.Enum.ChildNotifyActionType.Click);
 			}
 		}
 
-		/**
-		 * Method to remove the event listeners
-		 *
-		 * @private
-		 * @memberof TabsHeaderItem
-		 */
+		// Method to remove the event listeners
 		private _removeEvents(): void {
 			this.selfElement.removeEventListener(GlobalEnum.HTMLEvent.Click, this._eventOnTabsClick);
 		}
 
-		/**
-		 * Method to set the event listeners
-		 *
-		 * @private
-		 * @memberof TabsHeaderItem
-		 */
+		// Method to set the event listeners
 		private _setUpEvents(): void {
 			this.selfElement.addEventListener(GlobalEnum.HTMLEvent.Click, this._eventOnTabsClick);
 		}
 
 		/**
-		 * Method to handle the Accessibility attributes
+		 * Method to set the Accessibility attributes
 		 *
 		 * @protected
-		 * @memberof OSFramework.Patterns.TabsHeaderItem.TabsHeaderItem
+		 * @param {boolean} [isUpdate=true]
+		 * @memberof TabsHeaderItem
 		 */
 		protected setA11YProperties(isUpdate = true): void {
 			// Static attribute to be added when the item is created

--- a/src/scripts/OSFramework/OSUI/Pattern/TimePicker/AbstractTimePicker.ts
+++ b/src/scripts/OSFramework/OSUI/Pattern/TimePicker/AbstractTimePicker.ts
@@ -4,7 +4,6 @@ namespace OSFramework.OSUI.Patterns.TimePicker {
 		extends AbstractProviderPattern<P, C>
 		implements ITimePicker
 	{
-		// eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/explicit-module-boundary-types
 		constructor(uniqueId: string, configs: C) {
 			super(uniqueId, configs);
 		}

--- a/src/scripts/OSFramework/OSUI/Pattern/Video/Video.ts
+++ b/src/scripts/OSFramework/OSUI/Pattern/Video/Video.ts
@@ -215,10 +215,10 @@ namespace OSFramework.OSUI.Patterns.Video {
 		private _triggerOnStateChangedEvent(stateChanged: string): void {
 			if (stateChanged === Patterns.Video.Enum.VideoStates.Unstarted) {
 				if (this._videoElement.currentTime === 0) {
-					this.triggerPlatformEventCallback(this._platformEventOnStateChanged.bind(this), stateChanged);
+					this.triggerPlatformEventCallback(this._platformEventOnStateChanged, stateChanged);
 				}
 			} else {
-				this.triggerPlatformEventCallback(this._platformEventOnStateChanged.bind(this), stateChanged);
+				this.triggerPlatformEventCallback(this._platformEventOnStateChanged, stateChanged);
 			}
 
 			// Update video state value

--- a/src/scripts/OSFramework/OSUI/Pattern/Video/Video.ts
+++ b/src/scripts/OSFramework/OSUI/Pattern/Video/Video.ts
@@ -30,12 +30,7 @@ namespace OSFramework.OSUI.Patterns.Video {
 			super(uniqueId, new VideoConfig(configs));
 		}
 
-		/**
-		 * Method that will set the Autoplay attribute
-		 *
-		 * @private
-		 * @memberof Video
-		 */
+		// Method that will set the Autoplay attribute
 		private _setAutoplay(): void {
 			this._videoElement.autoplay = this.configs.Autoplay;
 
@@ -46,22 +41,12 @@ namespace OSFramework.OSUI.Patterns.Video {
 			}
 		}
 
-		/**
-		 * Method that will set the controls attribute
-		 *
-		 * @private
-		 * @memberof Video
-		 */
+		// Method that will set the controls attribute
 		private _setControls(): void {
 			this._videoElement.controls = this.configs.Controls;
 		}
 
-		/**
-		 * Method that will set the Height attribute
-		 *
-		 * @private
-		 * @memberof Video
-		 */
+		// Method that will set the Height attribute
 		private _setHeight(): void {
 			if (this.configs.Height !== Constants.EmptyString) {
 				OSUI.Helper.Dom.Attribute.Set(
@@ -74,32 +59,17 @@ namespace OSFramework.OSUI.Patterns.Video {
 			}
 		}
 
-		/**
-		 * Method that will set the loop attribute
-		 *
-		 * @private
-		 * @memberof Video
-		 */
+		// Method that will set the loop attribute
 		private _setLoop(): void {
 			this._videoElement.loop = this.configs.Loop;
 		}
 
-		/**
-		 * Method that will set the muted attribute
-		 *
-		 * @private
-		 * @memberof Video
-		 */
+		// Method that will set the muted attribute
 		private _setMuted(): void {
 			this._videoElement.muted = this.configs.Muted;
 		}
 
-		/**
-		 * Method that will set the poster image on video
-		 *
-		 * @private
-		 * @memberof Video
-		 */
+		// Method that will set the poster image on video
 		private _setPosterUrl(): void {
 			if (this.configs.PosterURL !== Constants.EmptyString) {
 				this._videoElement.poster = this.configs.PosterURL;
@@ -108,12 +78,7 @@ namespace OSFramework.OSUI.Patterns.Video {
 			}
 		}
 
-		/**
-		 * Method to apply all initial video configs
-		 *
-		 * @private
-		 * @memberof Video
-		 */
+		// Method to apply all initial video configs
 		private _setVideoConfigs(): void {
 			this._setAutoplay();
 
@@ -135,12 +100,7 @@ namespace OSFramework.OSUI.Patterns.Video {
 			}
 		}
 
-		/**
-		 * Method to create the source element
-		 *
-		 * @private
-		 * @memberof Video
-		 */
+		// Method to create the source element
 		private _setVideoSource(): void {
 			// Get the file extension from URL
 			const _urlFileExtension = OSUI.Helper.URL.GetFileTypeFromURL(this.configs.URL);
@@ -157,12 +117,7 @@ namespace OSFramework.OSUI.Patterns.Video {
 			this._videoSourceElement.type = Patterns.Video.Enum.VideoAttributes.TypePath + _urlFileExtension;
 		}
 
-		/**
-		 * Method create the track element
-		 *
-		 * @private
-		 * @memberof Video
-		 */
+		// Method create the track element
 		private _setVideoTrack(): void {
 			// Check if contains tracks to be added
 			// If true, create the element with all the attributes
@@ -187,12 +142,7 @@ namespace OSFramework.OSUI.Patterns.Video {
 			}
 		}
 
-		/**
-		 * Method that will set the Width attribute
-		 *
-		 * @private
-		 * @memberof Video
-		 */
+		// Method that will set the Width attribute
 		private _setWidth(): void {
 			if (this.configs.Width !== Constants.EmptyString) {
 				OSUI.Helper.Dom.Attribute.Set(
@@ -205,13 +155,7 @@ namespace OSFramework.OSUI.Patterns.Video {
 			}
 		}
 
-		/**
-		 * Method that triggers the OnStateChanged event
-		 *
-		 * @private
-		 * @param {string} stateChanged value of video state
-		 * @memberof Video
-		 */
+		// Method that triggers the OnStateChanged event
 		private _triggerOnStateChangedEvent(stateChanged: string): void {
 			if (stateChanged === Patterns.Video.Enum.VideoStates.Unstarted) {
 				if (this._videoElement.currentTime === 0) {

--- a/src/scripts/OutSystems/OSUI/Patterns/BottomSheetAPI.ts
+++ b/src/scripts/OutSystems/OSUI/Patterns/BottomSheetAPI.ts
@@ -10,8 +10,7 @@ namespace OutSystems.OSUI.Patterns.BottomSheetAPI {
 	 * @param {string} propertyName Property name that will be updated
 	 * @param {*} propertyValue Value that will be set to the property
 	 */
-	// eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/explicit-module-boundary-types
-	export function ChangeProperty(bottomSheetId: string, propertyName: string, propertyValue: any): string {
+	export function ChangeProperty(bottomSheetId: string, propertyName: string, propertyValue: unknown): string {
 		const result = OutSystems.OSUI.Utils.CreateApiResponse({
 			errorCode: ErrorCodes.BottomSheet.FailChangeProperty,
 			callback: () => {

--- a/src/scripts/OutSystems/OSUI/Patterns/CarouselAPI.ts
+++ b/src/scripts/OutSystems/OSUI/Patterns/CarouselAPI.ts
@@ -48,8 +48,7 @@ namespace OutSystems.OSUI.Patterns.CarouselAPI {
 	 * @param {string} propertyName Property name that will be updated
 	 * @param {*} propertyValue Value that will be set to the property
 	 */
-	// eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/explicit-module-boundary-types
-	export function ChangeProperty(carouselId: string, propertyName: string, propertyValue: any): string {
+	export function ChangeProperty(carouselId: string, propertyName: string, propertyValue: unknown): string {
 		const result = OutSystems.OSUI.Utils.CreateApiResponse({
 			errorCode: ErrorCodes.Carousel.FailChangeProperty,
 			callback: () => {

--- a/src/scripts/OutSystems/OSUI/Patterns/DatePickerAPI.ts
+++ b/src/scripts/OutSystems/OSUI/Patterns/DatePickerAPI.ts
@@ -10,8 +10,7 @@ namespace OutSystems.OSUI.Patterns.DatePickerAPI {
 	 * @param {string} propertyName Property name that will be updated
 	 * @param {*} propertyValue Value that will be set to the property
 	 */
-	// eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/explicit-module-boundary-types
-	export function ChangeProperty(datePickerId: string, propertyName: string, propertyValue: any): string {
+	export function ChangeProperty(datePickerId: string, propertyName: string, propertyValue: unknown): string {
 		const result = OutSystems.OSUI.Utils.CreateApiResponse({
 			errorCode: ErrorCodes.DatePicker.FailChangeProperty,
 			callback: () => {

--- a/src/scripts/OutSystems/OSUI/Patterns/DropdownServerSideItemAPI.ts
+++ b/src/scripts/OutSystems/OSUI/Patterns/DropdownServerSideItemAPI.ts
@@ -13,8 +13,11 @@ namespace OutSystems.OSUI.Patterns.DropdownServerSideItemAPI {
 	 * @param {string} propertyName Property name that will be updated
 	 * @param {*} propertyValue Value that will be set to the property
 	 */
-	// eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/explicit-module-boundary-types
-	export function ChangeProperty(dropdownServerSideItemId: string, propertyName: string, propertyValue: any): string {
+	export function ChangeProperty(
+		dropdownServerSideItemId: string,
+		propertyName: string,
+		propertyValue: unknown
+	): string {
 		const result = OutSystems.OSUI.Utils.CreateApiResponse({
 			errorCode: ErrorCodes.DropdownServerSideItem.FailChangeProperty,
 			callback: () => {

--- a/src/scripts/OutSystems/OSUI/Patterns/FlipContentAPI.ts
+++ b/src/scripts/OutSystems/OSUI/Patterns/FlipContentAPI.ts
@@ -10,8 +10,7 @@ namespace OutSystems.OSUI.Patterns.FlipContentAPI {
 	 * @param {string} propertyName Property name that will be updated
 	 * @param {*} propertyValue Value that will be set to the property
 	 */
-	// eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/explicit-module-boundary-types
-	export function ChangeProperty(flipId: string, propertyName: string, propertyValue: any): string {
+	export function ChangeProperty(flipId: string, propertyName: string, propertyValue: unknown): string {
 		const result = OutSystems.OSUI.Utils.CreateApiResponse({
 			errorCode: ErrorCodes.FlipContent.FailChangeProperty,
 			callback: () => {

--- a/src/scripts/OutSystems/OSUI/Patterns/GalleryAPI.ts
+++ b/src/scripts/OutSystems/OSUI/Patterns/GalleryAPI.ts
@@ -10,8 +10,7 @@ namespace OutSystems.OSUI.Patterns.GalleryAPI {
 	 * @param {string} propertyName Property name that will be updated
 	 * @param {*} propertyValue Value that will be set to the property
 	 */
-	// eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/explicit-module-boundary-types
-	export function ChangeProperty(galleryId: string, propertyName: string, propertyValue: any): string {
+	export function ChangeProperty(galleryId: string, propertyName: string, propertyValue: unknown): string {
 		const result = OutSystems.OSUI.Utils.CreateApiResponse({
 			errorCode: ErrorCodes.Gallery.FailChangeProperty,
 			callback: () => {

--- a/src/scripts/OutSystems/OSUI/Patterns/InlineSvgAPI.ts
+++ b/src/scripts/OutSystems/OSUI/Patterns/InlineSvgAPI.ts
@@ -9,8 +9,7 @@ namespace OutSystems.OSUI.Patterns.InlineSvgAPI {
 	 * @param {string} propertyName
 	 * @param {*} propertyValue
 	 */
-	// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any
-	export function ChangeProperty(inlineSvgId: string, propertyName: string, propertyValue: any): string {
+	export function ChangeProperty(inlineSvgId: string, propertyName: string, propertyValue: unknown): string {
 		const result = OutSystems.OSUI.Utils.CreateApiResponse({
 			errorCode: ErrorCodes.InlineSvg.FailChangeProperty,
 			callback: () => {

--- a/src/scripts/OutSystems/OSUI/Patterns/MonthPickerAPI.ts
+++ b/src/scripts/OutSystems/OSUI/Patterns/MonthPickerAPI.ts
@@ -10,8 +10,7 @@ namespace OutSystems.OSUI.Patterns.MonthPickerAPI {
 	 * @param {string} propertyName Property name that will be updated
 	 * @param {*} propertyValue Value that will be set to the property
 	 */
-	// eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/explicit-module-boundary-types
-	export function ChangeProperty(monthPickerId: string, propertyName: string, propertyValue: any): string {
+	export function ChangeProperty(monthPickerId: string, propertyName: string, propertyValue: unknown): string {
 		const result = OutSystems.OSUI.Utils.CreateApiResponse({
 			errorCode: ErrorCodes.MonthPicker.FailChangeProperty,
 			callback: () => {

--- a/src/scripts/OutSystems/OSUI/Patterns/NotificationAPI.ts
+++ b/src/scripts/OutSystems/OSUI/Patterns/NotificationAPI.ts
@@ -9,8 +9,7 @@ namespace OutSystems.OSUI.Patterns.NotificationAPI {
 	 * @param {string} propertyName
 	 * @param {*} propertyValue
 	 */
-	// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any
-	export function ChangeProperty(notificationId: string, propertyName: string, propertyValue: any): string {
+	export function ChangeProperty(notificationId: string, propertyName: string, propertyValue: unknown): string {
 		const result = OutSystems.OSUI.Utils.CreateApiResponse({
 			errorCode: ErrorCodes.Notification.FailChangeProperty,
 			callback: () => {

--- a/src/scripts/OutSystems/OSUI/Patterns/ProgressAPI.ts
+++ b/src/scripts/OutSystems/OSUI/Patterns/ProgressAPI.ts
@@ -10,8 +10,7 @@ namespace OutSystems.OSUI.Patterns.ProgressAPI {
 	 * @param {string} propertyName Property name that will be updated
 	 * @param {*} propertyValue Value that will be set to the property
 	 */
-	// eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/explicit-module-boundary-types
-	export function ChangeProperty(progressId: string, propertyName: string, propertyValue: any): string {
+	export function ChangeProperty(progressId: string, propertyName: string, propertyValue: unknown): string {
 		const result = OutSystems.OSUI.Utils.CreateApiResponse({
 			errorCode: ErrorCodes.Progress.FailChangeProperty,
 			callback: () => {

--- a/src/scripts/OutSystems/OSUI/Patterns/RatingAPI.ts
+++ b/src/scripts/OutSystems/OSUI/Patterns/RatingAPI.ts
@@ -10,8 +10,7 @@ namespace OutSystems.OSUI.Patterns.RatingAPI {
 	 * @param {string} propertyName Property name that will be updated
 	 * @param {*} propertyValue Value that will be set to the property
 	 */
-	// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any
-	export function ChangeProperty(ratingId: string, propertyName: string, propertyValue: any): string {
+	export function ChangeProperty(ratingId: string, propertyName: string, propertyValue: unknown): string {
 		const result = OutSystems.OSUI.Utils.CreateApiResponse({
 			errorCode: ErrorCodes.Rating.FailChangeProperty,
 			callback: () => {

--- a/src/scripts/OutSystems/OSUI/Patterns/SearchAPI.ts
+++ b/src/scripts/OutSystems/OSUI/Patterns/SearchAPI.ts
@@ -9,8 +9,7 @@ namespace OutSystems.OSUI.Patterns.SearchAPI {
 	 * @param {string} propertyName
 	 * @param {*} propertyValue
 	 */
-	// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any
-	export function ChangeProperty(searchId: string, propertyName: string, propertyValue: any): string {
+	export function ChangeProperty(searchId: string, propertyName: string, propertyValue: unknown): string {
 		const result = OutSystems.OSUI.Utils.CreateApiResponse({
 			errorCode: ErrorCodes.Search.FailChangeProperty,
 			callback: () => {

--- a/src/scripts/OutSystems/OSUI/Patterns/SectionIndexAPI.ts
+++ b/src/scripts/OutSystems/OSUI/Patterns/SectionIndexAPI.ts
@@ -10,8 +10,7 @@ namespace OutSystems.OSUI.Patterns.SectionIndexAPI {
 	 * @param {string} propertyName Property name that will be updated
 	 * @param {*} propertyValue Value that will be set to the property
 	 */
-	// eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/explicit-module-boundary-types
-	export function ChangeProperty(sectionIndexId: string, propertyName: string, propertyValue: any): string {
+	export function ChangeProperty(sectionIndexId: string, propertyName: string, propertyValue: unknown): string {
 		const result = OutSystems.OSUI.Utils.CreateApiResponse({
 			errorCode: ErrorCodes.SectionIndex.FailChangeProperty,
 			callback: () => {

--- a/src/scripts/OutSystems/OSUI/Patterns/SectionIndexItemAPI.ts
+++ b/src/scripts/OutSystems/OSUI/Patterns/SectionIndexItemAPI.ts
@@ -10,8 +10,7 @@ namespace OutSystems.OSUI.Patterns.SectionIndexItemAPI {
 	 * @param {string} propertyName Property name that will be updated
 	 * @param {*} propertyValue Value that will be set to the property
 	 */
-	// eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/explicit-module-boundary-types
-	export function ChangeProperty(sectionIndexItemId: string, propertyName: string, propertyValue: any): string {
+	export function ChangeProperty(sectionIndexItemId: string, propertyName: string, propertyValue: unknown): string {
 		const result = OutSystems.OSUI.Utils.CreateApiResponse({
 			errorCode: ErrorCodes.SectionIndexItem.FailChangeProperty,
 			callback: () => {

--- a/src/scripts/OutSystems/OSUI/Patterns/SubmenuAPI.ts
+++ b/src/scripts/OutSystems/OSUI/Patterns/SubmenuAPI.ts
@@ -10,8 +10,7 @@ namespace OutSystems.OSUI.Patterns.SubmenuAPI {
 	 * @param {string} propertyName Property name that will be updated
 	 * @param {*} propertyValue Value that will be set to the property
 	 */
-	// eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/explicit-module-boundary-types
-	export function ChangeProperty(submenuId: string, propertyName: string, propertyValue: any): string {
+	export function ChangeProperty(submenuId: string, propertyName: string, propertyValue: unknown): string {
 		const result = OutSystems.OSUI.Utils.CreateApiResponse({
 			errorCode: ErrorCodes.Submenu.FailChangeProperty,
 			callback: () => {

--- a/src/scripts/OutSystems/OSUI/Patterns/TabsContentItemAPI.ts
+++ b/src/scripts/OutSystems/OSUI/Patterns/TabsContentItemAPI.ts
@@ -10,8 +10,7 @@ namespace OutSystems.OSUI.Patterns.TabsContentItemAPI {
 	 * @param {string} propertyName Property name that will be updated
 	 * @param {*} propertyValue Value that will be set to the property
 	 */
-	// eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/explicit-module-boundary-types
-	export function ChangeProperty(tabsContentItemId: string, propertyName: string, propertyValue: any): string {
+	export function ChangeProperty(tabsContentItemId: string, propertyName: string, propertyValue: unknown): string {
 		const result = OutSystems.OSUI.Utils.CreateApiResponse({
 			errorCode: ErrorCodes.TabsContentItem.FailChangeProperty,
 			callback: () => {

--- a/src/scripts/OutSystems/OSUI/Patterns/TabsHeaderItemAPI.ts
+++ b/src/scripts/OutSystems/OSUI/Patterns/TabsHeaderItemAPI.ts
@@ -10,8 +10,7 @@ namespace OutSystems.OSUI.Patterns.TabsHeaderItemAPI {
 	 * @param {string} propertyName Property name that will be updated
 	 * @param {*} propertyValue Value that will be set to the property
 	 */
-	// eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/explicit-module-boundary-types
-	export function ChangeProperty(tabsHeaderItemId: string, propertyName: string, propertyValue: any): string {
+	export function ChangeProperty(tabsHeaderItemId: string, propertyName: string, propertyValue: unknown): string {
 		const result = OutSystems.OSUI.Utils.CreateApiResponse({
 			errorCode: ErrorCodes.TabsHeaderItem.FailChangeProperty,
 			callback: () => {

--- a/src/scripts/OutSystems/OSUI/Patterns/TimePickerAPI.ts
+++ b/src/scripts/OutSystems/OSUI/Patterns/TimePickerAPI.ts
@@ -10,8 +10,7 @@ namespace OutSystems.OSUI.Patterns.TimePickerAPI {
 	 * @param {string} propertyName Property name that will be updated
 	 * @param {*} propertyValue Value that will be set to the property
 	 */
-	// eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/explicit-module-boundary-types
-	export function ChangeProperty(timePickerId: string, propertyName: string, propertyValue: any): string {
+	export function ChangeProperty(timePickerId: string, propertyName: string, propertyValue: unknown): string {
 		const result = OutSystems.OSUI.Utils.CreateApiResponse({
 			errorCode: ErrorCodes.TimePicker.FailChangeProperty,
 			callback: () => {

--- a/src/scripts/OutSystems/OSUI/Patterns/TooltipAPI.ts
+++ b/src/scripts/OutSystems/OSUI/Patterns/TooltipAPI.ts
@@ -10,8 +10,7 @@ namespace OutSystems.OSUI.Patterns.TooltipAPI {
 	 * @param {string} propertyName Property name that will be updated
 	 * @param {*} propertyValue Value that will be set to the property
 	 */
-	// eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/explicit-module-boundary-types
-	export function ChangeProperty(tooltipId: string, propertyName: string, propertyValue: any): string {
+	export function ChangeProperty(tooltipId: string, propertyName: string, propertyValue: unknown): string {
 		const result = OutSystems.OSUI.Utils.CreateApiResponse({
 			errorCode: ErrorCodes.Tooltip.FailChangeProperty,
 			callback: () => {

--- a/src/scripts/OutSystems/OSUI/Utils/ButtonsEffect.ts
+++ b/src/scripts/OutSystems/OSUI/Utils/ButtonsEffect.ts
@@ -50,7 +50,7 @@ namespace OutSystems.OSUI.Utils {
 			// only if it has a class, only if it's beneath 'main-content' and doesn't pass it, if it's not a chart
 			if (
 				typeof element.className !== 'undefined' &&
-				!element.classList.contains('.main-content') &&
+				!element.classList.contains('main-content') &&
 				!(element instanceof SVGElement)
 			) {
 				if (element.className.split(' ').indexOf(classname) >= 0) {

--- a/src/scripts/OutSystems/OSUI/Utils/ButtonsEffect.ts
+++ b/src/scripts/OutSystems/OSUI/Utils/ButtonsEffect.ts
@@ -44,6 +44,7 @@ namespace OutSystems.OSUI.Utils {
 		}, 1800);
 	}
 
+	//TODO: review this function.
 	function _hasSomeParentTheClass(element: HTMLElement, classname: string) {
 		if (element) {
 			// only if it has a class, only if it's beneath 'main-content' and doesn't pass it, if it's not a chart

--- a/src/scripts/OutSystems/OSUI/Utils/ButtonsEffect.ts
+++ b/src/scripts/OutSystems/OSUI/Utils/ButtonsEffect.ts
@@ -28,6 +28,9 @@ namespace OutSystems.OSUI.Utils {
 		function OnTransitionEnd() {
 			if (spanEl && this === el && this === spanEl.parentNode) {
 				this.removeChild(spanEl);
+				el.removeEventListener(OSFramework.OSUI.GlobalEnum.HTMLEvent.AnimationEnd, OnTransitionEnd, false);
+				el.removeEventListener('webkitAnimationEnd', OnTransitionEnd, false);
+				el = undefined;
 			}
 		}
 	}

--- a/src/scripts/OutSystems/OSUI/Utils/ButtonsEffect.ts
+++ b/src/scripts/OutSystems/OSUI/Utils/ButtonsEffect.ts
@@ -1,6 +1,5 @@
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 namespace OutSystems.OSUI.Utils {
-	// eslint-disable-next-line @typescript-eslint/no-explicit-any
 	function _bodyClick(eventName: string, event: PointerEvent) {
 		const target = event.target as HTMLElement;
 		if (target.classList.contains('btn')) {

--- a/src/scripts/OutSystems/OSUI/Utils/CreateApiResponse.ts
+++ b/src/scripts/OutSystems/OSUI/Utils/CreateApiResponse.ts
@@ -2,8 +2,7 @@
 namespace OutSystems.OSUI.Utils {
 	// Set APIHandler type structure
 	type APIHandler = {
-		// eslint-disable-next-line
-		callback: any;
+		callback: OSFramework.OSUI.GlobalCallbacks.Generic;
 		errorCode: string;
 		hasValue?: boolean;
 	};
@@ -14,7 +13,7 @@ namespace OutSystems.OSUI.Utils {
 		isSuccess: boolean;
 		message: string;
 		// eslint-disable-next-line
-		value?: any;
+		value?: unknown;
 	};
 
 	/**

--- a/src/scripts/OutSystems/OSUI/Utils/GetClosest.ts
+++ b/src/scripts/OutSystems/OSUI/Utils/GetClosest.ts
@@ -10,8 +10,7 @@ namespace OutSystems.OSUI.Utils {
 	 *
 	 */
 	//TODO: Is this function necessary?
-	// eslint-disable-next-line @typescript-eslint/no-explicit-any
-	export function GetClosest(elem: HTMLElement, selector: string): any {
+	export function GetClosest(elem: HTMLElement, selector: string): unknown {
 		return elem.closest(selector) ? elem.closest(selector) : false;
 	}
 }

--- a/src/scripts/OutSystems/OSUI/Utils/LayoutPrivateBodyCssVars.ts
+++ b/src/scripts/OutSystems/OSUI/Utils/LayoutPrivateBodyCssVars.ts
@@ -1,14 +1,7 @@
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 namespace OutSystems.OSUI.Utils.LayoutPrivate {
 	export abstract class CssBodyVariables {
-		/**
-		 * Method that will check if dark mode is active
-		 *
-		 * @private
-		 * @static
-		 * @param {(isDarkMode: boolean) => void} callback
-		 * @memberof CssBodyVariables
-		 */
+		// Method that will check if dark mode is active
 		private static _checkDarkModeStatus(callback: (isDarkMode: boolean) => void): void {
 			if (typeof window !== 'undefined' && window.matchMedia) {
 				// Set the media query to check for dark mode
@@ -30,14 +23,7 @@ namespace OutSystems.OSUI.Utils.LayoutPrivate {
 			}
 		}
 
-		/**
-		 * Method that will check if highContrast mode is active
-		 *
-		 * @private
-		 * @static
-		 * @param {(isHighContrast: boolean) => void} callback
-		 * @memberof CssBodyVariables
-		 */
+		// Method that will check if highContrast mode is active
 		private static _checkHighContrastStatus(callback: (isHighContrast: boolean) => void): void {
 			if (typeof window !== 'undefined' && window.matchMedia) {
 				// Set the media query to check for highContrast mode
@@ -59,13 +45,7 @@ namespace OutSystems.OSUI.Utils.LayoutPrivate {
 			}
 		}
 
-		/**
-		 * Method to set body css variables for a phone or tablet app
-		 *
-		 * @private
-		 * @static
-		 * @memberof CssBodyVariables
-		 */
+		// Method to set body css variables for a phone or tablet app
 		private static _isPhoneOrTablet(): void {
 			OSFramework.OSUI.Helper.Dom.Styles.SetStyleAttribute(
 				document.body,
@@ -74,13 +54,7 @@ namespace OutSystems.OSUI.Utils.LayoutPrivate {
 			);
 		}
 
-		/**
-		 * Method that will set the css variables to body element
-		 *
-		 * @private
-		 * @static
-		 * @memberof CssBodyVariables
-		 */
+		// Method that will set the css variables to body element
 		private static _setCssVars(): void {
 			// Ensure app is not a web app
 			if (OSUI.Utils.DeviceDetection.IsWebApp() === false) {
@@ -132,13 +106,7 @@ namespace OutSystems.OSUI.Utils.LayoutPrivate {
 			});
 		}
 
-		/**
-		 * Method to set body css variables for non web app
-		 *
-		 * @private
-		 * @static
-		 * @memberof CssBodyVariables
-		 */
+		// Method to set body css variables for non web app
 		private static _setNotWebApp(): void {
 			const headerContent = OSFramework.OSUI.Helper.Dom.ClassSelector(
 				document,

--- a/src/scripts/OutSystems/OSUI/Utils/PreviewInDevices/OnPostMessage.ts
+++ b/src/scripts/OutSystems/OSUI/Utils/PreviewInDevices/OnPostMessage.ts
@@ -7,27 +7,16 @@ namespace OutSystems.OSUI.Utils.PreviewInDevices {
 	 * @class OnPostMessage
 	 */
 	abstract class OnPostMessage {
-		/**
-		 * Holds the knowledge if the app is running within the Preview In Devices.
-		 *
-		 * @private
-		 * @static
-		 * @memberof OnPostMessage
-		 */
+		// Holds the knowledge if the app is running within the Preview In Devices.
 		private static _isInPreviewInDevices = false;
 
-		/**
-		 * Adds a css class to the body, to make it easily style accordingly.
-		 *
-		 * @private
-		 * @static
-		 * @memberof OnPostMessage
-		 */
+		// Adds a css class to the body, to make it easily style accordingly.
 		private static _addInPreviewCssClass(): void {
 			OnPostMessage._isInPreviewInDevices = true;
 			document.body.classList.add('PreviewInDevices');
 		}
 
+		// Creates the CSS overrides for the preview in devices
 		private static _createPhonePreviewStyle(notchValue: number) {
 			if (!notchValue) {
 				return;
@@ -66,6 +55,7 @@ namespace OutSystems.OSUI.Utils.PreviewInDevices {
 			document.head.appendChild(style);
 		}
 
+		// Creates the CSS overrides for the preview in devices
 		private static _createTabletPreviewStyle() {
 			const style = document.createElement('style');
 			style.textContent = `
@@ -82,6 +72,7 @@ namespace OutSystems.OSUI.Utils.PreviewInDevices {
 			document.head.appendChild(style);
 		}
 
+		// Function that handles the message event, sent by preview in devices
 		private static _message(evtName: string, evt: MessageEvent): void {
 			if (
 				OSFramework.OSUI.GlobalEnum.HTMLEvent.Message === evtName &&
@@ -91,15 +82,7 @@ namespace OutSystems.OSUI.Utils.PreviewInDevices {
 			}
 		}
 
-		/**
-		 * Adds the required CSS classes, and CSS overrides so that the application adapts correctly
-		 * to the device selected in the preview devices.
-		 *
-		 * @private
-		 * @static
-		 * @param {*} evt
-		 * @memberof OnPostMessage
-		 */
+		// Adds the required CSS classes, and CSS overrides so that the application adapts correctly to the device selected in the preview devices.
 		private static _messageFromPreview(evt: MessageEvent<IDataPreviewInDevice>): void {
 			OnPostMessage._addInPreviewCssClass();
 			if (OSFramework.OSUI.Helper.DeviceInfo.IsPhone) {
@@ -129,6 +112,9 @@ namespace OutSystems.OSUI.Utils.PreviewInDevices {
 
 		/**
 		 * Function used to set the message event
+		 *
+		 * @static
+		 * @memberof OnPostMessage
 		 */
 		public static Set(): void {
 			if (window.self !== window.top) {
@@ -141,6 +127,9 @@ namespace OutSystems.OSUI.Utils.PreviewInDevices {
 
 		/**
 		 * Function used to unset the message event
+		 *
+		 * @static
+		 * @memberof OnPostMessage
 		 */
 		public static Unset(): void {
 			OSFramework.OSUI.Event.DOMEvents.Listeners.GlobalListenerManager.Instance.removeHandler(

--- a/src/scripts/OutSystems/OSUI/Utils/PreviewInDevices/OnPostMessage.ts
+++ b/src/scripts/OutSystems/OSUI/Utils/PreviewInDevices/OnPostMessage.ts
@@ -7,7 +7,7 @@ namespace OutSystems.OSUI.Utils.PreviewInDevices {
 	 * @class OnPostMessage
 	 */
 	abstract class OnPostMessage {
-		// Holds the knowledge if the app is running within the Preview In Devices.
+		// Holds the knowledge if the app is running within the Preview In Devices in ODC.
 		private static _isInPreviewInDevices = false;
 
 		// Adds a css class to the body, to make it easily style accordingly.

--- a/src/scripts/OutSystems/OSUI/Utils/PreviewInDevices/OnPostMessage.ts
+++ b/src/scripts/OutSystems/OSUI/Utils/PreviewInDevices/OnPostMessage.ts
@@ -126,7 +126,7 @@ namespace OutSystems.OSUI.Utils.PreviewInDevices {
 		}
 
 		/**
-		 * Function used to unset the message event
+		 * Method used to unset the message event
 		 *
 		 * @static
 		 * @memberof OnPostMessage

--- a/src/scripts/OutSystems/OSUI/Utils/PreviewInDevices/OnPostMessage.ts
+++ b/src/scripts/OutSystems/OSUI/Utils/PreviewInDevices/OnPostMessage.ts
@@ -111,7 +111,7 @@ namespace OutSystems.OSUI.Utils.PreviewInDevices {
 		}
 
 		/**
-		 * Function used to set the message event
+		 * Method used to set the message event
 		 *
 		 * @static
 		 * @memberof OnPostMessage

--- a/src/scripts/OutSystems/OSUI/Utils/PreviewInDevices/OnPostMessage.ts
+++ b/src/scripts/OutSystems/OSUI/Utils/PreviewInDevices/OnPostMessage.ts
@@ -10,7 +10,7 @@ namespace OutSystems.OSUI.Utils.PreviewInDevices {
 		// Holds the knowledge if the app is running within the Preview In Devices in ODC.
 		private static _isInPreviewInDevices = false;
 
-		// Adds a css class to the body, to make it easily style accordingly.
+		// Adds a CSS class to the body to make it easily style accordingly.
 		private static _addInPreviewCssClass(): void {
 			OnPostMessage._isInPreviewInDevices = true;
 			document.body.classList.add('PreviewInDevices');

--- a/src/scripts/OutSystems/OSUI/Utils/PreviewInDevices/OnPostMessage.ts
+++ b/src/scripts/OutSystems/OSUI/Utils/PreviewInDevices/OnPostMessage.ts
@@ -72,7 +72,7 @@ namespace OutSystems.OSUI.Utils.PreviewInDevices {
 			document.head.appendChild(style);
 		}
 
-		// Function that handles the message event, sent by preview in devices
+		// Method that handles the message event, sent by Preview In Devices in ODC
 		private static _message(evtName: string, evt: MessageEvent): void {
 			if (
 				OSFramework.OSUI.GlobalEnum.HTMLEvent.Message === evtName &&

--- a/src/scripts/OutSystems/OSUI/Utils/PreviewInDevices/OnPostMessage.ts
+++ b/src/scripts/OutSystems/OSUI/Utils/PreviewInDevices/OnPostMessage.ts
@@ -16,7 +16,7 @@ namespace OutSystems.OSUI.Utils.PreviewInDevices {
 			document.body.classList.add('PreviewInDevices');
 		}
 
-		// Creates the CSS overrides for the preview in devices
+		// Creates the CSS overrides for the Preview In Devices in ODC
 		private static _createPhonePreviewStyle(notchValue: number) {
 			if (!notchValue) {
 				return;

--- a/src/scripts/OutSystems/OSUI/Utils/PreviewInDevices/OnPostMessage.ts
+++ b/src/scripts/OutSystems/OSUI/Utils/PreviewInDevices/OnPostMessage.ts
@@ -82,7 +82,7 @@ namespace OutSystems.OSUI.Utils.PreviewInDevices {
 			}
 		}
 
-		// Adds the required CSS classes, and CSS overrides so that the application adapts correctly to the device selected in the preview devices.
+		// Adds the required CSS classes and CSS overrides so that the application adapts correctly to the device selected in the Preview In Devices in ODC
 		private static _messageFromPreview(evt: MessageEvent<IDataPreviewInDevice>): void {
 			OnPostMessage._addInPreviewCssClass();
 			if (OSFramework.OSUI.Helper.DeviceInfo.IsPhone) {

--- a/src/scripts/OutSystems/OSUI/Utils/PreviewInDevices/OnPostMessage.ts
+++ b/src/scripts/OutSystems/OSUI/Utils/PreviewInDevices/OnPostMessage.ts
@@ -55,7 +55,7 @@ namespace OutSystems.OSUI.Utils.PreviewInDevices {
 			document.head.appendChild(style);
 		}
 
-		// Creates the CSS overrides for the preview in devices
+		// Creates the CSS overrides for the Preview In Devices in ODC
 		private static _createTabletPreviewStyle() {
 			const style = document.createElement('style');
 			style.textContent = `

--- a/src/scripts/OutSystems/OSUI/Utils/ToggleClass.ts
+++ b/src/scripts/OutSystems/OSUI/Utils/ToggleClass.ts
@@ -4,7 +4,7 @@ namespace OutSystems.OSUI.Utils {
 	 * [Deprecated] Function used to Toogle a class to a given element
 	 *
 	 * @export
-	 * @param {HTMLElement} el
+	 * @param {HTMLElement} element
 	 * @param {*} state
 	 * @param {string} className
 	 */

--- a/src/scripts/OutSystems/OSUI/Utils/ToggleClass.ts
+++ b/src/scripts/OutSystems/OSUI/Utils/ToggleClass.ts
@@ -8,8 +8,7 @@ namespace OutSystems.OSUI.Utils {
 	 * @param {*} state
 	 * @param {string} className
 	 */
-	// eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/explicit-module-boundary-types
-	export function ToggleClass(element: HTMLElement, state: any, className: string): void {
+	export function ToggleClass(element: HTMLElement, state: unknown, className: string): void {
 		if (!state) {
 			setTimeout(function () {
 				if (!state) {

--- a/src/scripts/OutSystems/OSUI/Utils/ToggleClass.ts
+++ b/src/scripts/OutSystems/OSUI/Utils/ToggleClass.ts
@@ -10,7 +10,7 @@ namespace OutSystems.OSUI.Utils {
 	 */
 	export function ToggleClass(element: HTMLElement, state: unknown, className: string): void {
 		if (!state) {
-			setTimeout(function () {
+			setTimeout(() => {
 				if (!state) {
 					OSFramework.OSUI.Helper.Dom.Styles.RemoveClass(element, className);
 				}

--- a/src/scripts/Providers/OSUI/Datepicker/Flatpickr/AbstractFlatpickr.ts
+++ b/src/scripts/Providers/OSUI/Datepicker/Flatpickr/AbstractFlatpickr.ts
@@ -40,7 +40,12 @@ namespace Providers.OSUI.Datepicker.Flatpickr {
 			this.configs.OnOpen = this.onDatePickerOpen.bind(this);
 		}
 
-		// Method used to set the needed HTML attributes
+		/**
+		 * Method used to set the HTML attributes to the Flatpickr input element
+		 *
+		 * @private
+		 * @memberof AbstractFlatpickr
+		 */
 		private _setAttributes(): void {
 			// Since a new input will be added by the flatpickr library, we must address it only at onReady
 			if (this.datePickerPlatformInputElem.nextSibling) {
@@ -63,7 +68,12 @@ namespace Providers.OSUI.Datepicker.Flatpickr {
 			}
 		}
 
-		// Method used to set the CSS classes to the pattern HTML elements
+		/**
+		 * Method used to set the CSS classes to the calendar HTML elements
+		 *
+		 * @private
+		 * @memberof AbstractFlatpickr
+		 */
 		private _setCalendarCssClasses(): void {
 			OSFramework.OSUI.Helper.Dom.Styles.AddClass(
 				this.provider.calendarContainer,
@@ -80,7 +90,12 @@ namespace Providers.OSUI.Datepicker.Flatpickr {
 			}
 		}
 
-		// Set the clientHeight to the parent container as an inline style in order vertical content remains same and avoid content vertical flickering!
+		/**
+		 * Method used to set the clientHeight to the parent container as an inline style in order vertical content remains same and avoid content vertical flickering!
+		 *
+		 * @private
+		 * @memberof AbstractFlatpickr
+		 */
 		private _setParentMinHeight(): void {
 			OSFramework.OSUI.Helper.Dom.Styles.SetStyleAttribute(
 				this.selfElement,
@@ -89,7 +104,14 @@ namespace Providers.OSUI.Datepicker.Flatpickr {
 			);
 		}
 
-		// Method to handle the keydows event for the Today Button
+		/**
+		 * Method used to handle the keydown event for the Today Button
+		 *
+		 * @private
+		 * @param {KeyboardEvent} e
+		 * @return {*}  {void}
+		 * @memberof AbstractFlatpickr
+		 */
 		private _todayButtonKeydown(e: KeyboardEvent): void {
 			switch (e.key) {
 				case OSFramework.OSUI.GlobalEnum.Keycodes.Tab:
@@ -107,7 +129,12 @@ namespace Providers.OSUI.Datepicker.Flatpickr {
 			}
 		}
 
-		// Remove the clientHeight that has been assigned before the redraw process!
+		/**
+		 * Method used to remove the clientHeight that has been assigned before the redraw process!
+		 *
+		 * @private
+		 * @memberof AbstractFlatpickr
+		 */
 		private _unsetParentMinHeight(): void {
 			OSFramework.OSUI.Helper.Dom.Styles.RemoveStyleAttribute(
 				this.selfElement,
@@ -115,7 +142,12 @@ namespace Providers.OSUI.Datepicker.Flatpickr {
 			);
 		}
 
-		// Update certain A11Y properties
+		/**
+		 * Method used to update the A11Y properties of the Flatpickr input element
+		 *
+		 * @private
+		 * @memberof AbstractFlatpickr
+		 */
 		private _updateA11yProperties(): void {
 			// Ensure flatpickrInputElem tabindex is updated based on the platform input status
 			OSFramework.OSUI.Helper.Dom.Attribute.Set(
@@ -514,7 +546,7 @@ namespace Providers.OSUI.Datepicker.Flatpickr {
 		/**
 		 * Method used to disable days on DatePicker
 		 *
-		 * @param disableDays
+		 * @param {string[]} disableDays
 		 * @memberof Flatpickr.DisableDays
 		 */
 		public disableDays(disableDays: string[]): void {
@@ -525,8 +557,8 @@ namespace Providers.OSUI.Datepicker.Flatpickr {
 		/**
 		 * Method used to disable weekdays on DatePicker
 		 *
-		 * @param disableWeekDays
-		 * @memberof Flatpickr.DisableWeekDays
+		 * @param {number[]} disableWeekDays
+		 * @memberof AbstractFlatpickr
 		 */
 		public disableWeekDays(disableWeekDays: number[]): void {
 			this.configs.DisabledWeekDays = disableWeekDays;
@@ -625,7 +657,8 @@ namespace Providers.OSUI.Datepicker.Flatpickr {
 		/**
 		 * Method used to set the DatePicker language
 		 *
-		 * @memberof Providers.OSUI.DatePicker.Flatpickr.AbstractFlatpickr
+		 * @param {string} value
+		 * @memberof AbstractFlatpickr
 		 */
 		public setLanguage(value: string): void {
 			// Set the new Language

--- a/src/scripts/Providers/OSUI/Datepicker/Flatpickr/AbstractFlatpickr.ts
+++ b/src/scripts/Providers/OSUI/Datepicker/Flatpickr/AbstractFlatpickr.ts
@@ -8,7 +8,7 @@ namespace Providers.OSUI.Datepicker.Flatpickr {
 		private _a11yInfoContainerElem: HTMLElement;
 		// Event OnBodyScroll common behaviour
 		private _bodyScrollCommonBehaviour: SharedProviderResources.Flatpickr.UpdatePositionOnScroll;
-		// Flag to store the satus of the platform input
+		// Flag to store the status of the platform input
 		private _isPlatformInputDisabled: boolean;
 		// Store HtmlElement for the provider focus span target
 		private _providerFocusSpanTarget: HTMLElement;

--- a/src/scripts/Providers/OSUI/Datepicker/Flatpickr/AbstractFlatpickr.ts
+++ b/src/scripts/Providers/OSUI/Datepicker/Flatpickr/AbstractFlatpickr.ts
@@ -8,7 +8,7 @@ namespace Providers.OSUI.Datepicker.Flatpickr {
 		private _a11yInfoContainerElem: HTMLElement;
 		// Event OnBodyScroll common behaviour
 		private _bodyScrollCommonBehaviour: SharedProviderResources.Flatpickr.UpdatePositionOnScroll;
-		/* Flag to store the satus of the platform input */
+		// Flag to store the satus of the platform input
 		private _isPlatformInputDisabled: boolean;
 		// Store HtmlElement for the provider focus span target
 		private _providerFocusSpanTarget: HTMLElement;
@@ -40,12 +40,7 @@ namespace Providers.OSUI.Datepicker.Flatpickr {
 			this.configs.OnOpen = this.onDatePickerOpen.bind(this);
 		}
 
-		/**
-		 * Method used to set the HTML attributes to the Flatpickr input element
-		 *
-		 * @private
-		 * @memberof AbstractFlatpickr
-		 */
+		// Method used to set the HTML attributes to the Flatpickr input element
 		private _setAttributes(): void {
 			// Since a new input will be added by the flatpickr library, we must address it only at onReady
 			if (this.datePickerPlatformInputElem.nextSibling) {
@@ -68,12 +63,7 @@ namespace Providers.OSUI.Datepicker.Flatpickr {
 			}
 		}
 
-		/**
-		 * Method used to set the CSS classes to the calendar HTML elements
-		 *
-		 * @private
-		 * @memberof AbstractFlatpickr
-		 */
+		// Method used to set the CSS classes to the calendar HTML elements
 		private _setCalendarCssClasses(): void {
 			OSFramework.OSUI.Helper.Dom.Styles.AddClass(
 				this.provider.calendarContainer,
@@ -90,12 +80,7 @@ namespace Providers.OSUI.Datepicker.Flatpickr {
 			}
 		}
 
-		/**
-		 * Method used to set the clientHeight to the parent container as an inline style in order vertical content remains same and avoid content vertical flickering!
-		 *
-		 * @private
-		 * @memberof AbstractFlatpickr
-		 */
+		// Method used to set the clientHeight to the parent container as an inline style in order vertical content remains same and avoid content vertical flickering!
 		private _setParentMinHeight(): void {
 			OSFramework.OSUI.Helper.Dom.Styles.SetStyleAttribute(
 				this.selfElement,
@@ -104,14 +89,7 @@ namespace Providers.OSUI.Datepicker.Flatpickr {
 			);
 		}
 
-		/**
-		 * Method used to handle the keydown event for the Today Button
-		 *
-		 * @private
-		 * @param {KeyboardEvent} e
-		 * @return {*}  {void}
-		 * @memberof AbstractFlatpickr
-		 */
+		// Method used to handle the keydown event for the Today Button
 		private _todayButtonKeydown(e: KeyboardEvent): void {
 			switch (e.key) {
 				case OSFramework.OSUI.GlobalEnum.Keycodes.Tab:
@@ -129,12 +107,7 @@ namespace Providers.OSUI.Datepicker.Flatpickr {
 			}
 		}
 
-		/**
-		 * Method used to remove the clientHeight that has been assigned before the redraw process!
-		 *
-		 * @private
-		 * @memberof AbstractFlatpickr
-		 */
+		// Method used to remove the clientHeight that has been assigned before the redraw process!
 		private _unsetParentMinHeight(): void {
 			OSFramework.OSUI.Helper.Dom.Styles.RemoveStyleAttribute(
 				this.selfElement,
@@ -142,12 +115,7 @@ namespace Providers.OSUI.Datepicker.Flatpickr {
 			);
 		}
 
-		/**
-		 * Method used to update the A11Y properties of the Flatpickr input element
-		 *
-		 * @private
-		 * @memberof AbstractFlatpickr
-		 */
+		// Method used to update the A11Y properties of the Flatpickr input element
 		private _updateA11yProperties(): void {
 			// Ensure flatpickrInputElem tabindex is updated based on the platform input status
 			OSFramework.OSUI.Helper.Dom.Attribute.Set(

--- a/src/scripts/Providers/OSUI/Dropdown/VirtualSelect/AbstractVirtualSelect.ts
+++ b/src/scripts/Providers/OSUI/Dropdown/VirtualSelect/AbstractVirtualSelect.ts
@@ -119,6 +119,11 @@ namespace Providers.OSUI.Dropdown.VirtualSelect {
 			this.selfElement.removeEventListener(OSFramework.OSUI.GlobalEnum.HTMLEvent.MouseUp, this._onMouseUpEvent);
 
 			OSFramework.OSUI.Event.DOMEvents.Listeners.GlobalListenerManager.Instance.removeHandler(
+				OSFramework.OSUI.Event.DOMEvents.Listeners.Type.OrientationChange,
+				this._eventOnOrientationChange
+			);
+
+			OSFramework.OSUI.Event.DOMEvents.Listeners.GlobalListenerManager.Instance.removeHandler(
 				OSFramework.OSUI.Event.DOMEvents.Listeners.Type.WindowResize,
 				this._eventOnWindowResize
 			);

--- a/src/scripts/Providers/OSUI/Dropdown/VirtualSelect/AbstractVirtualSelect.ts
+++ b/src/scripts/Providers/OSUI/Dropdown/VirtualSelect/AbstractVirtualSelect.ts
@@ -1,6 +1,6 @@
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 namespace Providers.OSUI.Dropdown.VirtualSelect {
-  export abstract class AbstractVirtualSelect<C extends Dropdown.VirtualSelect.AbstractVirtualSelectConfig>
+	export abstract class AbstractVirtualSelect<C extends Dropdown.VirtualSelect.AbstractVirtualSelectConfig>
 		extends OSFramework.OSUI.Patterns.Dropdown.AbstractDropdown<VirtualSelect, C>
 		implements IVirtualSelect
 	{
@@ -145,12 +145,12 @@ namespace Providers.OSUI.Dropdown.VirtualSelect {
 				this.uniqueId
 			);
 
-      if (OSFramework.OSUI.Helper.DeviceInfo.HasAccessibilityEnabled) {
-        OSFramework.OSUI.Helper.Dom.Styles.AddClass(
-          this.provider.$dropboxContainer,
-          OSFramework.OSUI.Constants.HasAccessibilityClass
-        );
-      }
+			if (OSFramework.OSUI.Helper.DeviceInfo.HasAccessibilityEnabled) {
+				OSFramework.OSUI.Helper.Dom.Styles.AddClass(
+					this.provider.$dropboxContainer,
+					OSFramework.OSUI.Constants.HasAccessibilityClass
+				);
+			}
 
 			// Set provider Info to be used by setProviderConfigs API calls
 			this.updateProviderEvents({

--- a/src/scripts/Providers/OSUI/Monthpicker/Flatpickr/FlatpickrMonth.ts
+++ b/src/scripts/Providers/OSUI/Monthpicker/Flatpickr/FlatpickrMonth.ts
@@ -13,7 +13,7 @@ namespace Providers.OSUI.MonthPicker.Flatpickr {
 		private _bodyScrollCommonBehaviour: SharedProviderResources.Flatpickr.UpdatePositionOnScroll;
 		// Store the provider options
 		private _flatpickrOpts: FlatpickrOptions;
-		// Flag to store the satus of the platform input
+		// Flag to store the status of the platform input
 		private _isPlatformInputDisabled: boolean;
 		// Validation of ZIndex position common behavior
 		private _zindexCommonBehavior: SharedProviderResources.Flatpickr.UpdateZindex;

--- a/src/scripts/Providers/OSUI/Monthpicker/Flatpickr/FlatpickrMonth.ts
+++ b/src/scripts/Providers/OSUI/Monthpicker/Flatpickr/FlatpickrMonth.ts
@@ -13,7 +13,7 @@ namespace Providers.OSUI.MonthPicker.Flatpickr {
 		private _bodyScrollCommonBehaviour: SharedProviderResources.Flatpickr.UpdatePositionOnScroll;
 		// Store the provider options
 		private _flatpickrOpts: FlatpickrOptions;
-		/* Flag to store the satus of the platform input */
+		// Flag to store the satus of the platform input
 		private _isPlatformInputDisabled: boolean;
 		// Validation of ZIndex position common behavior
 		private _zindexCommonBehavior: SharedProviderResources.Flatpickr.UpdateZindex;
@@ -33,12 +33,7 @@ namespace Providers.OSUI.MonthPicker.Flatpickr {
 			this.configs.OnOpenEventCallback = this.onOpen.bind(this);
 		}
 
-		/**
-		 * Method that will get the instance of the Global onBodyClick event.
-		 *
-		 * @private
-		 * @memberof Providers.OSUI.MonthPicker.Flatpickr.OSUIFlatpickrMonth
-		 */
+		// Method that will get the instance of the Global onBodyClick event.
 		private _getBodyOnClickGlobalEvent(): void {
 			this._bodyOnClickGlobalEvent =
 				OSFramework.OSUI.Event.DOMEvents.Listeners.GlobalListenerManager.Instance.events.get(

--- a/src/scripts/Providers/OSUI/Timepicker/Flatpickr/FlatpickrTime.ts
+++ b/src/scripts/Providers/OSUI/Timepicker/Flatpickr/FlatpickrTime.ts
@@ -11,7 +11,7 @@ namespace Providers.OSUI.TimePicker.Flatpickr {
 		private _bodyScrollCommonBehaviour: SharedProviderResources.Flatpickr.UpdatePositionOnScroll;
 		// Store the provider options
 		private _flatpickrOpts: FlatpickrOptions;
-		/* Flag to store the satus of the platform input */
+		// Flag to store the satus of the platform input
 		private _isPlatformInputDisabled: boolean;
 		// Validation of ZIndex position common behavior
 		private _zindexCommonBehavior: SharedProviderResources.Flatpickr.UpdateZindex;
@@ -31,12 +31,7 @@ namespace Providers.OSUI.TimePicker.Flatpickr {
 			this.configs.OnOpenEventCallback = this.onOpen.bind(this);
 		}
 
-		/**
-		 * Method that will get the instance of the Global onBodyClick event.
-		 *
-		 * @private
-		 * @memberof Providers.OSUI.TimePicker.Flatpickr.OSUIFlatpickrTime
-		 */
+		// Method that will get the instance of the Global onBodyClick event.
 		private _getBodyOnClickGlobalEvent(): void {
 			this._bodyOnClickGlobalEvent =
 				OSFramework.OSUI.Event.DOMEvents.Listeners.GlobalListenerManager.Instance.events.get(

--- a/src/scripts/Providers/OSUI/Timepicker/Flatpickr/FlatpickrTime.ts
+++ b/src/scripts/Providers/OSUI/Timepicker/Flatpickr/FlatpickrTime.ts
@@ -11,7 +11,7 @@ namespace Providers.OSUI.TimePicker.Flatpickr {
 		private _bodyScrollCommonBehaviour: SharedProviderResources.Flatpickr.UpdatePositionOnScroll;
 		// Store the provider options
 		private _flatpickrOpts: FlatpickrOptions;
-		// Flag to store the satus of the platform input
+		// Flag to store the status of the platform input
 		private _isPlatformInputDisabled: boolean;
 		// Validation of ZIndex position common behavior
 		private _zindexCommonBehavior: SharedProviderResources.Flatpickr.UpdateZindex;


### PR DESCRIPTION
This PR is for improving the usage of handlers, standardize the comments across methods, and additional code improvements.

### What was happening
- There were several places where the handlers for events were not being removed:
   - **FocusTrap**: using method.bind in add and remove event listener;
   - **DropdownServerSide**: instead of `removeHandler`, was used `addHandler`
   - **Video & Submenu**: were unnecessarily doing a double `.bind(this)` to the method
   - **ButtonEffects**: handlers for `AnimationEnd` were not being removed
   - **AbstractVirtualSelect**: handler for `OrientationChange` was not being removed.
- The private methods were documented using the wrong format.

### What was done
- Fixed/added the removal of handlers to events
- Standardized the documentation to all private methods
- Completely removed the usage of `any` in the code.


### Checklist
-   [x] tested locally
-   [x] documented the code
-   [x] clean all warnings and errors of eslint
-   [ ] requires changes in OutSystems (if so, provide a module with changes)
-   [ ] requires new sample page in OutSystems (if so, provide a module with changes)
