### PR TITLE
ROU-12687: Set minimum release age for npm and dependabot package updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,6 +12,8 @@ updates:
           day: monday
           time: '09:00'
           timezone: Europe/Lisbon
+      cooldown:
+          default-days: 7
       open-pull-requests-limit: 3
       rebase-strategy: disabled
       labels:

--- a/.github/workflows/template-ts-build-project.yaml
+++ b/.github/workflows/template-ts-build-project.yaml
@@ -71,7 +71,7 @@ jobs:
         permissions:
             id-token: write
             contents: read
-        steps: 
+        steps:
             - name: 📥 Checkout main branch
               uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
               with:
@@ -85,13 +85,6 @@ jobs:
                   tenant-id: ${{ secrets.OSUI_AZURE_TENANT_ID }}
                   subscription-id: ${{ secrets.OSUI_AZURE_SUBSCRIPTION_ID }}
 
-            - name: 🔑 Get Azure DevOps token
-              id: get-devOps-token
-              #uses: OutSystems/rd.github-reusable-workflows/.github/actions/az-keyvault-get@9d497d1c5bc6e355aa8f4663539e6b75c212f6b4 #v2.0.7
-              uses: ./.github/actions/az-keyvault-get
-              with:
-                  key-name: o11odc-github-ado-token-prd
-
             - name: 🔑 Get SonarCloud token
               id: get-sonarcloud-token
               if: ${{ inputs.run-sonarcloud == true }}
@@ -99,10 +92,6 @@ jobs:
               uses: ./.github/actions/az-keyvault-get
               with:
                   key-name: o11odc-github-sonarcloud-token-prd
-
-            - name: ⭕ Connect to OutSystems Environment
-              shell: bash
-              run: npx @outsystems/assistant login --token ${{ steps.get-devOps-token.outputs.az-keyvault-value }}
 
             - name: 🕸️ Install dependencies
               run: npm install

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+min-release-age=7


### PR DESCRIPTION
This PR sets the minimum release age for [npm](https://docs.npmjs.com/cli/v11/using-npm/config#min-release-age%7Chttps://docs.npmjs.com/cli/v11/using-npm/config#min-release-age%7Csmart-link) and [dependabot](https://github.blog/changelog/2025-07-01-dependabot-supports-configuration-of-a-minimum-package-age/) package updates.

### Checklist

-   [ ] tested locally
-   [ ] documented the code
-   [ ] clean all warnings and errors of eslint
-   [ ] requires changes in OutSystems (if so, provide a module with changes)
-   [ ] requires new sample page in OutSystems (if so, provide a module with changes)