### PR TITLE
ROU-12253: Update Virtual Select to v1.1.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
 		"@typescript-eslint/eslint-plugin": "^5.62.0",
 		"@typescript-eslint/parser": "^5.62.0",
 		"branch-name": "^1.0.0",
-		"browser-sync": "^3.0.3",
+		"browser-sync": "^3.0.4",
 		"eslint": "^8.57.1",
 		"eslint-config-prettier": "^9.1.0",
 		"eslint-plugin-prettier": "^5.2.5",

--- a/src/scripts/Providers/OSUI/Dropdown/VirtualSelect/AbstractVirtualSelectEnum.ts
+++ b/src/scripts/Providers/OSUI/Dropdown/VirtualSelect/AbstractVirtualSelectEnum.ts
@@ -5,7 +5,7 @@ namespace Providers.OSUI.Dropdown.VirtualSelect.Enum {
 	 */
 	export enum ProviderInfo {
 		Name = 'VirtualSelect',
-		Version = '1.1.0',
+		Version = '1.1.2',
 	}
 
 	/**

--- a/src/scripts/Providers/OSUI/Dropdown/VirtualSelect/README.md
+++ b/src/scripts/Providers/OSUI/Dropdown/VirtualSelect/README.md
@@ -1,3 +1,3 @@
-# VirtualSelect · ![virtualselect version](https://img.shields.io/badge/version-v1.1.0-informational)
+# VirtualSelect · ![virtualselect version](https://img.shields.io/badge/version-v1.1.2-informational)
 
 All info about this Provider <a href="https://sa-si-dev.github.io/virtual-select/#/">here</a>.

--- a/src/scripts/Providers/OSUI/Dropdown/VirtualSelect/scss/_virtualselect_lib.scss
+++ b/src/scripts/Providers/OSUI/Dropdown/VirtualSelect/scss/_virtualselect_lib.scss
@@ -1,5 +1,5 @@
 /*!
- * Virtual Select v1.1.0
+ * Virtual Select v1.1.2
  * https://sa-si-dev.github.io/virtual-select
  * Licensed under MIT (https://github.com/sa-si-dev/virtual-select/blob/master/LICENSE)
  */


### PR DESCRIPTION
This PR is to update the VirtualSelect library to the latest pre-release **v1.1.2**

### What was done

- Updated Virtual Select provider to the latest pre-release **v1.1.2**
    - _Note:_  couldn’t create an npm since the GH failed for permission, and [this](https://github.com/OutSystems/outsystems-ui/blob/b207c90e3391e7030e3e252a8b53ee34f53a609e/package.json#L70 ) will be outdated   

### Checklist

-   [X] tested locally
-   [X] documented the code
-   [X] clean all warnings and errors of eslint
-   [X] requires changes in OutSystems (if so, provide a module with changes)
-   [ ] requires new sample page in OutSystems (if so, provide a module with changes)
