### PR TITLE
ROU-12726: V2 - Inputs with icon and dropdowns broken after Icons Modernization 

### DIFF
--- a/src/scripts/Providers/OSUI/Dropdown/VirtualSelect/scss/_virtualselect.scss
+++ b/src/scripts/Providers/OSUI/Dropdown/VirtualSelect/scss/_virtualselect.scss
@@ -246,7 +246,7 @@
 		&.show-value-as-tags {
 			&.has-value {
 				.vscomp-clear-button {
-					left: var(--space-l);
+					left: var(--space-xl);
 				}
 				.vscomp-toggle-button {
 					padding-right: var(--space-s);

--- a/src/scss/01-foundations/_icon-library-odc.scss
+++ b/src/scss/01-foundations/_icon-library-odc.scss
@@ -110,6 +110,9 @@ body.iconLibrary-phosphor {
 // ---------------------------------------------------------------------------
 // Component selectors – use CSS variables (with FontAwesome as fallback when no library class is set)
 // ---------------------------------------------------------------------------
+.icon.ph{
+	display: inline-block;
+}
 
 // Accordion – caret icon
 .osui-accordion-item__icon--caret:after {
@@ -133,9 +136,22 @@ body.iconLibrary-phosphor {
 	}
 
 	.form-control[data-input]{
-		padding-left: var(--space-l);
+		padding-left: var(--space-xl);
 	}
 }
+
+.is-rtl .input-search {
+	&::after {
+		left: auto;
+		right: var(--space-base);
+	}
+
+	.form-control[data-input]{
+		padding-left: var(--space-base);
+		padding-right: var(--space-xl);
+	}
+}
+
 
 // Submenu – header arrow
 .osui-submenu {
@@ -170,6 +186,11 @@ body.iconLibrary-phosphor {
 	top: 50%;
 	transform: translateY(-50%);
 	transition: transform 200ms ease;
+}
+
+.is-rtl .dropdown-container:after { 
+	left: var(--space-base);
+	right: auto;
 }
 
 .dropdown-expanded.dropdown-container {
@@ -350,6 +371,11 @@ body.iconLibrary-phosphor {
 	line-height: 1;
 	display: flex;
 	left: 1px;
+}
+
+.is-rtl .vscomp-wrapper.multiple .vscomp-option.selected .checkbox-icon:after {
+	left: auto;
+	right: 1px;
 }
 
 .osui-dropdown-search {


### PR DESCRIPTION
### What was happening
- Icon whitespace on input-search;
- RTL fixes;

### What was done
- fix RTL;
- fix phosphor icon decoration;

### Checklist
-   [ ] tested locally
-   [ ] documented the code
-   [ ] clean all warnings and errors of eslint
-   [ ] requires changes in OutSystems (if so, provide a module with changes)
-   [ ] requires new sample page in OutSystems (if so, provide a module with changes)
