### PR TITLE
ROU-12726: Inputs with icon and dropdowns broken after Icons Modernization;

### DIFF
--- a/src/scss/01-foundations/_icon-library-odc.scss
+++ b/src/scss/01-foundations/_icon-library-odc.scss
@@ -130,6 +130,10 @@ body.iconLibrary-phosphor {
 		top: 50%;
 		transform: translateY(-50%);
 	}
+	
+	.form-control[data-input]{
+		padding-left: var(--space-l);
+	}
 }
 
 // Submenu – header arrow
@@ -156,8 +160,10 @@ body.iconLibrary-phosphor {
 .dropdown-container:after {
 	color: var(--color-neutral-7);
 	content: var(--osui-icon-arrow-down);
+	cursor: pointer;
 	font-family: var(--osui-icon-font-family);
 	font-size: var(--font-size-h5);
+	pointer-events: none;
 	position: absolute;
 	right: var(--space-base);
 	top: 50%;

--- a/src/scss/01-foundations/_icon-library-odc.scss
+++ b/src/scss/01-foundations/_icon-library-odc.scss
@@ -126,11 +126,12 @@ body.iconLibrary-phosphor {
 		content: var(--osui-icon-search);
 		font-family: var(--osui-icon-font-family);
 		left: var(--space-base);
+		pointer-events: none;
 		position: absolute;
 		top: 50%;
 		transform: translateY(-50%);
 	}
-	
+
 	.form-control[data-input]{
 		padding-left: var(--space-l);
 	}


### PR DESCRIPTION
This PR is for fixing inputs and dropdowns visual and interaction bugs that were caused by icon modernization. 

### What was happening
- On input type search the magnifying icon was overlapping the input content;
- After the icon modernization the dropdown widget caret was preventing the click and also change the cursor type;

### What was done
- add padding on input search for magnifying icon;
- fix dropdown interaction above caret;

### Test Steps

1. Go to sample
2. Check the input search magnifying icon is not above the placeholder/content
3. Check also if it's possible to interact with the input by clicking on the icon;
4. Check the dropdown search caret is clickable and it activates the widget

### Checklist

-   [x] tested locally
-   [x] documented the code
-   [ ] clean all warnings and errors of eslint
-   [ ] requires changes in OutSystems (if so, provide a module with changes)
-   [ ] requires new sample page in OutSystems (if so, provide a module with changes)
