### PR TITLE
ROU-12359: Improving the network type code

### DIFF
--- a/src/scripts/OutSystems/OSUI/Utils/Network.ts
+++ b/src/scripts/OutSystems/OSUI/Utils/Network.ts
@@ -20,9 +20,14 @@ namespace OutSystems.OSUI.Utils.Network {
 		// This method can't implement the CreateApiResponse method since it's defined as a function in SS
 		let typeofConnection = 'webbrowser';
 
-		if (navigator.connection !== undefined && navigator.connection.type !== undefined) {
-			//In a mobile device
-			typeofConnection = navigator.connection.type;
+		if (navigator.onLine) {
+			if (navigator.connection?.type) {
+				typeofConnection = navigator.connection.type;
+			} else {
+				typeofConnection = 'unknown';
+			}
+		} else {
+			typeofConnection = 'none';
 		}
 
 		return typeofConnection;


### PR DESCRIPTION
This PR is for improving what values are returned in case the object `navigator.connection.type` is not defined.
In some situations as in iOS native shell the value might not be returned.

### Test Steps
1. Enter the page in the native app
2. Click on the button to obtain that information
3. Validate the values obtained in android and ios

### Checklist
-   [x] tested locally
-   [x] documented the code
-   [x] clean all warnings and errors of eslint
-   [ ] requires changes in OutSystems (if so, provide a module with changes)
-   [ ] requires new sample page in OutSystems (if so, provide a module with changes)
