### PR TITLE
ROU-12067: AccorionItem - Prevent content reflow when collapsed

### DIFF
--- a/src/scripts/OSFramework/OSUI/Pattern/AccordionItem/AccordionItem.ts
+++ b/src/scripts/OSFramework/OSUI/Pattern/AccordionItem/AccordionItem.ts
@@ -117,15 +117,7 @@ namespace OSFramework.OSUI.Patterns.AccordionItem {
 				this._eventOnTransitionEnd
 			);
 
-			if (isExpand) {
-				// End of animation, item is expanded
-				Helper.Dom.Styles.AddClass(this._accordionItemContentElem, Enum.CssClass.PatternExpanded);
-				this._isOpen = true;
-			} else {
-				// End of animation, item is collapsed
-				Helper.Dom.Styles.AddClass(this._accordionItemContentElem, Enum.CssClass.PatternCollapsed);
-				this._isOpen = false;
-			}
+			this._isOpen = isExpand;
 
 			this.setA11YProperties();
 			this._onToggleCallback();
@@ -315,6 +307,14 @@ namespace OSFramework.OSUI.Patterns.AccordionItem {
 					this._transitionEndHandler,
 					false
 				);
+
+				if (this._isOpen) {
+					// End of animation, item is expanded
+					Helper.Dom.Styles.AddClass(this._accordionItemContentElem, Enum.CssClass.PatternExpanded);
+				} else {
+					// End of animation, item is collapsed
+					Helper.Dom.Styles.AddClass(this._accordionItemContentElem, Enum.CssClass.PatternCollapsed);
+				}
 			}
 		}
 

--- a/src/scripts/OSFramework/OSUI/Pattern/AccordionItem/scss/_accordion-item.scss
+++ b/src/scripts/OSFramework/OSUI/Pattern/AccordionItem/scss/_accordion-item.scss
@@ -179,6 +179,11 @@
 			&-collapsed {
 				height: 0;
 				visibility: hidden;
+
+				// This is to avoid reflowing the content when collapsed
+				& > div {
+					display: none;
+				}
 			}
 
 			&-expanded {


### PR DESCRIPTION
This PR will fix a performance issue due a reflow at the AccordionItem content when it's closed.

### What was happening

- Once there are a multiple AccordionItems at the screen containing a Textarea or/and an Input if/when input gets typed really quick there are performance issues due the reflow.

### What was done

- Changing the moment where `osui-accordion-item__content--is-expanded` and `osui-accordion-item__content--is-collapsed` selectors are being set. They are now being set when open/close animation ends.
- A `display:none` has been added to the content when AccordionItem is collapsed to prevent the reflow of the content.

