### PR TITLE
ROU-12062: Change the validation that adds gesture events to the BottomSheet

### DIFF
--- a/src/scripts/OSFramework/OSUI/Pattern/BottomSheet/BottomSheet.ts
+++ b/src/scripts/OSFramework/OSUI/Pattern/BottomSheet/BottomSheet.ts
@@ -82,7 +82,7 @@ namespace OSFramework.OSUI.Patterns.BottomSheet {
 
 		// Method to handle the creation of the GestureEvents
 		private _handleGestureEvents(): void {
-			if (!Helper.DeviceInfo.IsDesktop) {
+			if (Helper.DeviceInfo.IsNative) {
 				// Create and save gesture event instance. Created here and not on constructor,
 				// as we need to pass element, only available after super.build()
 				this._gestureEventInstance = new Event.GestureEvent.DragEvent(this._bottomSheetHeaderElem);

--- a/src/scripts/OSFramework/OSUI/Pattern/BottomSheet/BottomSheet.ts
+++ b/src/scripts/OSFramework/OSUI/Pattern/BottomSheet/BottomSheet.ts
@@ -82,7 +82,7 @@ namespace OSFramework.OSUI.Patterns.BottomSheet {
 
 		// Method to handle the creation of the GestureEvents
 		private _handleGestureEvents(): void {
-			if (Helper.DeviceInfo.IsNative) {
+			if (Helper.DeviceInfo.IsNative || Helper.DeviceInfo.IsTouch) {
 				// Create and save gesture event instance. Created here and not on constructor,
 				// as we need to pass element, only available after super.build()
 				this._gestureEventInstance = new Event.GestureEvent.DragEvent(this._bottomSheetHeaderElem);


### PR DESCRIPTION
### What was happening

- BottomSheet didn't have drag on some Tablets in landscape (iPad Pro, for instance) since its size is identified as Desktop by the platform.

### What was done

- Changed the validation that adds gesture events to the BottomSheet so that it will now check if it's a native app or has touch events (will use the two checks just for readability and for safety).

### Test Steps

The tests should be made on a browser emulator, on iOS/Android in the browser, as a PWA, and on iOS/Android using a native build: 
1. Open a screen with a BottomSheet
2. Open the BottomSheet and 

### Screenshots



### Checklist

-   [X] tested locally
-   [ ] documented the code
-   [ ] clean all warnings and errors of eslint
-   [ ] requires changes in OutSystems (if so, provide a module with changes)
-   [ ] requires new sample page in OutSystems (if so, provide a module with changes)
