### PR TITLE
ROU-12567: Fix Carousel a11y issues

### DIFF
--- a/src/scripts/OSFramework/OSUI/Pattern/Carousel/scss/_carousel.scss
+++ b/src/scripts/OSFramework/OSUI/Pattern/Carousel/scss/_carousel.scss
@@ -47,6 +47,12 @@
 			z-index: var(--layer-local-tier-1);
 
 			&__page {
+				// WCAG 2.5.8: Target offset of 6px on each side meets the 24px minimum
+				// (12px dot + 6px margin × 2 = 24px total territory per axis)
+				height: 12px;
+				margin: 6px;
+				width: 12px;
+
 				&.is-active {
 					background-color: get-background-color('primary');
 					z-index: var(--layer-local-tier-1);

--- a/src/scripts/Providers/OSUI/Carousel/Splide/Splide.ts
+++ b/src/scripts/Providers/OSUI/Carousel/Splide/Splide.ts
@@ -24,6 +24,8 @@ namespace Providers.OSUI.Carousel.Splide {
 		private _eventOnResize: OSFramework.OSUI.GlobalCallbacks.Generic;
 		// Store if a List widget is used inside the CarouselItems placeholder
 		private _hasList: boolean;
+		// Store the pending list-roles poll timeout id, so it can be cancelled on re-entry
+		private _listRolesPollId: number | undefined;
 		// Store the onSlideMoved event
 		private _platformEventOnSlideMoved: OSFramework.OSUI.Patterns.Carousel.Callbacks.OSOnSlideMovedEvent;
 		// Store initial provider options
@@ -43,10 +45,17 @@ namespace Providers.OSUI.Carousel.Splide {
 
 		// Method to wait for the OutSystems List widget to finish loading before applying roles
 		private _applyListRolesWhenReady(listEl: HTMLElement): void {
+			// Cancel any previously pending poll before starting a new one to prevent loop stacking
+			if (this._listRolesPollId !== undefined) {
+				clearTimeout(this._listRolesPollId);
+				this._listRolesPollId = undefined;
+			}
+
 			if (!listEl.classList.contains('list-loading') && listEl.children.length > 0) {
 				this._applyListRoles(listEl);
 			} else {
-				OSFramework.OSUI.Helper.ApplySetTimeOut(() => {
+				this._listRolesPollId = OSFramework.OSUI.Helper.ApplySetTimeOut(() => {
+					this._listRolesPollId = undefined;
 					this._applyListRolesWhenReady(listEl);
 				}, 100);
 			}
@@ -88,8 +97,22 @@ namespace Providers.OSUI.Carousel.Splide {
 			// Set initial carousel width
 			this._setCarouselWidth();
 
-			// Init the provider
-			this.provider.mount();
+			// Init the provider — pass a custom extension so list roles are re-applied on every
+			// mount cycle, including after provider.refresh() which wipes provider.on() listeners.
+			// The extension's mount() runs after all built-in components (including A11y) have
+			// already mounted, so Splide's ARIA roles are already set and can be overridden directly.
+			// eslint-disable-next-line @typescript-eslint/no-this-alias
+			const self = this;
+			this.provider.mount({
+				// eslint-disable-next-line @typescript-eslint/naming-convention
+				OSUIListRoles: function () {
+					return {
+						mount(): void {
+							self._setListRoles();
+						},
+					};
+				},
+			});
 
 			// Update pagination class, in case navigation was changed
 			this._togglePaginationClass();
@@ -140,6 +163,11 @@ namespace Providers.OSUI.Carousel.Splide {
 					this.redraw();
 					// This needs to be called again, to update the size one final time, to prevent situation where the Carousel wouldn't assume 100% width
 					this._setCarouselWidth();
+				} else {
+					// refresh() reapplies Splide's default ARIA (e.g. tabpanel/presentation) without firing
+					// mounted — e.g. when DevTools toggles and triggers resize. Full redraw remounts and
+					// mounted reapplies list roles; after refresh-only we must restore them here.
+					this._setListRoles();
 				}
 			}, 500);
 		}
@@ -174,7 +202,6 @@ namespace Providers.OSUI.Carousel.Splide {
 		// Method to set the OnInitializeEvent
 		private _setOnInitializedEvent(): void {
 			this.provider.on(Enum.SpliderEvents.Mounted, () => {
-				this._setListRoles();
 				this.triggerPlatformInitializedEventCallback();
 			});
 		}
@@ -387,6 +414,12 @@ namespace Providers.OSUI.Carousel.Splide {
 		 * @memberof Providers.OSUI.Carousel.Splide.OSUISplide
 		 */
 		public dispose(): void {
+			// Cancel any pending list-roles poll to prevent it firing after disposal
+			if (this._listRolesPollId !== undefined) {
+				clearTimeout(this._listRolesPollId);
+				this._listRolesPollId = undefined;
+			}
+
 			// Check if provider is ready
 			if (this.isBuilt) {
 				this.provider.destroy();
@@ -513,6 +546,10 @@ namespace Providers.OSUI.Carousel.Splide {
 
 					this.redraw();
 				}
+			} else if (this._hasList && this._carouselListWidgetElem) {
+				// Even when redraw is blocked (e.g. during a changeProperty call), re-apply list roles
+				// in case the List widget refreshed its content and replaced DOM nodes that had the roles.
+				this._applyListRolesWhenReady(this._carouselListWidgetElem);
 			}
 		}
 	}

--- a/src/scripts/Providers/OSUI/Carousel/Splide/Splide.ts
+++ b/src/scripts/Providers/OSUI/Carousel/Splide/Splide.ts
@@ -35,8 +35,17 @@ namespace Providers.OSUI.Carousel.Splide {
 			super(uniqueId, new SplideConfig(configs));
 		}
 
-		// Method to apply role="list" and role="listitem" to the list element and its direct children
+		// Method to apply role="list" and role="listitem" to the list element and its direct children.
+		// Skips native list elements (ul/ol) and elements whose direct children are native list
+		// elements (li/ul/ol), since those already carry implicit list semantics.
 		private _applyListRoles(listEl: HTMLElement): void {
+			const _isNativeList = listEl.tagName === 'UL' || listEl.tagName === 'OL';
+			const _hasNativeListChildren = listEl.querySelector(':scope > li, :scope > ul, :scope > ol') !== null;
+
+			if (_isNativeList || _hasNativeListChildren) {
+				return;
+			}
+
 			listEl.setAttribute('role', 'list');
 			listEl.querySelectorAll(':scope > *').forEach((item) => {
 				item.setAttribute('role', 'listitem');
@@ -181,6 +190,18 @@ namespace Providers.OSUI.Carousel.Splide {
 
 		// Method to assign correct ARIA list roles so screen readers interpret carousel lists properly
 		private _setListRoles(): void {
+			// Remove role="tabpanel" from slides that contain img, ul, ol, or li — elements for
+			// which tabpanel ownership is invalid or creates conflicting semantics
+			this.selfElement.querySelectorAll(OSFramework.OSUI.Constants.Dot + Enum.CssClass.SplideSlide).forEach((slide) => {
+				const _slideEl = slide as HTMLElement;
+				if (
+					OSFramework.OSUI.Helper.Dom.Attribute.Get(_slideEl, OSFramework.OSUI.Constants.A11YAttributes.Role.AttrName) === OSFramework.OSUI.Constants.A11YAttributes.Role.TabPanel &&
+					_slideEl.querySelector('img, ul, ol, li')
+				) {
+					OSFramework.OSUI.Helper.Dom.Attribute.Remove(_slideEl, OSFramework.OSUI.Constants.A11YAttributes.Role.AttrName);
+				}
+			});
+
 			if (this._hasList && this._carouselListWidgetElem) {
 				// Dynamic content: poll until the List widget finishes loading before applying roles
 				this._applyListRolesWhenReady(this._carouselListWidgetElem);

--- a/src/scripts/Providers/OSUI/Carousel/Splide/Splide.ts
+++ b/src/scripts/Providers/OSUI/Carousel/Splide/Splide.ts
@@ -101,14 +101,11 @@ namespace Providers.OSUI.Carousel.Splide {
 			// mount cycle, including after provider.refresh() which wipes provider.on() listeners.
 			// The extension's mount() runs after all built-in components (including A11y) have
 			// already mounted, so Splide's ARIA roles are already set and can be overridden directly.
-			// eslint-disable-next-line @typescript-eslint/no-this-alias
-			const self = this;
 			this.provider.mount({
-				// eslint-disable-next-line @typescript-eslint/naming-convention
-				OSUIListRoles: function () {
+				OSUIListRoles: () => {
 					return {
-						mount(): void {
-							self._setListRoles();
+						mount: () => {
+							this._setListRoles();
 						},
 					};
 				},

--- a/src/scripts/Providers/OSUI/Carousel/Splide/Splide.ts
+++ b/src/scripts/Providers/OSUI/Carousel/Splide/Splide.ts
@@ -126,9 +126,9 @@ namespace Providers.OSUI.Carousel.Splide {
 				// Add the placeholder content already with the correct html structure per item, expected by the library
 				for (const item of _childrenList) {
 					if (!item.classList.contains(Enum.CssClass.SplideSlide)) {
-						// Splide assigns role="tabpanel" to each splide__slide element.
-						// That role is only valid on container elements, not on <img>.
-						// Wrap bare images in a <div> so the role lands on the container.
+						// Splide assigns role="tabpanel" to each splide__slide element, which is then
+						// overridden with role="listitem" by the OSUIListRoles extension. Neither role
+						// is valid on an <img>. Wrap bare images in a <div> so the role lands on the container.
 						if (item.tagName === 'IMG') {
 							const wrapper = document.createElement(OSFramework.OSUI.GlobalEnum.HTMLElement.Div);
 							item.replaceWith(wrapper);

--- a/src/scripts/Providers/OSUI/Carousel/Splide/Splide.ts
+++ b/src/scripts/Providers/OSUI/Carousel/Splide/Splide.ts
@@ -126,7 +126,7 @@ namespace Providers.OSUI.Carousel.Splide {
 				// Add the placeholder content already with the correct html structure per item, expected by the library
 				for (const item of _childrenList) {
 					if (!item.classList.contains(Enum.CssClass.SplideSlide)) {
-						// Splide assigns role="tabpanel" to each splide__slide element, which is then
+						// Splide assigns role="presentation" to each splide__slide element, which is then
 						// overridden with role="listitem" by the OSUIListRoles extension. Neither role
 						// is valid on an <img>. Wrap bare images in a <div> so the role lands on the container.
 						if (item.tagName === 'IMG') {
@@ -161,7 +161,7 @@ namespace Providers.OSUI.Carousel.Splide {
 					// This needs to be called again, to update the size one final time, to prevent situation where the Carousel wouldn't assume 100% width
 					this._setCarouselWidth();
 				} else {
-					// refresh() reapplies Splide's default ARIA (e.g. tabpanel/presentation) without firing
+					// refresh() reapplies Splide's default ARIA (e.g. presentation) without firing
 					// mounted — e.g. when DevTools toggles and triggers resize. Full redraw remounts and
 					// mounted reapplies list roles; after refresh-only we must restore them here.
 					this._setListRoles();

--- a/src/scripts/Providers/OSUI/Carousel/Splide/Splide.ts
+++ b/src/scripts/Providers/OSUI/Carousel/Splide/Splide.ts
@@ -80,13 +80,24 @@ namespace Providers.OSUI.Carousel.Splide {
 		private _prepareCarouselItems(): void {
 			// Define the element that has the items. The List widget if dynamic content, otherwise get from the placeholder directly
 			const _targetList = this._hasList ? this._carouselListWidgetElem : this._carouselPlaceholderElem;
-			const _childrenList = _targetList.children;
+			// Snapshot into a static array: iterating the live HTMLCollection while mutating the DOM skips nodes
+			const _childrenList = Array.from(_targetList.children);
 
 			if (_childrenList.length > 0) {
 				// Add the placeholder content already with the correct html structure per item, expected by the library
 				for (const item of _childrenList) {
 					if (!item.classList.contains(Enum.CssClass.SplideSlide)) {
-						item.classList.add(Enum.CssClass.SplideSlide);
+						// Splide assigns role="tabpanel" to each splide__slide element.
+						// That role is only valid on container elements, not on <img>.
+						// Wrap bare images in a <div> so the role lands on the container.
+						if (item.tagName === 'IMG') {
+							const wrapper = document.createElement(OSFramework.OSUI.GlobalEnum.HTMLElement.Div);
+							item.replaceWith(wrapper);
+							wrapper.appendChild(item);
+							wrapper.classList.add(Enum.CssClass.SplideSlide);
+						} else {
+							item.classList.add(Enum.CssClass.SplideSlide);
+						}
 					}
 				}
 			}

--- a/src/scripts/Providers/OSUI/Carousel/Splide/Splide.ts
+++ b/src/scripts/Providers/OSUI/Carousel/Splide/Splide.ts
@@ -33,6 +33,25 @@ namespace Providers.OSUI.Carousel.Splide {
 			super(uniqueId, new SplideConfig(configs));
 		}
 
+		// Method to apply role="list" and role="listitem" to the list element and its direct children
+		private _applyListRoles(listEl: HTMLElement): void {
+			listEl.setAttribute('role', 'list');
+			listEl.querySelectorAll(':scope > *').forEach((item) => {
+				item.setAttribute('role', 'listitem');
+			});
+		}
+
+		// Method to wait for the OutSystems List widget to finish loading before applying roles
+		private _applyListRolesWhenReady(listEl: HTMLElement): void {
+			if (!listEl.classList.contains('list-loading') && listEl.children.length > 0) {
+				this._applyListRoles(listEl);
+			} else {
+				OSFramework.OSUI.Helper.ApplySetTimeOut(() => {
+					this._applyListRolesWhenReady(listEl);
+				}, 100);
+			}
+		}
+
 		// Method to check if a List Widget is used inside the placeholder and assign the _listWidget variable
 		private _checkListWidget(): void {
 			this._hasList = OutSystems.OSUI.Utils.GetHasListInside(this._carouselPlaceholderElem);
@@ -135,9 +154,27 @@ namespace Providers.OSUI.Carousel.Splide {
 			);
 		}
 
+		// Method to assign correct ARIA list roles so screen readers interpret carousel lists properly
+		private _setListRoles(): void {
+			if (this._hasList && this._carouselListWidgetElem) {
+				// Dynamic content: poll until the List widget finishes loading before applying roles
+				this._applyListRolesWhenReady(this._carouselListWidgetElem);
+			} else {
+				// Static content: apply roles directly to the splide__list element
+				const splideList = OSFramework.OSUI.Helper.Dom.ClassSelector(
+					this.selfElement,
+					Enum.CssClass.SplideList
+				);
+				if (splideList) {
+					this._applyListRoles(splideList);
+				}
+			}
+		}
+
 		// Method to set the OnInitializeEvent
 		private _setOnInitializedEvent(): void {
 			this.provider.on(Enum.SpliderEvents.Mounted, () => {
+				this._setListRoles();
 				this.triggerPlatformInitializedEventCallback();
 			});
 		}

--- a/src/scripts/Providers/OSUI/Carousel/Splide/SplideConfig.ts
+++ b/src/scripts/Providers/OSUI/Carousel/Splide/SplideConfig.ts
@@ -75,6 +75,7 @@ namespace Providers.OSUI.Carousel.Splide {
 		public getProviderConfig(): SplideOpts {
 			this._providerOptions = {
 				arrows: this._getArrowConfig(),
+				role: 'presentation',
 				breakpoints: {
 					768: {
 						perPage: this.ItemsPhone,


### PR DESCRIPTION
This PR is for...

[Sample page](https://outsystemsui-dev.outsystemsenterprise.com/TaskSample_DEV_ROU12567/TestScreen1)

### What was happening

- The carousel was not WCAG 2.2 compliant

### What was done

- This PR implements the changes in this [documentation PR](https://github.com/OutSystems/docs-product-internal/pull/2218) to ensure that the carousel is WCAG 2.2 compliant

### Test Steps

1. Verify that pagination controls meet the minimum target size of 24px
<img width="1903" height="930" alt="Screenshot 2026-05-06 at 5 19 06 PM" src="https://github.com/user-attachments/assets/5bfab9d5-cecf-42b7-8783-e0d84e73927f" />

2. Verify that for carousels with images, the `tabpanel` role was removed from the image.
<img width="539" height="199" alt="Screenshot 2026-05-06 at 6 06 45 PM" src="https://github.com/user-attachments/assets/44e2da27-b70b-410a-a5c3-e5b6a0d32c79" />


3. Verify that lists within the carousel have a `list` role and each item has a `listitem` role
<img width="712" height="327" alt="Screenshot 2026-05-06 at 5 22 46 PM" src="https://github.com/user-attachments/assets/a8c99a05-fcdf-4dfd-a963-0a808f2f7b06" />

4. Verify that each carousel has a role of `presentation` rather than `region` so that multiple carousels within the same page do not throw an a11y error
<img width="647" height="69" alt="Screenshot 2026-05-08 at 3 30 29 PM" src="https://github.com/user-attachments/assets/adc85e60-766c-47e7-aa30-9702f4fc90f7" />

5. Verify that for `ol` and `ul` elements within carousels there is no role attribute as these elements use semantic HTML and should be detected by a screen reader.
<img width="519" height="512" alt="Screenshot 2026-05-08 at 3 32 28 PM" src="https://github.com/user-attachments/assets/7bc10a0b-838c-4726-b97c-61151e28f65c" />

### Checklist

-   [ ] tested locally
-   [ ] documented the code
-   [ ] clean all warnings and errors of eslint
-   [ ] requires changes in OutSystems (if so, provide a module with changes)
-   [ ] requires new sample page in OutSystems (if so, provide a module with changes)
