### PR TITLE
ROU-12709: Add validation for date to onSelect callback

### DIFF
--- a/src/scripts/OSFramework/OSUI/Helper/Dates.ts
+++ b/src/scripts/OSFramework/OSUI/Helper/Dates.ts
@@ -12,17 +12,20 @@ namespace OSFramework.OSUI.Helper {
 		 * @return {*}  {string}
 		 * @memberof OSFramework.Helper.Dates
 		 */
-		public static GetJsonDateFromDate(_date: Date): string {
-			const jsonDate = {
-				year: _date.getFullYear(),
-				month: _date.getMonth() + 1,
-				day: _date.getDate(),
-				hours: _date.getHours(),
-				minutes: _date.getMinutes(),
-				seconds: _date.getSeconds(),
-			};
-
-			return JSON.stringify(jsonDate);
+		public static GetJsonDateFromDate(_date: Date): string | undefined {
+			if (_date !== undefined) {
+				const jsonDate = {
+					year: _date.getFullYear(),
+					month: _date.getMonth() + 1,
+					day: _date.getDate(),
+					hours: _date.getHours(),
+					minutes: _date.getMinutes(),
+					seconds: _date.getSeconds(),
+				};
+				return JSON.stringify(jsonDate);
+			} else {
+				return '';
+			}
 		}
 
 		/**


### PR DESCRIPTION
This PR is to add a validation for the date to the onSelect callback 

### What was happening

- When a user opened the date picker and closed without selecting a date, an error was thrown.

### What was done

- A validation was added to ensure that if the date is undefined, the callback is called with an empty leading to the event being called on the client side using the OutSystems null date

### Test Steps

1. Open the sample application
2. Open the development tools in the terminal
3. Open the date picker
4. Close without selecting a date
5. Validate that no error is displayed in the console

### Checklist

-   [ ] tested locally
-   [ ] documented the code
-   [ ] clean all warnings and errors of eslint
-   [ ] requires changes in OutSystems (if so, provide a module with changes)
-   [ ] requires new sample page in OutSystems (if so, provide a module with changes)
