### PR TITLE
ROU-12688: Fixed nested table last row styles

### DIFF
--- a/src/scss/03-widgets/_table.scss
+++ b/src/scss/03-widgets/_table.scss
@@ -88,7 +88,7 @@
 	}
 
 	.table-row:last-child {
-		& td {
+		& > td {
 			border-bottom: none;
 
 			&:last-child {
@@ -97,7 +97,7 @@
 			}
 		}
 
-		td:first-child {
+		& > td:first-child {
 			border-radius: var(--border-radius-none) var(--border-radius-none) var(--border-radius-none)
 				var(--border-radius-soft);
 		}


### PR DESCRIPTION
This PR is to fix the styles for the table in cases where nested tables are used


### What was happening

- When a nested table was used inside a table, the nested table in the last row of the parent table would appear without the row separators.

<img width="999" height="526" alt="Screenshot 2026-04-16 at 11 23 55" src="https://github.com/user-attachments/assets/691d2fb9-5802-4293-b932-5d7d10ce33cc" />


### What was done

- The styles were updated to ensure that it only applies to the direct row and not to all the child rows that have a similar class structure. 

### Test Steps

1. Open the sample application
2. Validate that the nested table in the last row of the parent table has separators between rows.

### Screenshots

<img width="1141" height="489" alt="Screenshot 2026-04-16 at 11 26 42" src="https://github.com/user-attachments/assets/e6a8113a-b418-413f-bb17-03037f2705ef" />

### Checklist

-   [ ] tested locally
-   [ ] documented the code
-   [ ] clean all warnings and errors of eslint
-   [ ] requires changes in OutSystems (if so, provide a module with changes)
-   [ ] requires new sample page in OutSystems (if so, provide a module with changes)
