### PR TITLE
ROU-11920: Update Virtual Select to v1.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,6 +67,6 @@
 		"typedoc-plugin-merge-modules": "^4.1.0",
 		"typedoc-umlclass": "^0.7.1",
 		"typescript": "^4.9.5",
-		"virtual-select-plugin": "^1.0.49"
+		"virtual-select-plugin": "^1.1.0"
 	}
 }

--- a/src/scripts/Providers/OSUI/Dropdown/VirtualSelect/AbstractVirtualSelectEnum.ts
+++ b/src/scripts/Providers/OSUI/Dropdown/VirtualSelect/AbstractVirtualSelectEnum.ts
@@ -5,7 +5,7 @@ namespace Providers.OSUI.Dropdown.VirtualSelect.Enum {
 	 */
 	export enum ProviderInfo {
 		Name = 'VirtualSelect',
-		Version = '1.0.49',
+		Version = '1.1.0',
 	}
 
 	/**

--- a/src/scripts/Providers/OSUI/Dropdown/VirtualSelect/README.md
+++ b/src/scripts/Providers/OSUI/Dropdown/VirtualSelect/README.md
@@ -1,3 +1,3 @@
-# VirtualSelect · ![virtualselect version](https://img.shields.io/badge/version-v1.0.49-informational)
+# VirtualSelect · ![virtualselect version](https://img.shields.io/badge/version-v1.1.0-informational)
 
 All info about this Provider <a href="https://sa-si-dev.github.io/virtual-select/#/">here</a>.

--- a/src/scripts/Providers/OSUI/Dropdown/VirtualSelect/scss/_virtualselect_lib.scss
+++ b/src/scripts/Providers/OSUI/Dropdown/VirtualSelect/scss/_virtualselect_lib.scss
@@ -1,5 +1,5 @@
 /*!
- * Virtual Select v1.0.49
+ * Virtual Select v1.1.0
  * https://sa-si-dev.github.io/virtual-select
  * Licensed under MIT (https://github.com/sa-si-dev/virtual-select/blob/master/LICENSE)
  */
@@ -609,10 +609,10 @@
 	left: 2px;
 }
 /*!
-  * Popover v1.0.13
-  * https://sa-si-dev.github.io/popover
-  * Licensed under MIT (https://github.com/sa-si-dev/popover/blob/master/LICENSE)
-  */
+ * Popover v1.0.13
+ * https://sa-si-dev.github.io/popover
+ * Licensed under MIT (https://github.com/sa-si-dev/popover/blob/master/LICENSE)
+ */
 .pop-comp-wrapper {
 	display: none;
 	position: absolute;


### PR DESCRIPTION
This PR is to update the VirtualSelect library to the latest version **v1.1.0**

### What was done

- Updated Virtual Select provider to **v1.1.0**

### Checklist

-   [X] tested locally
-   [X] documented the code
-   [X] clean all warnings and errors of eslint
-   [X] requires changes in OutSystems (if so, provide a module with changes)
-   [ ] requires new sample page in OutSystems (if so, provide a module with changes)
