### PR TITLE
ROU-11743: Fixing type in TypeScript

### DIFF
--- a/src/scripts/OSFramework/OSUI/Pattern/Progress/Bar/ProgressBar.ts
+++ b/src/scripts/OSFramework/OSUI/Pattern/Progress/Bar/ProgressBar.ts
@@ -3,7 +3,7 @@
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 namespace OSFramework.OSUI.Patterns.Progress.Bar {
 	export class Bar extends Progress.AbstractProgress<ProgressBarConfig> {
-		constructor(uniqueId: string, configs: unknown) {
+		constructor(uniqueId: string, configs: JSON) {
 			super(uniqueId, new ProgressBarConfig(configs));
 			this.progressType = ProgressEnum.ProgressTypes.Bar;
 		}

--- a/src/scripts/OSFramework/OSUI/Pattern/Progress/Circle/ProgressCircle.ts
+++ b/src/scripts/OSFramework/OSUI/Pattern/Progress/Circle/ProgressCircle.ts
@@ -35,7 +35,7 @@ namespace OSFramework.OSUI.Patterns.Progress.Circle {
 			r: Enum.DefaultValues.RadialRadius,
 		};
 
-		constructor(uniqueId: string, configs: unknown) {
+		constructor(uniqueId: string, configs: JSON) {
 			super(uniqueId, new ProgressCircleConfig(configs));
 		}
 


### PR DESCRIPTION
This PR is for fixing a small TypeScript type error. No effect in runtime.

### What was happening
- There was a warning in typescript compilation

### What was done
- Changed the type from `unknown` to `JSON`

### Checklist
-   [ ] tested locally
-   [ ] documented the code
-   [ ] clean all warnings and errors of eslint
-   [ ] requires changes in OutSystems (if so, provide a module with changes)
-   [ ] requires new sample page in OutSystems (if so, provide a module with changes)
