### PR TITLE
ROU-12263: Added iPhone 17 to iPhone devices list

### DIFF
--- a/src/scripts/OSFramework/OSUI/Helper/Device.ts
+++ b/src/scripts/OSFramework/OSUI/Helper/Device.ts
@@ -99,6 +99,12 @@ namespace OSFramework.OSUI.Helper {
 		{ width: 1290, height: 2796, description: 'iphone 16 plus' },
 		{ width: 1206, height: 2622, description: 'iphone 16 pro' },
 		{ width: 1320, height: 2868, description: 'iphone 16 pro max' },
+
+		// iPhone17
+		{ width: 1206, height: 2622, description: 'iphone 17' },
+		{ width: 1320, height: 2868, description: 'iphone 17 air' }, // New model replacing 'Plus'
+		{ width: 1206, height: 2622, description: 'iphone 17 pro' },
+		{ width: 1320, height: 2868, description: 'iphone 17 pro max' },
 	];
 
 	export abstract class DeviceInfo {


### PR DESCRIPTION
### What was happening

- To keep our code base modern and updated, we need to revisit the list of supported iPhone sizes used for adding the CSS class `iphonex`.

### What was done

- Added all iPhone 17 devices to the list of iPhone devices with the associated resolutions

### Test Steps

1. Open an app on an iPhone 17
2. Check that the `iphonex` is present


### Checklist

-   [X] tested locally
-   [X] documented the code
-   [ ] clean all warnings and errors of eslint
-   [ ] requires changes in OutSystems (if so, provide a module with changes)
-   [ ] requires new sample page in OutSystems (if so, provide a module with changes)
