### PR TITLE
ROU-11864: Fix tab indicator incorrect positioning

### DIFF
--- a/src/scripts/OSFramework/OSUI/Pattern/Tabs/Tabs.ts
+++ b/src/scripts/OSFramework/OSUI/Pattern/Tabs/Tabs.ts
@@ -502,10 +502,10 @@ namespace OSFramework.OSUI.Patterns.Tabs {
 					} else {
 						this._activeTabHeaderElement = null;
 					}
-
-					// Update scale size variable
-					this._handleTabIndicator();
 				}
+
+        // Update scale size variable
+        Helper.AsyncInvocation(this._handleTabIndicator.bind(this));
 			}
 		}
 


### PR DESCRIPTION
This PR is for...

[Sample page](https://outsystemsui-dev.outsystemsenterprise.com/TaskSample_DEV_ROU11864/TabsChangeRuntime?_ts=638817884920100380)

### What was happening
- Hiding a Header Item that was active or not could cause a visual desynchronization of the tab indicator and the position of the currently active tab.

### What was done
- Used the Helper AsyncInvocation function to ensure that the tab indicator update occurs only after the Tab Header item has been completely removed.
- Moved the tab indicator update outside of the if condition that checks whether the removed Header item was active since we want to update the tab indicator regardless of that condition.

### Test Steps
1. Select the First Tab;
2. Hide Header 1 using the toggle on top of the page;
3. Check that the tab indicator is correctly placed below the the tab that is now active;
4. Reveal Header 1 using the toggle on top of the page;
5. Select the Third Tab;
6. Hide Header 1 using the toggle on top of the page once again;
7. Check that the tab indicator is correctly placed below the the tab that is now active;

### Screenshots

(prefer animated gif)

### Checklist

-   [x] tested locally
-   [ ] documented the code
-   [x] clean all warnings and errors of eslint
-   [ ] requires changes in OutSystems (if so, provide a module with changes)
-   [ ] requires new sample page in OutSystems (if so, provide a module with changes)
