### PR TITLE
ROU-12726: V3 - Inputs with icon and dropdowns broken after Icons Modernization

### DIFF
--- a/src/scripts/Providers/OSUI/Dropdown/VirtualSelect/scss/_virtualselect.scss
+++ b/src/scripts/Providers/OSUI/Dropdown/VirtualSelect/scss/_virtualselect.scss
@@ -241,9 +241,7 @@
 				margin-left: var(--space-m);
 				margin-right: var(--space-none);
 			}
-		}
-		
-		&.has-value {
+
 			&,
 			&.show-value-as-tags{
 				.vscomp-clear-button {

--- a/src/scripts/Providers/OSUI/Dropdown/VirtualSelect/scss/_virtualselect.scss
+++ b/src/scripts/Providers/OSUI/Dropdown/VirtualSelect/scss/_virtualselect.scss
@@ -242,12 +242,18 @@
 				margin-right: var(--space-none);
 			}
 		}
-
-		&.show-value-as-tags {
-			&.has-value {
+		
+		&.has-value {
+			&,
+			&.show-value-as-tags{
 				.vscomp-clear-button {
 					left: var(--space-xl);
 				}
+			}	
+		}
+
+		&.show-value-as-tags {
+			&.has-value {
 				.vscomp-toggle-button {
 					padding-right: var(--space-s);
 				}


### PR DESCRIPTION
### What was happening

- dropdown-search was misaligned compared with dropdown-tags when in RTL

### What was done

- fix clear button of rtl dropdown-search


### Checklist

-   [x] tested locally
-   [ ] documented the code
-   [ ] clean all warnings and errors of eslint
-   [ ] requires changes in OutSystems (if so, provide a module with changes)
-   [ ] requires new sample page in OutSystems (if so, provide a module with changes)
