### PR TITLE
ROU-11919: Increment version and add styles for dropdowns

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# OutSystems UI · v2.23.1
+# OutSystems UI · v2.24.0
 
 ![GitHub License](https://img.shields.io/badge/License-BSD%203--Clause-blue.svg) ![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg)
 

--- a/gulp/ProjectSpecs/DefaultSpecs.js
+++ b/gulp/ProjectSpecs/DefaultSpecs.js
@@ -21,7 +21,7 @@ const constants = {
 
 // Store the default project specifications
 const specs = {
-    "version": "2.23.1",
+    "version": "2.24.0",
     "name": "OutSystems UI",
     "description": "",
     "url": "Website:\n • https://www.outsystems.com/outsystems-ui",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "outsystems-ui",
-	"version": "2.23.1",
+	"version": "2.24.0",
 	"description": "OutSystems UI Framework",
 	"license": "BSD-3-Clause",
 	"scripts": {

--- a/src/scripts/OSFramework/OSUI/Constants.ts
+++ b/src/scripts/OSFramework/OSUI/Constants.ts
@@ -166,7 +166,7 @@ namespace OSFramework.OSUI.Constants {
 	export const OSPlatform = '<->platformType<->';
 
 	/* OSUI Version */
-	export const OSUIVersion = '2.23.1';
+	export const OSUIVersion = '2.24.0';
 
 	/* Constant to be used across project as the zero value*/
 	export const ZeroValue = 0;

--- a/src/scripts/OSFramework/OSUI/Pattern/AnimatedLabel/AnimatedLabel.ts
+++ b/src/scripts/OSFramework/OSUI/Pattern/AnimatedLabel/AnimatedLabel.ts
@@ -13,17 +13,13 @@ namespace OSFramework.OSUI.Patterns.AnimatedLabel {
 		private _eventBlur: GlobalCallbacks.Generic;
 		private _eventFocus: GlobalCallbacks.Generic;
 		private _eventKeyDown: GlobalCallbacks.Generic;
-		private _isDisposed = false;
-
 		// Set the input html element
 		private _inputElement: HTMLInputElement | HTMLTextAreaElement;
-
 		// Set the inputPlaceholder html element
 		private _inputPhElement: HTMLElement;
-
+		private _isDisposed = false;
 		// Flag that will be manage if the label is active
 		private _isLabelFocus: boolean;
-
 		// Set the labelPlaceholder html element
 		private _labelPhElement: HTMLElement;
 

--- a/src/scripts/Providers/OSUI/Dropdown/VirtualSelect/scss/_virtualselect.scss
+++ b/src/scripts/Providers/OSUI/Dropdown/VirtualSelect/scss/_virtualselect.scss
@@ -520,6 +520,15 @@
 	margin-top: 1px;
 }
 
+// When using the extensibility property allowNewOption
+.vscomp-new-option-icon {
+	&::before {
+		border: 15px solid var(--color-primary);
+		border-bottom-color: rgba(0, 0, 0, 0);
+		border-left-color: rgba(0, 0, 0, 0);
+	}
+}
+
 // Accessibility -----------------------------------------------------------------
 ///
 .has-accessible-features {
@@ -597,14 +606,6 @@
 		&::-webkit-scrollbar-thumb {
 			border: var(--border-size-s) solid var(--color-neutral-4);
 		}
-	}
-}
-
-.vscomp-new-option-icon {
-	&::before {
-		border: 15px solid var(--color-primary);
-		border-bottom-color: rgba(0, 0, 0, 0);
-		border-left-color: rgba(0, 0, 0, 0);
 	}
 }
 

--- a/src/scripts/Providers/OSUI/Dropdown/VirtualSelect/scss/_virtualselect.scss
+++ b/src/scripts/Providers/OSUI/Dropdown/VirtualSelect/scss/_virtualselect.scss
@@ -372,7 +372,7 @@
 	display: none;
 }
 
-// Bottom part - Parent wrapper opptions container
+// Bottom part - Parent wrapper Options container
 .pop-comp-wrapper {
 	box-shadow: none;
 }
@@ -396,7 +396,7 @@
 	}
 }
 
-// Opptions container input search wrapper
+// Options container input search wrapper
 .vscomp-search-container {
 	border-bottom: var(--border-size-s) solid var(--color-neutral-5);
 	padding: var(--space-none) var(--space-s) var(--space-none) var(--space-xl);
@@ -442,7 +442,7 @@
 	}
 }
 
-// Opptions container input search
+// Options container input search
 .vscomp-search-input {
 	font-size: var(--font-size-s);
 
@@ -532,17 +532,17 @@
 		}
 	}
 
-  .vscomp-toggle-all-button:focus {
-    box-shadow: none;
+	.vscomp-toggle-all-button:focus {
+		box-shadow: none;
 
-    .checkbox-icon {
-      @include a11y-default-outline;
-    }
-  }
+		.checkbox-icon {
+			@include a11y-default-outline;
+		}
+	}
 
-  .vscomp-option.focused {
-    @include a11y-default-outline(true);
-  }
+	.vscomp-option.focused {
+		@include a11y-default-outline(true);
+	}
 }
 
 // OS HighContrast Enabled -------------------------------------------------------
@@ -597,6 +597,14 @@
 		&::-webkit-scrollbar-thumb {
 			border: var(--border-size-s) solid var(--color-neutral-4);
 		}
+	}
+}
+
+.vscomp-new-option-icon {
+	&::before {
+		border: 15px solid var(--color-primary);
+		border-bottom-color: rgba(0, 0, 0, 0);
+		border-left-color: rgba(0, 0, 0, 0);
 	}
 }
 

--- a/src/scss/O11.OutSystemsUI.scss
+++ b/src/scss/O11.OutSystemsUI.scss
@@ -17,7 +17,7 @@ PS: This comment block will not be visible in the compiled version!
 =============================================================================== */
 
 /*!
-OutSystems UI 2.23.0 • O11 Platform
+OutSystems UI 2.24.0 • O11 Platform
 Website:
  • https://www.outsystems.com/outsystems-ui
 GitHub:

--- a/src/scss/ODC.OutSystemsUI.scss
+++ b/src/scss/ODC.OutSystemsUI.scss
@@ -17,7 +17,7 @@ PS: This comment block will not be visible in the compiled version!
 =============================================================================== */
 
 /*!
-OutSystems UI 2.23.0 • ODC Platform
+OutSystems UI 2.24.0 • ODC Platform
 Website:
  • https://www.outsystems.com/outsystems-ui
 GitHub:


### PR DESCRIPTION
### What was done
- Incremented version to `2.24.0`
- Added styles for Dropdown Search and Tags for the case where we use the extensibility property `allowNewOption`
- Fixed two lint warnings in the AnimatedLabels

### Test Steps

1. Go to the DropdownSearch test page
2. Go to the “Extensibility Features” section
3. Select the `allowNewOption = true`
4. Click on Apply
5. Type “Joe“
6. Check that the + icon now has the primary color
7. Repeat it in the DropdownTags test page

### Screenshots
![image](https://github.com/user-attachments/assets/7b5791d8-17b0-405d-98d1-70f1c6872028)


### Checklist

-   [X] tested locally
-   [X] documented the code
-   [X] clean all warnings and errors of eslint
-   [ ] requires changes in OutSystems
-   [ ] requires new sample page in OutSystems