### PR TITLE
ROU-12050: Menu nav element tabIndex issue once at desktop

### DIFF
--- a/src/scripts/OutSystems/OSUI/Utils/Menu.ts
+++ b/src/scripts/OutSystems/OSUI/Utils/Menu.ts
@@ -216,19 +216,24 @@ namespace OutSystems.OSUI.Utils.Menu {
 
 		// Set the tabindex and aria-expanded attributes based on the enableA11Y flag
 		if (enableA11Y) {
-			OSFramework.OSUI.Helper.A11Y.TabIndexTrue(menu);
-			OSFramework.OSUI.Helper.A11Y.AriaExpandedTrue(menu);
-
 			for (const item of focusableEls) {
 				OSFramework.OSUI.Helper.A11Y.TabIndexTrue(item as HTMLElement);
 			}
 		} else {
-			OSFramework.OSUI.Helper.A11Y.TabIndexFalse(menu);
-			OSFramework.OSUI.Helper.A11Y.AriaExpandedFalse(menu);
-
 			for (const item of focusableEls) {
 				OSFramework.OSUI.Helper.A11Y.TabIndexFalse(item as HTMLElement);
 			}
+		}
+
+		if (_appProp.menu.isOpen) {
+			OSFramework.OSUI.Helper.A11Y.TabIndexTrue(menu);
+			OSFramework.OSUI.Helper.A11Y.AriaExpandedTrue(menu);
+		} else if (OSFramework.OSUI.Helper.DeviceInfo.IsDesktop) {
+			OSFramework.OSUI.Helper.Dom.Attribute.Remove(menu, OSFramework.OSUI.Constants.A11YAttributes.TabIndex);
+			OSFramework.OSUI.Helper.Dom.Attribute.Remove(menu, OSFramework.OSUI.Constants.A11YAttributes.Aria.Expanded);
+		} else {
+			OSFramework.OSUI.Helper.A11Y.TabIndexFalse(menu);
+			OSFramework.OSUI.Helper.A11Y.AriaExpandedFalse(menu);
 		}
 	};
 


### PR DESCRIPTION
This PR will prevent [nav] element to have tabindex atribute once at desktop.

### What was happening

- Users do not directly interact with the [nav] element, its inclusion in the tab order is being flagged by accessibility evaluation tools.

### What was done

- Ensure [nav] element do not contains the tabindex atribute once at desktop screen sizes.
- Kept the mobile and the overflow menu use cases in order to focus remain at the [nav] element once it gets opened.

