### PR TITLE
ROU-12139: Fixing Submenu issue, for when it starts empty

### DIFF
--- a/src/scripts/OSFramework/OSUI/Pattern/Submenu/Submenu.ts
+++ b/src/scripts/OSFramework/OSUI/Pattern/Submenu/Submenu.ts
@@ -31,11 +31,11 @@ namespace OSFramework.OSUI.Patterns.Submenu {
 		}
 
 		// Add the event listeners to the submenu
-		private _addEventListeners(): void {
+		private _addEventListeners(addKeyboardEvent = true): void {
 			// Add events only if has elements inside
 			if (this._hasElements) {
 				// Add this event only if we haven't added
-				if (this._hasOnHoverListeners === false) {
+				if (addKeyboardEvent) {
 					this._submenuHeaderElement.addEventListener(GlobalEnum.HTMLEvent.keyDown, this._eventKeypress);
 				}
 
@@ -95,7 +95,7 @@ namespace OSFramework.OSUI.Patterns.Submenu {
 		}
 
 		// Checks if there are valid child elements
-		private _hasValidChilds(): boolean {
+		private _hasValidChildren(): boolean {
 			if (this.isBuilt) {
 				return this._submenuLinksElement.querySelector(':not(span:empty)') !== null;
 			}
@@ -310,7 +310,7 @@ namespace OSFramework.OSUI.Patterns.Submenu {
 			this._submenuAllLinksElement = [...this._submenuLinksElement.querySelectorAll(GlobalEnum.HTMLElement.Link)];
 
 			// Check if submenu has childs
-			if (this._hasValidChilds()) {
+			if (this._hasValidChildren()) {
 				this._hasElements = true;
 			}
 
@@ -411,7 +411,7 @@ namespace OSFramework.OSUI.Patterns.Submenu {
 					Event.DOMEvents.Listeners.Type.BodyOnClick,
 					this._globalEventBody
 				);
-			} else {
+			} else if (this.hasClickOutsideToClose === false) {
 				Event.DOMEvents.Listeners.GlobalListenerManager.Instance.removeHandler(
 					Event.DOMEvents.Listeners.Type.BodyOnClick,
 					this._globalEventBody
@@ -531,7 +531,7 @@ namespace OSFramework.OSUI.Patterns.Submenu {
 
 					Helper.Dom.Styles.AddClass(this.selfElement, Enum.CssClass.PatternIsHover);
 
-					this._addEventListeners();
+					this._addEventListeners(false);
 				}
 			}
 		}
@@ -543,7 +543,7 @@ namespace OSFramework.OSUI.Patterns.Submenu {
 		 */
 		public updateOnRender(): void {
 			if (this.isBuilt) {
-				if (this._hasValidChilds()) {
+				if (this._hasValidChildren()) {
 					if (this._hasElements === false) {
 						this._hasElements = true;
 						this.setInitialStates();


### PR DESCRIPTION
When all the links in the Submenu were added asynchronously, such as being dependent on a condition that comes from an aggregate/Data Action, this cause the Submenu to stay permanently in a state of no links, as such not _openable_. 
This PR is for make Submenu check on the changes of the inner links, in order to change its state accordingly.

### What was happening
- After being built, Submenu was not validating changes on the child links
- This cause 2 issues: 
   - when started empty, would not open
   - when starting with links, and links being removed afterwards, it would still be possible to open it

### What was done
- New method to validate the existence of children - **that are not empty span***
- New method that isolates the attachment of listeners.
- Changed method _updateOnRender()_ to validate potential changes on the children, and act accordingly.

* Empty span, is the element created by the platform to represent an **_IF_**.

### Test Steps
1. Go to sample page
2. (Try to) Click on `Does not work` menu (**expected**: nothing opens)
3. Click on `Works` menu (**expected**: opens with one link `Sample link`
4. Click on `Action 1` menu (**expected**: both menus `Does not work` and `Works`, can be open and will have new links inside: `Action 1 - fetched` and Value 1:[random number])
5. Click on `Undo Action 1` menu (**expected**: the menu `Does not work`, will not open when clicked)

### Screenshots
![submenu-open-issue](https://github.com/user-attachments/assets/4c3a4e23-7797-4546-bfb2-b86435cf5c3e)

### Checklist
-   [x] tested locally
-   [x] documented the code
-   [x] clean all warnings and errors of eslint
-   [ ] requires changes in OutSystems (if so, provide a module with changes)
-   [ ] requires new sample page in OutSystems (if so, provide a module with changes)
