### PR TITLE
ROU-11784: Review how ariaLabel is being set to the DropdownSearch and DropdownTags

### DIFF
--- a/src/scripts/Providers/OSUI/Dropdown/VirtualSelect/AbstractVirtualSelect.ts
+++ b/src/scripts/Providers/OSUI/Dropdown/VirtualSelect/AbstractVirtualSelect.ts
@@ -13,8 +13,6 @@ namespace Providers.OSUI.Dropdown.VirtualSelect {
 		private _onSelectedOptionEvent: OSFramework.OSUI.GlobalCallbacks.Generic;
 		private _platformEventSelectedOptCallback: OSFramework.OSUI.Patterns.Dropdown.Callbacks.OSOnSelectEvent;
 
-		// Store the hidden input AriaLabel value
-		protected hiddenInputWrapperAriaLabelVal: string;
 		// Store a reference of available provider methods
 		protected virtualselectConfigs: VirtualSelectMethods;
 		// Store the provider options
@@ -40,12 +38,6 @@ namespace Providers.OSUI.Dropdown.VirtualSelect {
 
 				this.selfElement.parentElement.appendChild(textContainer);
 			}
-		}
-
-		// Manage the attributes to be added
-		private _manageAttributes(): void {
-			// Manage A11Y attributes
-			this.setA11YProperties();
 		}
 
 		// Manage the disable status of the pattern
@@ -164,9 +156,6 @@ namespace Providers.OSUI.Dropdown.VirtualSelect {
 				events: this.virtualselectConfigs,
 			});
 
-			// Add attributes to the element if needed
-			this._manageAttributes();
-
 			const _bodyEvent = OSFramework.OSUI.Event.DOMEvents.Listeners.GlobalListenerManager.Instance.events.get(
 				OSFramework.OSUI.Event.DOMEvents.Listeners.Type.BodyOnClick
 			) as OSFramework.OSUI.Event.DOMEvents.Listeners.IListener;
@@ -191,14 +180,13 @@ namespace Providers.OSUI.Dropdown.VirtualSelect {
 		}
 
 		/**
-		 * Method that adds the necessary attributes for A11Y purposes
+		 * This method has no implementation on this pattern context!
 		 *
 		 * @protected
 		 * @memberof Providers.OSUI.Dropdown.VirtualSelect.AbstractVirtualSelect
 		 */
 		protected setA11YProperties(): void {
-			// Set the Hidden Input AriaLabel value
-			this.setHiddenInputWrapperAriaLabelVal();
+			console.log(OSFramework.OSUI.GlobalEnum.WarningMessages.MethodNotImplemented);
 		}
 
 		/**
@@ -440,15 +428,16 @@ namespace Providers.OSUI.Dropdown.VirtualSelect {
 		}
 
 		/**
-		 * Method used to set the Hidden Input AriaLabel text value
-		 *
-		 * @param {string} value
-		 * @memberof Providers.OSUI.Dropdown.VirtualSelect.AbstractVirtualSelect
+		 * @deprecated use 'SetVirtualSelectConfigs' client action through LowCode or 'OutSystems.OSUI.Patterns.DropdownAPI.SetProviderConfigs()' API instead.
 		 */
 		public setHiddenInputWrapperAriaLabelVal(value?: string): void {
-			this.hiddenInputWrapperAriaLabelVal = value === undefined ? this.hiddenInputWrapperAriaLabelVal : value;
-			// Set HiddenInput AriaLabel Value
-			OSFramework.OSUI.Helper.A11Y.AriaLabel(this.provider.$wrapper, this.hiddenInputWrapperAriaLabelVal);
+			console.warn(
+				'setHiddenInputWrapperAriaLabelVal(...), is deprecated. Please use `SetVirtualSelectConfigs` client action through LowCode or `OutSystems.OSUI.Patterns.DropdownAPI.SetProviderConfigs(...)` JS API instead.'
+			);
+
+			this.setProviderConfigs({
+				ariaLabelText: value,
+			});
 		}
 
 		/**

--- a/src/scripts/Providers/OSUI/Dropdown/VirtualSelect/Search/VirtualSelectSearch.ts
+++ b/src/scripts/Providers/OSUI/Dropdown/VirtualSelect/Search/VirtualSelectSearch.ts
@@ -4,11 +4,6 @@ namespace Providers.OSUI.Dropdown.VirtualSelect.Search {
 	export class OSUIVirtualSelectSearch extends AbstractVirtualSelect<VirtualSelectSearchConfig> {
 		constructor(uniqueId: string, configs: JSON) {
 			super(uniqueId, new VirtualSelectSearchConfig(configs));
-
-			// Set the AriaLabel text value for the hidden text input wrapper
-			this.hiddenInputWrapperAriaLabelVal = this.configs.AllowMultipleSelection
-				? Dropdown.VirtualSelect.Enum.PropertiesValues.AriaLabelMultipleValue
-				: Dropdown.VirtualSelect.Enum.PropertiesValues.AriaLabelSingleValue;
 		}
 
 		/**

--- a/src/scripts/Providers/OSUI/Dropdown/VirtualSelect/Search/VirtualSelectSearchConfig.ts
+++ b/src/scripts/Providers/OSUI/Dropdown/VirtualSelect/Search/VirtualSelectSearchConfig.ts
@@ -49,6 +49,9 @@ namespace Providers.OSUI.Dropdown.VirtualSelect.Search {
 		public getProviderConfig(): VirtualSelectOpts {
 			const virtualSelectSearchOpts = {
 				multiple: this.AllowMultipleSelection,
+				ariaLabelText: this.AllowMultipleSelection
+					? VirtualSelect.Enum.PropertiesValues.AriaLabelMultipleValue
+					: VirtualSelect.Enum.PropertiesValues.AriaLabelSingleValue,
 			};
 
 			return this.mergeConfigs(super.getProviderConfig(), virtualSelectSearchOpts, this.providerExtendedOptions);

--- a/src/scripts/Providers/OSUI/Dropdown/VirtualSelect/Tags/VirtualSelectTags.ts
+++ b/src/scripts/Providers/OSUI/Dropdown/VirtualSelect/Tags/VirtualSelectTags.ts
@@ -4,9 +4,6 @@ namespace Providers.OSUI.Dropdown.VirtualSelect.Tags {
 	export class OSUIVirtualSelectTags extends AbstractVirtualSelect<VirtualSelectTagsConfig> {
 		constructor(uniqueId: string, configs: JSON) {
 			super(uniqueId, new VirtualSelectTagsConfig(configs));
-
-			// Set the AriaLabel text value for the hidden text input wrapper
-			this.hiddenInputWrapperAriaLabelVal = Dropdown.VirtualSelect.Enum.PropertiesValues.AriaLabelMultipleValue;
 		}
 
 		/**

--- a/src/scripts/Providers/OSUI/Dropdown/VirtualSelect/Tags/VirtualSelectTagsConfig.ts
+++ b/src/scripts/Providers/OSUI/Dropdown/VirtualSelect/Tags/VirtualSelectTagsConfig.ts
@@ -39,6 +39,7 @@ namespace Providers.OSUI.Dropdown.VirtualSelect.Tags {
 		 */
 		public getProviderConfig(): VirtualSelectOpts {
 			const virtualSelectTagsOpts = {
+				ariaLabelText: VirtualSelect.Enum.PropertiesValues.AriaLabelMultipleValue,
 				multiple: true,
 				showValueAsTags: true,
 			};

--- a/src/scripts/Providers/OSUI/Dropdown/VirtualSelect/VirtualSelect.d.ts
+++ b/src/scripts/Providers/OSUI/Dropdown/VirtualSelect/VirtualSelect.d.ts
@@ -58,6 +58,7 @@ namespace Providers.OSUI.Dropdown.VirtualSelect {
 		allOptionsSelectedText?: string;
 		allowNewOption?: boolean;
 		alwaysShowSelectedOptionsCount?: boolean;
+		ariaLabelText?: string;
 		autofocus?: boolean;
 		autoSelectFirstOption?: boolean;
 		clearButtonText?: string;


### PR DESCRIPTION
This PR will change the way **DropdownSearch** and **DropdownTags** `aria-label` value attribute is being set.


### What was happening

- `aria-label` attribute was being changed by changing it's value directly.
- The previous approach didn't take consideration on the `ariaLabelText` library (VirtualSelect) attribute;

### What was done

- `setHiddenInputWrapperAriaLabelVal()` method has been deprecated **deprecated**.
- Updated the way expected tests to be added as `aria-label` are being set, by using the provider property.


### Checklist

-   [x] tested locally
-   [x] documented the code
-   [x] clean all warnings and errors of eslint
-   [  ] requires changes in OutSystems (if so, provide a module with changes)
-   [  ] requires new sample page in OutSystems (if so, provide a module with changes)
