### PR TITLE
ROU-12709: Updated date picker on select parameters

### DIFF
--- a/src/scripts/OSFramework/OSUI/Helper/Dates.ts
+++ b/src/scripts/OSFramework/OSUI/Helper/Dates.ts
@@ -5,6 +5,27 @@ namespace OSFramework.OSUI.Helper {
 		private static _serverFormat = '';
 
 		/**
+		 * Function to be used in order to get the Json Date from a given Date
+		 *
+		 * @static
+		 * @param {Date} _date
+		 * @return {*}  {string}
+		 * @memberof OSFramework.Helper.Dates
+		 */
+		public static GetJsonDateFromDate(_date: Date): string {
+			const jsonDate = {
+				year: _date.getFullYear(),
+				month: _date.getMonth() + 1,
+				day: _date.getDate(),
+				hours: _date.getHours(),
+				minutes: _date.getMinutes(),
+				seconds: _date.getSeconds(),
+			};
+
+			return JSON.stringify(jsonDate);
+		}
+
+		/**
 		 * Function to be used in order to get the Time from a given Date
 		 *
 		 * @static

--- a/src/scripts/Providers/OSUI/Datepicker/Flatpickr/RangeDate/FlatpickrRangeDate.ts
+++ b/src/scripts/Providers/OSUI/Datepicker/Flatpickr/RangeDate/FlatpickrRangeDate.ts
@@ -85,7 +85,11 @@ namespace Providers.OSUI.Datepicker.Flatpickr.RangeDate {
 					this.flatpickrInputElem.value
 				);
 				// Trigger platform's onChange callback event
-				this.triggerPlatformEventCallback(this.onSelectedCallbackEvent, _selectedDate[0], _selectedDate[1]);
+				this.triggerPlatformEventCallback(
+					this.onSelectedCallbackEvent,
+					OSFramework.OSUI.Helper.Dates.GetJsonDateFromDate(selectedDates[0]),
+					OSFramework.OSUI.Helper.Dates.GetJsonDateFromDate(selectedDates[1])
+				);
 			}
 		}
 

--- a/src/scripts/Providers/OSUI/Datepicker/Flatpickr/SingleDate/FlatpickrSingleDate.ts
+++ b/src/scripts/Providers/OSUI/Datepicker/Flatpickr/SingleDate/FlatpickrSingleDate.ts
@@ -71,7 +71,10 @@ namespace Providers.OSUI.Datepicker.Flatpickr.SingleDate {
 			// Check if values are not beeing updated by UpdateInitialDate API Method!
 			if (this._isUpdatedInitialDateByClientAction === false) {
 				// Trigger platform's onChange callback event
-				this.triggerPlatformEventCallback(this.onSelectedCallbackEvent, _selectedDate);
+				this.triggerPlatformEventCallback(
+					this.onSelectedCallbackEvent,
+					OSFramework.OSUI.Helper.Dates.GetJsonDateFromDate(selectedDates[0])
+				);
 			}
 
 			// Reset Flag value;

--- a/src/scss/O11.OutSystemsUI.scss
+++ b/src/scss/O11.OutSystemsUI.scss
@@ -17,7 +17,7 @@ PS: This comment block will not be visible in the compiled version!
 =============================================================================== */
 
 /*!
-OutSystems UI 2.28.0 • O11 Platform
+OutSystems UI 2.29.0 • O11 Platform
 Website:
  • https://www.outsystems.com/outsystems-ui
 GitHub:

--- a/src/scss/ODC.OutSystemsUI.scss
+++ b/src/scss/ODC.OutSystemsUI.scss
@@ -17,7 +17,7 @@ PS: This comment block will not be visible in the compiled version!
 =============================================================================== */
 
 /*!
-OutSystems UI 2.28.0 • ODC Platform
+OutSystems UI 2.29.0 • ODC Platform
 Website:
  • https://www.outsystems.com/outsystems-ui
 GitHub:


### PR DESCRIPTION
This PR is to update the DatePicker's onSelect callback parameter

### What was happening

- The onSelect in DatePicker and DatePickerRange was calling the client callback, passing the date directly as a string

### What was done

- The date is converted into a JSON containing the date information and this JSON is passed when calling the client callback 

### Test Steps

1. Open the sample application
2. Select a DST date such as `27-03-1983` on the Date Picker
3. Validate that the feedback message presents the correct date
4. In the Date Picker Range, select `27-03-1983` as start and `27-03-1983` as end date
5. Validate that the feedback message is correct


### Checklist

-   [x] tested locally
-   [x] documented the code
-   [x] clean all warnings and errors of eslint
-   [x] requires changes in OutSystems (if so, provide a module with changes)
-   [ ] requires new sample page in OutSystems (if so, provide a module with changes)
