### PR TITLE
ROU-12311: revert layer system regression with virtual select

### DIFF
--- a/src/scripts/OSFramework/OSUI/Pattern/OverflowMenu/scss/_overflowmenu.scss
+++ b/src/scripts/OSFramework/OSUI/Pattern/OverflowMenu/scss/_overflowmenu.scss
@@ -56,6 +56,13 @@
 	}
 }
 
+// layer exception when a popup is open on the same screen
+html:has(.show-as-popup) {
+	.osui-overflow-menu__balloon.osui-balloon--is-open {
+		z-index: var(--layer-global-off-canvas);
+	}
+}
+
 .tablet,
 .phone {
 	.osui-overflow-menu {

--- a/src/scss/01-foundations/_root.scss
+++ b/src/scss/01-foundations/_root.scss
@@ -118,7 +118,7 @@
 	/*! Fixed/Absolute Patterns that need their variables on a global level to be referenced on all DOM contexts */
 	--osui-bottom-sheet-layer: var(--layer-global-off-canvas);
 	--osui-notification-layer: var(--layer-global-instant-interaction);
-	--osui-popup-layer: var(--layer-global-instant-interaction);
+	--osui-popup-layer: var(--layer-global-off-canvas);
 	--osui-sidebar-layer: var(--layer-global-off-canvas);
 	--osui-menu-layer: calc(var(--layer-global-navigation) + var(--layer-local-tier-2));
 }


### PR DESCRIPTION
This pull request addresses z-index layering issues for popups and overflow menus to ensure proper stacking behavior when popups are open. The main focus is on improving how popups and overflow menus interact visually, especially when multiple UI layers are present.

**Layering and z-index adjustments:**

* Changed the value of the `--osui-popup-layer` CSS variable from `var(--layer-global-instant-interaction)` to `var(--layer-global-off-canvas)` in `_root.scss`, aligning popups with other off-canvas elements for consistent stacking.
* Added a new CSS rule in `_overflowmenu.scss` that increases the z-index of `.osui-overflow-menu__balloon.osui-balloon--is-open` when a popup is open on the same screen, using the `:has(.show-as-popup)` selector to apply the layer exception.

### Checklist

-   [ ] tested locally
-   [ ] documented the code
-   [ ] clean all warnings and errors of eslint
-   [ ] requires changes in OutSystems (if so, provide a module with changes)
-   [ ] requires new sample page in OutSystems (if so, provide a module with changes)
