### PR TITLE
ROU-11773: DropdownServerSideItem: OnSelected Event Fires Twice When Using Keyboard

### DIFF
--- a/src/scripts/OSFramework/OSUI/Pattern/Dropdown/ServerSide/DropdownServerSide.ts
+++ b/src/scripts/OSFramework/OSUI/Pattern/Dropdown/ServerSide/DropdownServerSide.ts
@@ -312,14 +312,14 @@ namespace OSFramework.OSUI.Patterns.Dropdown.ServerSide {
 					case GlobalEnum.Keycodes.ArrowUp:
 						// Check If focused item is not the first one!
 						if (getOptionItemIndex > 0) {
-							this._updateOptionItemFocuStateOnKeyPress(optionItem, getOptionItemIndex - 1);
+							this._updateOptionItemFocusStateOnKeyPress(optionItem, getOptionItemIndex - 1);
 						}
 						break;
 
 					// ArrowDown
 					case GlobalEnum.Keycodes.ArrowDown:
 						if (getOptionItemIndex < this.getChildItems().length - 1) {
-							this._updateOptionItemFocuStateOnKeyPress(optionItem, getOptionItemIndex + 1);
+							this._updateOptionItemFocusStateOnKeyPress(optionItem, getOptionItemIndex + 1);
 						}
 						break;
 
@@ -580,14 +580,14 @@ namespace OSFramework.OSUI.Patterns.Dropdown.ServerSide {
 		}
 
 		// Method to (un)set option item focus statue
-		private _updateOptionItemFocuStateOnKeyPress(
+		private _updateOptionItemFocusStateOnKeyPress(
 			optionItem: Patterns.DropdownServerSideItem.IDropdownServerSideItem,
 			itemIndex: number
 		): void {
 			// Check if Dropdown should only allow single option selected!
 			if (this.configs.AllowMultipleSelection === false) {
 				// Unset IsSelected to the previous Item
-				optionItem.toggleSelected();
+				optionItem.toggleSelected(false);
 				// Set IsSelected to the next item
 				this.getChildByIndex(itemIndex).toggleSelected();
 			}


### PR DESCRIPTION
This PR is for fixing keyboard interaction feedback of the DropdownServerSideItem; 

### What was happening

- when the keyboard was used to select dropdownItem two events were fired, one by the item that was unselected, and other by the selected item.

### What was done
- don't trigger callback of the unselected option item, since it will be called by the new option item select.

### Test Steps

1. Go to sample 
2. Open Console
3. Using keyboard navigation navigate/select between items 
4. Lock to the console and check that there aren’t 2 values return at the same timestamp

### Checklist

-   [x] tested locally
-   [x] documented the code
-   [x] clean all warnings and errors of eslint
-   [ ] requires changes in OutSystems (if so, provide a module with changes)
-   [ ] requires new sample page in OutSystems (if so, provide a module with changes)
