### PR TITLE
ROU-12725: Fix aria labels setter when no main content exists

### DIFF
--- a/src/scripts/OutSystems/OSUI/Utils/LayoutPrivateSetA11Y.ts
+++ b/src/scripts/OutSystems/OSUI/Utils/LayoutPrivateSetA11Y.ts
@@ -8,7 +8,6 @@ namespace OutSystems.OSUI.Utils.LayoutPrivate {
 	 * @class SetA11Y
 	 */
 	export abstract class SetA11Y {
-
 		/**
 		 * Method used to set the A11Y attributes to the layout elements
 		 *
@@ -17,20 +16,42 @@ namespace OutSystems.OSUI.Utils.LayoutPrivate {
 		 */
 		private static _setA11Y(): void {
 			// Get Main Html Element reference
-			const mainContentElem = OSFramework.OSUI.Helper.Dom.ClassSelector(document, OSFramework.OSUI.GlobalEnum.CssClassElements.MainContent);
-			const hasMainElemRoleAttr = OSFramework.OSUI.Helper.Dom.Attribute.Has(mainContentElem, OSFramework.OSUI.Constants.A11YAttributes.Role.AttrName);
+			const mainContentElem = OSFramework.OSUI.Helper.Dom.ClassSelector(
+				document,
+				OSFramework.OSUI.GlobalEnum.CssClassElements.MainContent
+			);
 
-			// Set Role to Main Html Element
-			if (mainContentElem && !hasMainElemRoleAttr) {
-				OSFramework.OSUI.Helper.Dom.Attribute.Set(mainContentElem, OSFramework.OSUI.Constants.A11YAttributes.Role.AttrName, OSFramework.OSUI.Constants.A11YAttributes.Role.Main);
+			if (mainContentElem) {
+				const hasMainElemRoleAttr = OSFramework.OSUI.Helper.Dom.Attribute.Has(
+					mainContentElem,
+					OSFramework.OSUI.Constants.A11YAttributes.Role.AttrName
+				);
+
+				// Set Role to Main Html Element
+				if (!hasMainElemRoleAttr) {
+					OSFramework.OSUI.Helper.Dom.Attribute.Set(
+						mainContentElem,
+						OSFramework.OSUI.Constants.A11YAttributes.Role.AttrName,
+						OSFramework.OSUI.Constants.A11YAttributes.Role.Main
+					);
+				}
+			} else {
+				console.warn('Main content element not found, skipping A11Y attributes set');
 			}
 
 			// Check if the window resize event has the handler setted already
-			const hasResizeEvtHandlerSet = OSFramework.OSUI.Event.DOMEvents.Listeners.GlobalListenerManager.Instance.hasHandler(OSFramework.OSUI.Event.DOMEvents.Listeners.Type.WindowResize, this._setMenuA11Y);
-			
+			const hasResizeEvtHandlerSet =
+				OSFramework.OSUI.Event.DOMEvents.Listeners.GlobalListenerManager.Instance.hasHandler(
+					OSFramework.OSUI.Event.DOMEvents.Listeners.Type.WindowResize,
+					this._setMenuA11Y
+				);
+
 			// If the handler is not setted and the layout is not LayoutSide, add the resize event handler in order to update the A11Y attributes when the layout is resized
 			if (!hasResizeEvtHandlerSet && !OutSystems.OSUI.Utils.DeviceDetection.CheckIsLayoutSide()) {
-				OSFramework.OSUI.Event.DOMEvents.Listeners.GlobalListenerManager.Instance.addHandler(OSFramework.OSUI.Event.DOMEvents.Listeners.Type.WindowResize, this._setMenuA11Y);
+				OSFramework.OSUI.Event.DOMEvents.Listeners.GlobalListenerManager.Instance.addHandler(
+					OSFramework.OSUI.Event.DOMEvents.Listeners.Type.WindowResize,
+					this._setMenuA11Y
+				);
 			}
 
 			// Set the A11Y attributes to the menu elements
@@ -45,14 +66,21 @@ namespace OutSystems.OSUI.Utils.LayoutPrivate {
 		 */
 		private static _setMenuA11Y(): void {
 			// Get Menu Html Element reference
-			const menuElem = OSFramework.OSUI.Helper.Dom.ClassSelector(document, OSFramework.OSUI.GlobalEnum.CssClassElements.MenuLinks);
+			const menuElem = OSFramework.OSUI.Helper.Dom.ClassSelector(
+				document,
+				OSFramework.OSUI.GlobalEnum.CssClassElements.MenuLinks
+			);
 
 			// Get the orientation value based on the device type
-			const orientationValue = OSFramework.OSUI.Helper.DeviceInfo.IsDesktop && !OutSystems.OSUI.Utils.DeviceDetection.CheckIsLayoutSide() ? OSFramework.OSUI.Constants.A11YAttributes.States.Horizontal : OSFramework.OSUI.Constants.A11YAttributes.States.Vertical;
+			const orientationValue =
+				OSFramework.OSUI.Helper.DeviceInfo.IsDesktop &&
+				!OutSystems.OSUI.Utils.DeviceDetection.CheckIsLayoutSide()
+					? OSFramework.OSUI.Constants.A11YAttributes.States.Horizontal
+					: OSFramework.OSUI.Constants.A11YAttributes.States.Vertical;
 
 			if (menuElem) {
-				if(orientationValue === OSFramework.OSUI.Constants.A11YAttributes.States.Horizontal) {
-					OSFramework.OSUI.Helper.A11Y.AriaOrientationHorizontal(menuElem); 
+				if (orientationValue === OSFramework.OSUI.Constants.A11YAttributes.States.Horizontal) {
+					OSFramework.OSUI.Helper.A11Y.AriaOrientationHorizontal(menuElem);
 				} else {
 					OSFramework.OSUI.Helper.A11Y.AriaOrientationVertical(menuElem);
 				}
@@ -67,7 +95,6 @@ namespace OutSystems.OSUI.Utils.LayoutPrivate {
 		 */
 		public static Set(): void {
 			this._setA11Y();
-
 		}
 	}
 }


### PR DESCRIPTION
This PR is to fix a bug that made the page give an error when there was no `main content` on the layout.

### What was happening

- An error was being thrown when the page didn't have a `main content`. 
- The error was caused by trying to set an aria label to an element that was null.

### What was done

- A validation was added to ensure that the aria label is only added if the `main content` exists.
- A warning message will be displayed if there is no `main content`.

### Test Steps

1. Open the sample application 
2. Validate that the page renders successfully 
3. Open the developer tools
4. Validate that no error is displayed in the console
5. Validate that a warning is written in the console

### Checklist

-   [ ] tested locally
-   [ ] documented the code
-   [ ] clean all warnings and errors of eslint
-   [ ] requires changes in OutSystems (if so, provide a module with changes)
-   [ ] requires new sample page in OutSystems (if so, provide a module with changes)
