### PR TITLE
ROU-11858: Improve error handling for scenarios without TabsHeaderItem/TabsContentItem

### DIFF
--- a/src/scripts/OSFramework/OSUI/ErrorCodes.ts
+++ b/src/scripts/OSFramework/OSUI/ErrorCodes.ts
@@ -57,6 +57,7 @@ namespace OSFramework.OSUI.ErrorCodes {
 		FailToSetChildItemAction: 'OSUI-GEN-09004',
 		FailUnsetNewChildContentItem: 'OSUI-GEN-09005',
 		FailUnsetNewChildHeaderItem: 'OSUI-GEN-09006',
+		FailNoContentOrHeaderItemFound: 'OSUI-GEN-09007',
 	};
 
 	export const AbstractParent = {

--- a/src/scripts/OSFramework/OSUI/Pattern/Tabs/Tabs.ts
+++ b/src/scripts/OSFramework/OSUI/Pattern/Tabs/Tabs.ts
@@ -960,8 +960,7 @@ namespace OSFramework.OSUI.Patterns.Tabs {
 				// to prevent triggering event if using client action SetActiveTab to set the already active item
 				(tabIndex === this.configs.StartingTab && this.isBuilt && tabsHeaderItem === undefined) ||
 				// To prevent changing tab when a dropdown is currently open and that content exists, which would cause UI issues
-				(this._activeTabContentElement &&
-					this._activeTabContentElement.selfElement.querySelector(Enum.ElementsBlockingOnChange.Dropdown))
+				this._activeTabContentElement?.selfElement.querySelector(Enum.ElementsBlockingOnChange.Dropdown)
 			) {
 				return;
 			}

--- a/src/scripts/OSFramework/OSUI/Pattern/Tabs/Tabs.ts
+++ b/src/scripts/OSFramework/OSUI/Pattern/Tabs/Tabs.ts
@@ -363,6 +363,17 @@ namespace OSFramework.OSUI.Patterns.Tabs {
 
 		// Method to make neccessary preparations for header and content items, that can't be done on their scope
 		private _prepareHeaderAndContentItems(): void {
+			// Make more visible the error message, if the user is trying to use the Tabs without any content or header item
+			// without being too intrusive
+			if (
+				this.getChildItems(Enum.ChildTypes.TabsContentItem).length === 0 ||
+				this.getChildItems(Enum.ChildTypes.TabsHeaderItem).length === 0
+			) {
+				console.log(
+					`${ErrorCodes.Tabs.FailNoContentOrHeaderItemFound}: To ensure predictable behavior and avoid runtime issues, the ${GlobalEnum.PatternName.Tabs} component under uniqueId: '${this.uniqueId}' is designed to include at least one ${GlobalEnum.PatternName.TabsHeaderItem} and one ${GlobalEnum.PatternName.TabsContentItem}.`
+				);
+			}
+
 			// Set if the Tabs has only one Content
 			this._hasSingleContent = this.getChildItems(Enum.ChildTypes.TabsContentItem).length === 1;
 
@@ -409,7 +420,7 @@ namespace OSFramework.OSUI.Patterns.Tabs {
 				this.unsetChild(childContentId);
 			} else {
 				throw new Error(
-					`${ErrorCodes.Tabs.FailUnsetNewChildContentItem}: The ${GlobalEnum.PatternName.TabsContentItem} under uniqueId: '${childContentId}' does not exist as an TabsContentItem from ${GlobalEnum.PatternName.Tabs} with Id: ${this.widgetId}.`
+					`${ErrorCodes.Tabs.FailUnsetNewChildContentItem}: The ${GlobalEnum.PatternName.TabsContentItem} under uniqueId: '${childContentId}' does not exist as a ${GlobalEnum.PatternName.TabsContentItem} from ${GlobalEnum.PatternName.Tabs} with Id: ${this.widgetId}.`
 				);
 			}
 
@@ -467,7 +478,7 @@ namespace OSFramework.OSUI.Patterns.Tabs {
 				this.unsetChild(childHeaderId);
 			} else {
 				throw new Error(
-					`${ErrorCodes.Tabs.FailUnsetNewChildHeaderItem}: The ${GlobalEnum.PatternName.TabsHeaderItem} under uniqueId: '${childHeaderId}' does not exist as an TabsHeaderItem from ${GlobalEnum.PatternName.Tabs} with Id: ${this.widgetId}.`
+					`${ErrorCodes.Tabs.FailUnsetNewChildHeaderItem}: The ${GlobalEnum.PatternName.TabsHeaderItem} under uniqueId: '${childHeaderId}' does not exist as a ${GlobalEnum.PatternName.TabsHeaderItem} from ${GlobalEnum.PatternName.Tabs} with Id: ${this.widgetId}.`
 				);
 			}
 
@@ -691,7 +702,7 @@ namespace OSFramework.OSUI.Patterns.Tabs {
 
 			if (newHeaderItem === undefined) {
 				throw new Error(
-					`${ErrorCodes.Tabs.FailChildItemClicked}: The ${GlobalEnum.PatternName.TabsHeaderItem} under uniqueId: '${childHeaderId}' does not exist as an TabsHeaderItem from ${GlobalEnum.PatternName.Tabs} with Id: ${this.widgetId}.`
+					`${ErrorCodes.Tabs.FailChildItemClicked}: The ${GlobalEnum.PatternName.TabsHeaderItem} under uniqueId: '${childHeaderId}' does not exist as a ${GlobalEnum.PatternName.TabsHeaderItem} from ${GlobalEnum.PatternName.Tabs} with Id: ${this.widgetId}.`
 				);
 			}
 
@@ -948,8 +959,9 @@ namespace OSFramework.OSUI.Patterns.Tabs {
 				this._activeTabHeaderElement === tabsHeaderItem ||
 				// to prevent triggering event if using client action SetActiveTab to set the already active item
 				(tabIndex === this.configs.StartingTab && this.isBuilt && tabsHeaderItem === undefined) ||
-				// To prevent changing tab when a dropdown is currently open, which would cause UI issues
-				this._activeTabContentElement.selfElement.querySelector(Enum.ElementsBlockingOnChange.Dropdown)
+				// To prevent changing tab when a dropdown is currently open and that content exists, which would cause UI issues
+				(this._activeTabContentElement &&
+					this._activeTabContentElement.selfElement.querySelector(Enum.ElementsBlockingOnChange.Dropdown))
 			) {
 				return;
 			}

--- a/src/scripts/OSFramework/OSUI/Pattern/Tabs/Tabs.ts
+++ b/src/scripts/OSFramework/OSUI/Pattern/Tabs/Tabs.ts
@@ -369,7 +369,7 @@ namespace OSFramework.OSUI.Patterns.Tabs {
 				this.getChildItems(Enum.ChildTypes.TabsContentItem).length === 0 ||
 				this.getChildItems(Enum.ChildTypes.TabsHeaderItem).length === 0
 			) {
-				console.log(
+				console.warn(
 					`${ErrorCodes.Tabs.FailNoContentOrHeaderItemFound}: To ensure predictable behavior and avoid runtime issues, the ${GlobalEnum.PatternName.Tabs} component under uniqueId: '${this.uniqueId}' is designed to include at least one ${GlobalEnum.PatternName.TabsHeaderItem} and one ${GlobalEnum.PatternName.TabsContentItem}.`
 				);
 			}


### PR DESCRIPTION
### What was happening

- By design, the Tabs component requires having at least one TabsHeaderItem/TabsContentItem, but we were not handling this, and an error was thrown: 
![image](https://github.com/user-attachments/assets/5ded5b31-8205-4b54-aa9a-28ec7f760948)


### What was done

- Made more visible the error message if the user is trying to use the Tabs without any content or a header item without being too intrusive, ie, logging a warning message in the console but throwing an error.

### Test Steps

1. Go to a screen with Tabs without TabsHeaderItem/TabsContentItem
2. Check that no error is thrown and that in the console we can see a `console.log` with the message `OSUI-GEN-09007: To ensure predictable behavior and avoid runtime issues, the Tabs component under uniqueId: '0.3kyrdmk6pa'  is designed to include at least one TabsHeaderItem and one TabsContentItem.`



### Checklist

-   [X] tested locally
-   [X] documented the code
-   [X] clean all warnings and errors of eslint
-   [ ] requires changes in OutSystems
-   [ ] requires new sample page in OutSystems
