### PR TITLE
ROU-11799: Fix inline date and month picker visual issues

### DIFF
--- a/src/scripts/OSFramework/OSUI/Pattern/DatePicker/scss/_datepicker.scss
+++ b/src/scripts/OSFramework/OSUI/Pattern/DatePicker/scss/_datepicker.scss
@@ -34,7 +34,7 @@
 
 		// Hide the platform input which is set as hidden by the library and we're change it into the expected type, however we do not want it visible since library will add a clone to better deal with the selected dates.
 		// We cannot use the provider class since the provider class will not be taken into consideration on the input widget react lifecycle
-		&:first-of-type {
+		&:first-of-type:not(.flatpickr-calendar.inline input) {
 			display: none;
 
 			// Make the platform input visible in Service Studio

--- a/src/scripts/OSFramework/OSUI/Pattern/MonthPicker/scss/_monthpicker.scss
+++ b/src/scripts/OSFramework/OSUI/Pattern/MonthPicker/scss/_monthpicker.scss
@@ -56,7 +56,7 @@
 
 		// Hide the platform input which is set as hidden by the library and we're change it into the expected type, however we do not want it visible since library will add a clone to better deal with the selected dates.
 		// We cannot use the provider class since the provider class will not be taken into consideration on the input widget react lifecycle
-		&:first-of-type {
+		&:first-of-type:not(.flatpickr-calendar.inline input) {
 			display: none;
 
 			// Make the platform input visible in Service Studio

--- a/src/scripts/Providers/OSUI/SharedProviderResources/Flatpickr/scss/_flatpickr.scss
+++ b/src/scripts/Providers/OSUI/SharedProviderResources/Flatpickr/scss/_flatpickr.scss
@@ -93,6 +93,10 @@
 	&.inline {
 		--osui-flatpickr-layer: var(--layer-global-screen);
 		display: inline-block;
+
+		.flatpickr-weekwrapper {
+			min-width: max-content;
+		}
 	}
 }
 

--- a/src/scripts/Providers/OSUI/SharedProviderResources/Flatpickr/scss/_flatpickr.scss
+++ b/src/scripts/Providers/OSUI/SharedProviderResources/Flatpickr/scss/_flatpickr.scss
@@ -91,6 +91,7 @@
 	}
 
 	&.inline {
+		--osui-flatpickr-layer: var(--layer-global-screen);
 		display: inline-block;
 	}
 }


### PR DESCRIPTION
### What was happening

- When using inline mode through extensibility, there were some UI issues:
    - The year input was not displayed for the Date Picker, Date Picker Range, and Month Picker
    - The week numbers were shrunk 
    - When opening a date and time-related picker above an inline version, we could see the arrows from the inline version below

### What was done

- Added specific rules for `.inline` mode.  

### Test Steps

1. Go to a screen with Date Pickers, Date Pickers Range, Month Pickers, and Time Pickers, with and without inline mode
2. Check that all the UI and functionalities are now working
3. Validate with RTL enabled

### Screenshots

- Before fix: 
![image](https://github.com/user-attachments/assets/03e69e86-4a40-4d4b-8306-dfef87903a14)

- After fix: 
![image](https://github.com/user-attachments/assets/6561ecf7-4e25-4184-bb3a-5844edd296e0)



### Checklist

-   [X] tested locally
-   [ ] documented the code
-   [ ] clean all warnings and errors of eslint
-   [ ] requires changes in OutSystems (if so, provide a module with changes)
-   [ ] requires new sample page in OutSystems (if so, provide a module with changes)
