### PR TITLE
ROU-12709: Update project version to 2.28.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# OutSystems UI · v2.29.0
+# OutSystems UI · v2.28.1
 
 ![GitHub License](https://img.shields.io/badge/License-BSD%203--Clause-blue.svg) ![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg)
 

--- a/gulp/ProjectSpecs/DefaultSpecs.js
+++ b/gulp/ProjectSpecs/DefaultSpecs.js
@@ -27,7 +27,7 @@ const constants = {
 
 // Store the default project specifications
 const specs = {
-    "version": "2.29.0",
+    "version": "2.28.1",
     "name": "OutSystems UI",
     "description": "",
     "url": "Website:\n • https://www.outsystems.com/outsystems-ui",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "outsystems-ui",
-	"version": "2.29.0",
+	"version": "2.28.1",
 	"description": "OutSystems UI Framework",
 	"license": "BSD-3-Clause",
 	"scripts": {

--- a/src/scripts/OSFramework/OSUI/Constants.ts
+++ b/src/scripts/OSFramework/OSUI/Constants.ts
@@ -173,7 +173,7 @@ namespace OSFramework.OSUI.Constants {
 	export const OSPlatform = '<->platformType<->';
 
 	/* OSUI Version */
-	export const OSUIVersion = '2.29.0';
+	export const OSUIVersion = '2.28.1';
 
 	/* Constant to be used across project as the zero value*/
 	export const ZeroValue = 0;


### PR DESCRIPTION
This PR is to sync project version strings across repository files. Replace 2.29.0 with 2.28.1 in README.md, gulp/ProjectSpecs/DefaultSpecs.js, package.json, and src/scripts/OSFramework/OSUI/Constants.ts to align metadata and OSUI version.

### Checklist

-   [x] tested locally
-   [ ] documented the code
-   [ ] clean all warnings and errors of eslint
-   [ ] requires changes in OutSystems (if so, provide a module with changes)
-   [ ] requires new sample page in OutSystems (if so, provide a module with changes)
