### PR TITLE
ROU-12799: Input with type search started to have an icon with v2.28.0 and icon modernization

### DIFF
--- a/src/scss/01-foundations/_icon-library-odc.scss
+++ b/src/scss/01-foundations/_icon-library-odc.scss
@@ -120,38 +120,6 @@ body.iconLibrary-phosphor {
 	font-family: var(--osui-icon-font-family);
 }
 
-// Search – search icon
-.input-search {
-	position: relative;
-
-	&::after {
-		color: var(--color-neutral-6);
-		content: var(--osui-icon-search);
-		font-family: var(--osui-icon-font-family);
-		left: var(--space-base);
-		pointer-events: none;
-		position: absolute;
-		top: 50%;
-		transform: translateY(-50%);
-	}
-
-	.form-control[data-input]{
-		padding-left: var(--space-xl);
-	}
-}
-
-.is-rtl .input-search {
-	&::after {
-		left: auto;
-		right: var(--space-base);
-	}
-
-	.form-control[data-input]{
-		padding-left: var(--space-base);
-		padding-right: var(--space-xl);
-	}
-}
-
 
 // Submenu – header arrow
 .osui-submenu {


### PR DESCRIPTION
This PR is for rollback the introduction of magnifying icon on input with type search

### What was happening

- this was introducing a visual breaking change on inputs with type search after the last minor upgrade.

### What was done

- remove magnifying icon from inputs with type search;

### Test Steps

1. Go to sample 
2. Check if the input doesn't have any icon
3. Inspect the DOM and check the input is of type search and has the a wrapper with the class "input-search";

### Checklist

-   [x] tested locally
-   [ ] documented the code
-   [ ] clean all warnings and errors of eslint
-   [ ] requires changes in OutSystems (if so, provide a module with changes)
-   [ ] requires new sample page in OutSystems (if so, provide a module with changes)
