### PR TITLE
ROU-12062: Add missing validation on BottomSheet

### DIFF
--- a/src/scripts/OSFramework/OSUI/Pattern/BottomSheet/BottomSheet.ts
+++ b/src/scripts/OSFramework/OSUI/Pattern/BottomSheet/BottomSheet.ts
@@ -280,7 +280,7 @@ namespace OSFramework.OSUI.Patterns.BottomSheet {
 			this._bottomSheetContentElem.addEventListener(GlobalEnum.HTMLEvent.Scroll, this._eventOnContentScroll);
 			this.selfElement.addEventListener(GlobalEnum.HTMLEvent.keyDown, this._eventOnKeypress);
 
-			if (!Helper.DeviceInfo.IsDesktop && this.gestureEventInstance !== undefined) {
+			if ((Helper.DeviceInfo.IsNative || Helper.DeviceInfo.IsTouch) && this.gestureEventInstance !== undefined) {
 				// Set event listeners and callbacks
 				this.setGestureEvents(
 					this._onGestureStart.bind(this),


### PR DESCRIPTION
### What was happening

- When entering on an iPad Pro in landscape and refreshing the screen, gestures were not working.

### What was done

- Added missing validation on BottomSheet

### Test Steps

1. Go to a screen with BottomSheet on an iPad Pro in landscape
2. Refresh the screen
3. Check that gestures are working now.


### Checklist

-   [X] tested locally
-   [ ] documented the code
-   [ ] clean all warnings and errors of eslint
-   [ ] requires changes in OutSystems (if so, provide a module with changes)
-   [ ] requires new sample page in OutSystems (if so, provide a module with changes)
