### PR TITLE
ROU-12066: FocusTrap - Initialize focus trap callbacks in constructor

### DIFF
--- a/src/scripts/OSFramework/OSUI/Behaviors/FocusTrap.ts
+++ b/src/scripts/OSFramework/OSUI/Behaviors/FocusTrap.ts
@@ -37,6 +37,9 @@ namespace OSFramework.OSUI.Behaviors {
 		constructor(opts: FocusTrapParams) {
 			this._focusableElements = [];
 
+			// Set the callbacks to be used
+			this._setCallbacks();
+
 			// Store the focus target element
 			this._targetElement = opts.focusTargetElement;
 
@@ -111,6 +114,7 @@ namespace OSFramework.OSUI.Behaviors {
 			this._predictableTopElement.removeEventListener(GlobalEnum.HTMLEvent.Focus, this._focusTopHandlerCallback);
 		}
 
+		// Method to set the callbacks to be used
 		private _setCallbacks(): void {
 			this._focusBottomHandlerCallback = this._focusBottomHandler.bind(this);
 			this._focusTopHandlerCallback = this._focusTopHandler.bind(this);


### PR DESCRIPTION
This PR will fix a regression issue at the focus trap.

### What was happening

- After changes made in an issue was added that is preventing FocusTrap to occurs.

### What was done

- Added the call to _setCallbacks() into the constructor to ensure focus trap event handler callbacks are set up before use.

### Checklist

-   [ ] tested locally
-   [ ] documented the code
-   [ ] clean all warnings and errors of eslint
-   [ ] requires changes in OutSystems (if so, provide a module with changes)
-   [ ] requires new sample page in OutSystems (if so, provide a module with changes)
