### PR TITLE
ROU-12311: fix z-index rule on Overflow-Menu for desktop

### DIFF
--- a/src/scripts/OSFramework/OSUI/Pattern/OverflowMenu/scss/_overflowmenu.scss
+++ b/src/scripts/OSFramework/OSUI/Pattern/OverflowMenu/scss/_overflowmenu.scss
@@ -57,10 +57,8 @@
 }
 
 // layer exception when a popup is open on the same screen
-html:has(.show-as-popup) {
-	.osui-overflow-menu__balloon.osui-balloon--is-open {
-		z-index: var(--layer-global-off-canvas);
-	}
+html:has(.popup-backdrop) .osui-overflow-menu__balloon {
+	z-index: var(--layer-global-off-canvas);
 }
 
 .tablet,


### PR DESCRIPTION
This pull request updates the CSS selector logic for the OverflowMenu balloon popup in the `src/scripts/OSFramework/OSUI/Pattern/OverflowMenu/scss/_overflowmenu.scss` file. The change refines how the z-index is applied when a popup is open, improving compatibility with the global popup backdrop in desktop and mobile view.


### Checklist

-   [ ] tested locally
-   [ ] documented the code
-   [ ] clean all warnings and errors of eslint
-   [ ] requires changes in OutSystems (if so, provide a module with changes)
-   [ ] requires new sample page in OutSystems (if so, provide a module with changes)
