### PR TITLE
ROU-11926: Protecting code that is run async 

### DIFF
--- a/src/scripts/OSFramework/OSUI/Pattern/AnimatedLabel/AnimatedLabel.ts
+++ b/src/scripts/OSFramework/OSUI/Pattern/AnimatedLabel/AnimatedLabel.ts
@@ -13,6 +13,7 @@ namespace OSFramework.OSUI.Patterns.AnimatedLabel {
 		private _eventBlur: GlobalCallbacks.Generic;
 		private _eventFocus: GlobalCallbacks.Generic;
 		private _eventKeyDown: GlobalCallbacks.Generic;
+		private _isDisposed = false;
 
 		// Set the input html element
 		private _inputElement: HTMLInputElement | HTMLTextAreaElement;
@@ -101,11 +102,13 @@ namespace OSFramework.OSUI.Patterns.AnimatedLabel {
 
 		// Method to remove Pattern Events
 		private _removeEvents(): void {
-			this._inputElement.removeEventListener(GlobalEnum.HTMLEvent.Blur, this._eventBlur);
-			this._inputElement.removeEventListener(GlobalEnum.HTMLEvent.Focus, this._eventFocus);
-			this._inputElement.removeEventListener(GlobalEnum.HTMLEvent.AnimationStart, this._eventAnimationStart);
-			if (this._inputElement.type === 'number') {
-				this._inputElement.removeEventListener(GlobalEnum.HTMLEvent.keyDown, this._eventKeyDown);
+			if (this._inputElement) {
+				this._inputElement.removeEventListener(GlobalEnum.HTMLEvent.Blur, this._eventBlur);
+				this._inputElement.removeEventListener(GlobalEnum.HTMLEvent.Focus, this._eventFocus);
+				this._inputElement.removeEventListener(GlobalEnum.HTMLEvent.AnimationStart, this._eventAnimationStart);
+				if (this._inputElement.type === 'number') {
+					this._inputElement.removeEventListener(GlobalEnum.HTMLEvent.keyDown, this._eventKeyDown);
+				}
 			}
 		}
 
@@ -196,13 +199,16 @@ namespace OSFramework.OSUI.Patterns.AnimatedLabel {
 		public build(): void {
 			//OS takes a while to set the TextArea
 			Helper.AsyncInvocation(() => {
-				super.build();
+				if (!this._isDisposed) {
+					// Set the common html elements
+					super.build();
 
-				this.setHtmlElements();
+					this.setHtmlElements();
 
-				this.setCallbacks();
+					this.setCallbacks();
 
-				this.finishBuild();
+					this.finishBuild();
+				}
 			});
 		}
 
@@ -212,6 +218,7 @@ namespace OSFramework.OSUI.Patterns.AnimatedLabel {
 		 * @memberof OSFramework.Patterns.AnimatedLabel.AnimatedLabel
 		 */
 		public dispose(): void {
+			this._isDisposed = true;
 			this.unsetCallbacks();
 
 			this.unsetHtmlElements();

--- a/src/scripts/OSFramework/OSUI/Pattern/Notification/Notification.ts
+++ b/src/scripts/OSFramework/OSUI/Pattern/Notification/Notification.ts
@@ -283,25 +283,27 @@ namespace OSFramework.OSUI.Patterns.Notification {
 		 * @memberof OSFramework.Patterns.Notification.Notification
 		 */
 		protected setInitialStates(): void {
-			// Set event if device is touch
-			if (Helper.DeviceInfo.IsTouch) {
-				this._eventType = GlobalEnum.HTMLEvent.TouchStart;
-			} else {
-				this._eventType = GlobalEnum.HTMLEvent.Click;
-			}
+			if (this.isBuilt) {
+				// Set event if device is touch
+				if (Helper.DeviceInfo.IsTouch) {
+					this._eventType = GlobalEnum.HTMLEvent.TouchStart;
+				} else {
+					this._eventType = GlobalEnum.HTMLEvent.Click;
+				}
 
-			// Set width value for Notification
-			Helper.Dom.Styles.SetStyleAttribute(this.selfElement, Enum.CssProperty.Width, this.configs.Width);
+				// Set width value for Notification
+				Helper.Dom.Styles.SetStyleAttribute(this.selfElement, Enum.CssProperty.Width, this.configs.Width);
 
-			// Set position initial class
-			Helper.Dom.Styles.AddClass(this.selfElement, Enum.CssClass.PatternPosition + this.configs.Position);
+				// Set position initial class
+				Helper.Dom.Styles.AddClass(this.selfElement, Enum.CssClass.PatternPosition + this.configs.Position);
 
-			if (this._isOpen) {
-				this._showNotification();
-			}
+				if (this._isOpen) {
+					this._showNotification();
+				}
 
-			if (this.configs.CloseAfterTime > 0 && this._isOpen) {
-				this._autoCloseNotification();
+				if (this.configs.CloseAfterTime > 0 && this._isOpen) {
+					this._autoCloseNotification();
+				}
 			}
 		}
 

--- a/src/scripts/OSFramework/OSUI/Pattern/Progress/Bar/ProgressBar.ts
+++ b/src/scripts/OSFramework/OSUI/Pattern/Progress/Bar/ProgressBar.ts
@@ -78,13 +78,15 @@ namespace OSFramework.OSUI.Patterns.Progress.Bar {
 		 * @memberof OSFramework.Patterns.Progress.Bar.Bar
 		 */
 		protected addInitialAnimation(): void {
-			// Check if the animation at init should be added
-			if (this.configs.AnimateInitialProgress) {
-				this.animateInitial();
-			}
+			if (this.isBuilt) {
+				// Check if the animation at init should be added
+				if (this.configs.AnimateInitialProgress) {
+					this.animateInitial();
+				}
 
-			// Update the progress value and the valuenow accessibility property
-			this.updatedProgressValue();
+				// Update the progress value and the valuenow accessibility property
+				this.updatedProgressValue();
+			}
 		}
 
 		/**

--- a/src/scripts/OSFramework/OSUI/Pattern/Tabs/Tabs.ts
+++ b/src/scripts/OSFramework/OSUI/Pattern/Tabs/Tabs.ts
@@ -504,8 +504,8 @@ namespace OSFramework.OSUI.Patterns.Tabs {
 					}
 				}
 
-        // Update scale size variable
-        Helper.AsyncInvocation(this._handleTabIndicator.bind(this));
+				// Update scale size variable
+				Helper.AsyncInvocation(this._handleTabIndicator.bind(this));
 			}
 		}
 
@@ -523,16 +523,18 @@ namespace OSFramework.OSUI.Patterns.Tabs {
 
 		// Method to set if the Tabs AutoHeight
 		private _setContentAutoHeight(hasAutoHeight: boolean): void {
-			if (this._hasDragGestures === false) {
-				if (hasAutoHeight) {
-					Helper.Dom.Styles.AddClass(this.selfElement, Enum.CssClasses.HasContentAutoHeight);
+			if (this.isBuilt) {
+				if (this._hasDragGestures === false) {
+					if (hasAutoHeight) {
+						Helper.Dom.Styles.AddClass(this.selfElement, Enum.CssClasses.HasContentAutoHeight);
+					} else {
+						Helper.Dom.Styles.RemoveClass(this.selfElement, Enum.CssClasses.HasContentAutoHeight);
+					}
 				} else {
-					Helper.Dom.Styles.RemoveClass(this.selfElement, Enum.CssClasses.HasContentAutoHeight);
+					console.warn(
+						`Tabs (${this.widgetId}): changes to ${Enum.Properties.ContentAutoHeight} parameter do not affect tabs when Gestures are in use.`
+					);
 				}
-			} else {
-				console.warn(
-					`Tabs (${this.widgetId}): changes to ${Enum.Properties.ContentAutoHeight} parameter do not affect tabs when Gestures are in use.`
-				);
 			}
 		}
 
@@ -575,19 +577,21 @@ namespace OSFramework.OSUI.Patterns.Tabs {
 
 		// Method to set the Tabs Height
 		private _setHeight(height: string): void {
-			// Set tabs overflow based on height
-			const tabsOverflow =
-				height === GlobalEnum.CssProperties.Auto || height === Constants.EmptyString
-					? GlobalEnum.CssProperties.Initial
-					: GlobalEnum.CssProperties.Auto;
+			if (this.isBuilt) {
+				// Set tabs overflow based on height
+				const tabsOverflow =
+					height === GlobalEnum.CssProperties.Auto || height === Constants.EmptyString
+						? GlobalEnum.CssProperties.Initial
+						: GlobalEnum.CssProperties.Auto;
 
-			// Create css variables
-			Helper.Dom.Styles.SetStyleAttribute(this.selfElement, Enum.CssProperty.TabsHeight, height);
-			Helper.Dom.Styles.SetStyleAttribute(
-				this.selfElement,
-				Enum.CssProperty.TabsContentItemOverflow,
-				tabsOverflow
-			);
+				// Create css variables
+				Helper.Dom.Styles.SetStyleAttribute(this.selfElement, Enum.CssProperty.TabsHeight, height);
+				Helper.Dom.Styles.SetStyleAttribute(
+					this.selfElement,
+					Enum.CssProperty.TabsContentItemOverflow,
+					tabsOverflow
+				);
+			}
 		}
 
 		// Method to set the initial options on screen load
@@ -610,13 +614,12 @@ namespace OSFramework.OSUI.Patterns.Tabs {
 
 		// Method to set if the Tabs are justified
 		private _setIsJustified(isJustified: boolean): void {
-			if (isJustified) {
-				Helper.Dom.Styles.AddClass(this.selfElement, Enum.CssClasses.IsJustified);
-			} else {
-				Helper.Dom.Styles.RemoveClass(this.selfElement, Enum.CssClasses.IsJustified);
-			}
-
 			if (this.isBuilt) {
+				if (isJustified) {
+					Helper.Dom.Styles.AddClass(this.selfElement, Enum.CssClasses.IsJustified);
+				} else {
+					Helper.Dom.Styles.RemoveClass(this.selfElement, Enum.CssClasses.IsJustified);
+				}
 				// Update scale size variable
 				this._handleTabIndicator();
 			}
@@ -638,10 +641,15 @@ namespace OSFramework.OSUI.Patterns.Tabs {
 
 		// Method to set the Tabs Position
 		private _setPosition(position: GlobalEnum.Direction): void {
-			Helper.Dom.Styles.RemoveClass(this.selfElement, Enum.CssClasses.Modifier + this._currentVerticalPositon);
-			Helper.Dom.Styles.AddClass(this.selfElement, Enum.CssClasses.Modifier + position);
+			if (this.isBuilt) {
+				Helper.Dom.Styles.RemoveClass(
+					this.selfElement,
+					Enum.CssClasses.Modifier + this._currentVerticalPositon
+				);
+				Helper.Dom.Styles.AddClass(this.selfElement, Enum.CssClasses.Modifier + position);
 
-			this._currentVerticalPositon = position;
+				this._currentVerticalPositon = position;
+			}
 		}
 
 		// Toggles the TableHeaderItem disabled status
@@ -770,10 +778,12 @@ namespace OSFramework.OSUI.Patterns.Tabs {
 		 * @memberof OSFramework.Patterns.Tabs.Tabs
 		 */
 		protected setA11YProperties(): void {
-			// Set aria-role to TabsHeader
-			Helper.A11Y.RoleTabList(this._tabsHeaderElement.firstElementChild as HTMLElement);
-			// Set aria-hidden to tabs indicator
-			Helper.A11Y.AriaHiddenTrue(this._tabsIndicatorElement);
+			if (this.isBuilt) {
+				// Set aria-role to TabsHeader
+				Helper.A11Y.RoleTabList(this._tabsHeaderElement.firstElementChild as HTMLElement);
+				// Set aria-hidden to tabs indicator
+				Helper.A11Y.AriaHiddenTrue(this._tabsIndicatorElement);
+			}
 		}
 
 		/**
@@ -783,9 +793,11 @@ namespace OSFramework.OSUI.Patterns.Tabs {
 		 * @memberof OSFramework.Patterns.Tabs.Tabs
 		 */
 		protected setCallbacks(): void {
-			this._eventOnHeaderKeypress = this._handleKeypressEvent.bind(this);
-			this._eventOnResize = this._handleOnResizeEvent.bind(this);
-			this._addEvents();
+			if (this.isBuilt) {
+				this._eventOnHeaderKeypress = this._handleKeypressEvent.bind(this);
+				this._eventOnResize = this._handleOnResizeEvent.bind(this);
+				this._addEvents();
+			}
 		}
 
 		/**


### PR DESCRIPTION
This PR is for protecting the code that is ran asynchronously in the `build`. 
The root cause is a concurrency race with the `render`, that was optimized in ODC and as such became faster, which caused the async code to run in a moment that the pattern is no longer built, in given conditions. Related with RPM-5839.

### What was happening
- In **ODC**, there is a scenario where patterns are conditionally rendered based on the value of the `isDataFetched` property, which is part of an Aggregate or DataAction. Specifically, when a user navigates to another page and then returns using the browser's back button, the page state is restored, including the value of `isDataFetched` = true.
- Here’s the issue:
   - When the user returns to the page, the final value of isDataFetched is preserved, causing the associated patterns to be initially built.
   - Once the page is restored, the isDataFetched value is set to false again, which results in the patterns being destroyed.
   - Afterward, as data is fetched, the isDataFetched value becomes true again, causing the patterns to be built again.
- As the some part of the `build` is done asynchronously, it was being triggered when the pattern had already been destroyed causing errors in the console, and potential misbehavior. 
- Affected patterns:
   - AnimatedLabel
   - Notification
   - ProgressBar
   - Tabs 

### What was done
- Protected the code that is invoked asynchronously, so that it validates if it should run.

### Test Steps
1. Enter the sample page
2. Validate that the patterns are properly displayed
3. Navigate to another page
4. In the other page, click on the "back button" of the browser
5. Validate that the patterns are being displayed correctly and there are no errors in the console.

### Checklist
-   [x] tested locally
-   [x] documented the code
-   [x] clean all warnings and errors of eslint
-   [ ] requires changes in OutSystems (if so, provide a module with changes)
-   [ ] requires new sample page in OutSystems (if so, provide a module with changes)
