### PR TITLE
ROU-12091: Sidebar/BottomSheet - Incorrect keyboard navigation on several widgets

### DIFF
--- a/src/scripts/OSFramework/OSUI/Behaviors/FocusTrap.ts
+++ b/src/scripts/OSFramework/OSUI/Behaviors/FocusTrap.ts
@@ -21,7 +21,7 @@ namespace OSFramework.OSUI.Behaviors {
 		private _focusBottomHandlerCallback: GlobalCallbacks.Generic;
 		private _focusTopCallback: GlobalCallbacks.Generic;
 		private _focusTopHandlerCallback: GlobalCallbacks.Generic;
-		private _focusableElements: HTMLElement[];
+		private readonly _focusableElements: HTMLElement[];
 		private _hasBeenPassThoughFirstOne = false;
 		private _lastFocusableElement: HTMLElement;
 		private _predictableBottomElement: HTMLElement;

--- a/src/scripts/OSFramework/OSUI/Behaviors/FocusTrap.ts
+++ b/src/scripts/OSFramework/OSUI/Behaviors/FocusTrap.ts
@@ -131,31 +131,6 @@ namespace OSFramework.OSUI.Behaviors {
 
 		// Method to set the focusable elements to be used
 		private _setFocusableElements(includeTabIndexHidden = false): void {
-			/**
-			 * NOTE: (MORE INFO @ROU-10963)
-			 *	We can find 2 sections below that must be explained:
-			 *		- TO BE REMOVED
-			 *			- After the missing part of the code is implemented (mentioned at the bullet point below), code inside this section should be removed!
-			 *		- TO KEEP
-			 *			- With this implementation we ensure that the focusable elements are not part of the inner patterns
-			 *			- However we still need to ensure focusable elements inside child patterns should be managed through their own FocusTrap
-			 *			- For now code is not prepared to it, but it should be considered in the future, that's why we keep this implementation commented
-			 */
-
-			/* TO BE REMOVED • START •••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••  */
-			// eslint-disable-next-line @typescript-eslint/no-unused-vars
-			includeTabIndexHidden = false;
-			this._focusableElements = Helper.Dom.GetFocusableElements(this._targetElement, false);
-			// Check if predicted elements exist at the _focusableElements
-			for (const predictedElement of this._focusableElements.filter(
-				(item) => item === this._predictableTopElement || item === this._predictableBottomElement
-			)) {
-				// If so, remove them from the array collection of _focusableElements
-				this._focusableElements.splice(this._focusableElements.indexOf(predictedElement), 1);
-			}
-			/* TO BE REMOVED • END •••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••  */
-
-			/* TO KEEP •••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••
 			// Ensure the list of focusable elements is empty
 			this._focusableElements.length = 0;
 
@@ -184,7 +159,6 @@ namespace OSFramework.OSUI.Behaviors {
 					}
 				}
 			}
-			••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••• */
 
 			// Remove the first element from array, because of predictable top element added for trapping
 			this._firstFocusableElement = this._focusableElements[0];

--- a/src/scripts/OSFramework/OSUI/GlobalEnum.ts
+++ b/src/scripts/OSFramework/OSUI/GlobalEnum.ts
@@ -183,6 +183,7 @@ namespace OSFramework.OSUI.GlobalEnum {
 		For = 'for',
 		Href = 'href',
 		Id = 'id',
+		Inert = 'inert',
 		Name = 'name',
 		StatusBar = 'data-status-bar-height',
 		Style = 'style',

--- a/src/scripts/OSFramework/OSUI/Helper/ManageAccessibility.ts
+++ b/src/scripts/OSFramework/OSUI/Helper/ManageAccessibility.ts
@@ -197,6 +197,12 @@ namespace OSFramework.OSUI.Helper {
 		 */
 		public static AriaHiddenFalse(element: HTMLElement): void {
 			Dom.Attribute.Set(element, Constants.A11YAttributes.Aria.Hidden, Constants.A11YAttributes.States.False);
+			/**
+			 * In order to ensure elements inside of the given element are focusable, we must remove the inert attribute
+			 * This attribute should also be managed in the same contexts where aria-hidden is also being managed, that's why
+			 * it's also being removed here.
+			 */
+			Dom.Attribute.Remove(element, GlobalEnum.HTMLAttributes.Inert);
 		}
 
 		/**
@@ -208,6 +214,12 @@ namespace OSFramework.OSUI.Helper {
 		 */
 		public static AriaHiddenTrue(element: HTMLElement): void {
 			Dom.Attribute.Set(element, Constants.A11YAttributes.Aria.Hidden, Constants.A11YAttributes.States.True);
+			/**
+			 * In order to ensure any other element inside of the given element is not focusable, we set the inert attribute
+			 * This attribute should also be managed in the same contexts where aria-hidden is also being managed, that's why
+			 * it's also being set here.
+			 */
+			Dom.Attribute.Set(element, GlobalEnum.HTMLAttributes.Inert, Constants.EmptyString);
 		}
 
 		/**

--- a/src/scripts/OSFramework/OSUI/Pattern/BottomSheet/BottomSheet.ts
+++ b/src/scripts/OSFramework/OSUI/Pattern/BottomSheet/BottomSheet.ts
@@ -169,9 +169,13 @@ namespace OSFramework.OSUI.Patterns.BottomSheet {
 
 			// Toggle class
 			if (isOpen) {
+				this._focusManagerInstance.storeLastFocusedElement();
+
 				Helper.Dom.Styles.AddClass(this.selfElement, Enum.CssClass.IsOpen);
 				Helper.Dom.Styles.AddClass(document.body, Enum.CssClass.IsActive);
 			} else {
+				this._focusManagerInstance.setFocusToStoredElement();
+
 				Helper.Dom.Styles.RemoveClass(this.selfElement, Enum.CssClass.IsOpen);
 				Helper.Dom.Styles.RemoveClass(document.body, Enum.CssClass.IsActive);
 			}
@@ -185,18 +189,11 @@ namespace OSFramework.OSUI.Patterns.BottomSheet {
 
 			// Handle focus trap logic
 			if (isOpen) {
-				this._focusManagerInstance.storeLastFocusedElement();
 				this._focusTrapInstance.enableForA11y();
 				// Focus on element when pattern is open
 				this.selfElement.focus();
 			} else {
 				this._focusTrapInstance.disableForA11y();
-
-				// Focus on last element clicked. Async to avoid conflict with closing animation
-				Helper.AsyncInvocation(() => {
-					this.selfElement.blur();
-					this._focusManagerInstance.setFocusToStoredElement();
-				});
 			}
 
 			// Trigger platform event

--- a/src/scripts/OSFramework/OSUI/Pattern/BottomSheet/BottomSheet.ts
+++ b/src/scripts/OSFramework/OSUI/Pattern/BottomSheet/BottomSheet.ts
@@ -238,22 +238,13 @@ namespace OSFramework.OSUI.Patterns.BottomSheet {
 				Helper.A11Y.RoleComplementary(this.selfElement);
 			}
 
-			Helper.Dom.Attribute.Set(
-				this.selfElement,
-				Constants.A11YAttributes.Aria.Hidden,
-				(!this._isOpen).toString()
-			);
-
-			Helper.Dom.Attribute.Set(
-				this.selfElement,
-				Constants.A11YAttributes.TabIndex,
-				this._isOpen
-					? Constants.A11YAttributes.States.TabIndexShow
-					: Constants.A11YAttributes.States.TabIndexHidden
-			);
-
-			// Will handle the tabindex value of the elements inside pattern
-			Helper.A11Y.SetElementsTabIndex(this._isOpen, this._focusTrapInstance.focusableElements);
+			if (this._isOpen) {
+				Helper.A11Y.TabIndexTrue(this.selfElement);
+				Helper.A11Y.AriaHiddenFalse(this.selfElement);
+			} else {
+				Helper.A11Y.TabIndexFalse(this.selfElement);
+				Helper.A11Y.AriaHiddenTrue(this.selfElement);
+			}
 		}
 
 		/**

--- a/src/scripts/OSFramework/OSUI/Pattern/OverflowMenu/scss/_overflowmenu.scss
+++ b/src/scripts/OSFramework/OSUI/Pattern/OverflowMenu/scss/_overflowmenu.scss
@@ -30,6 +30,7 @@
 	&__balloon {
 		min-width: var(--osui-overflow-menu-min-width);
 		overflow: hidden;
+		z-index: var(--layer-global-instant-interaction);
 
 		a {
 			color: var(--color-neutral-9);


### PR DESCRIPTION
This PR will fix A11Y keyboard navigation issue under the context of SideBar and BottomSheet.

### What was happening

- When keyboard navigation (A11Y) was in use inside SideBar/BottomSheet, containing any other type of OSUI components that has to manage their own focusable elements, the navigation process was broken.
- This was happening because we were updating `tabindex="-1"` into `tabindex="0"` no matter where the element with this attribute is/belongs.

### What was done

- Added the logic to just affect the update of the `tabindex="-1"` elements on the first layer of SideBar/BottomSheet children.
- From now on, components inside of this both elements will maintain their default keyboard navigation.
- This will also fix a layer issue on the OverflowMenu balloon since it was being behind the DropdownTags when combined in the same context.
- Focus is being now properly managed which remove the console errors/warnings reported from the Chrome. 

