### PR TITLE
ROU-12148: Menu - Fixing focus trap

### DIFF
--- a/src/scripts/OSFramework/OSUI/GlobalEnum.ts
+++ b/src/scripts/OSFramework/OSUI/GlobalEnum.ts
@@ -34,6 +34,7 @@ namespace OSFramework.OSUI.GlobalEnum {
 		List = 'list',
 		LoginPassword = 'login-password',
 		MainContent = 'main-content',
+		MenuContent = 'app-menu-content',
 		MenuLinks = 'app-menu-links',
 		Placeholder = 'ph',
 		Popup = 'popup-dialog',

--- a/src/scripts/OSFramework/OSUI/Helper/ManageAccessibility.ts
+++ b/src/scripts/OSFramework/OSUI/Helper/ManageAccessibility.ts
@@ -214,12 +214,19 @@ namespace OSFramework.OSUI.Helper {
 		 */
 		public static AriaHiddenTrue(element: HTMLElement): void {
 			Dom.Attribute.Set(element, Constants.A11YAttributes.Aria.Hidden, Constants.A11YAttributes.States.True);
-			/**
-			 * In order to ensure any other element inside of the given element is not focusable, we set the inert attribute
-			 * This attribute should also be managed in the same contexts where aria-hidden is also being managed, that's why
-			 * it's also being set here.
-			 */
-			Dom.Attribute.Set(element, GlobalEnum.HTMLAttributes.Inert, Constants.EmptyString);
+
+			// Inert attr can't be added to elements that will have focus event...
+			if (
+				element.classList.contains(GlobalEnum.FocusTrapClasses.FocusTrapTop) === false &&
+				element.classList.contains(GlobalEnum.FocusTrapClasses.FocusTrapBottom) === false
+			) {
+				/**
+				 * In order to ensure any other element inside of the given element is not focusable, we set the inert attribute
+				 * This attribute should also be managed in the same contexts where aria-hidden is also being managed, that's why
+				 * it's also being set here.
+				 */
+				Dom.Attribute.Set(element, GlobalEnum.HTMLAttributes.Inert, Constants.EmptyString);
+			}
 		}
 
 		/**

--- a/src/scripts/OSFramework/OSUI/Pattern/Submenu/Submenu.ts
+++ b/src/scripts/OSFramework/OSUI/Pattern/Submenu/Submenu.ts
@@ -152,7 +152,13 @@ namespace OSFramework.OSUI.Patterns.Submenu {
 				}
 			}
 
-			e.stopPropagation();
+			// Check if it's inside menu and not open to stop the propagation event
+			if (
+				this.selfElement.closest(Constants.Dot + GlobalEnum.CssClassElements.MenuContent) === null ||
+				(this.selfElement.closest(Constants.Dot + GlobalEnum.CssClassElements.MenuContent) && this._isOpen)
+			) {
+				e.stopPropagation();
+			}
 		}
 
 		// Trigger the submenu after an hover behaviour

--- a/src/scripts/OutSystems/OSUI/Utils/Menu.ts
+++ b/src/scripts/OutSystems/OSUI/Utils/Menu.ts
@@ -84,24 +84,40 @@ namespace OutSystems.OSUI.Utils.Menu {
 
 	// Menu on keypress handler
 	const _menuOnKeypress = function (e: KeyboardEvent) {
-		const isTabPressed = e.key === 'Tab';
+		// If ESC, Close Menu
 		const isEscapedPressed = e.key === 'Escape';
-		const isShiftKey = e.shiftKey;
-		const focusableEls = OSFramework.OSUI.Helper.Dom.TagSelectorAll(_appProp.menu.element, _menuFocusableElems);
-
-		const firstFocusableEl = focusableEls[0] as HTMLElement;
-		const lastFocusableEl = focusableEls[focusableEls.length - 1] as HTMLElement;
-
-		if (!isTabPressed && !isEscapedPressed) {
-			return;
-		}
-
-		//If ESC, Close Menu
 		if (isEscapedPressed && _appProp.menu.isOpen) {
 			e.preventDefault();
 			e.stopPropagation();
 			_toggleMenu();
+			return;
 		}
+		// If any other than TAB or ESC is pressed
+		const isTabPressed = e.key === 'Tab';
+		if (!isTabPressed && !isEscapedPressed) {
+			return;
+		}
+
+		const isShiftKey = e.shiftKey;
+		const allPossibleFocusableEls = OSFramework.OSUI.Helper.Dom.TagSelectorAll(
+			_appProp.menu.element,
+			_menuFocusableElems
+		);
+		const focusableEls = [];
+
+		// Remove all elements that are inside a submenu to be manged by the submenu itself
+		for (const item of allPossibleFocusableEls) {
+			if (
+				item.closest(
+					OSFramework.OSUI.Constants.Dot + OSFramework.OSUI.Patterns.Submenu.Enum.CssClass.PatternLinks
+				) === null
+			) {
+				focusableEls.push(item);
+			}
+		}
+
+		const firstFocusableEl = focusableEls[0] as HTMLElement;
+		const lastFocusableEl = focusableEls[focusableEls.length - 1] as HTMLElement;
 
 		if (isShiftKey) {
 			if (document.activeElement === firstFocusableEl) {


### PR DESCRIPTION
This PR will fix an A11Y issue at the Menu.

### What was happening

- Once used under the context of mobile apps and/or mobile resolutions focus trap was not being set as it should.

### What was done

- Update and set the focusable elements properly since there was several wrong elements considered.

### Checklist

-   [ ] tested locally
-   [ ] documented the code
-   [ ] clean all warnings and errors of eslint
-   [ ] requires changes in OutSystems (if so, provide a module with changes)
-   [ ] requires new sample page in OutSystems (if so, provide a module with changes)
