### PR TITLE
ROU-12798: Update Virtual Select to v1.2.0

### DIFF
--- a/src/scripts/Providers/OSUI/Dropdown/VirtualSelect/AbstractVirtualSelectEnum.ts
+++ b/src/scripts/Providers/OSUI/Dropdown/VirtualSelect/AbstractVirtualSelectEnum.ts
@@ -5,7 +5,7 @@ namespace Providers.OSUI.Dropdown.VirtualSelect.Enum {
 	 */
 	export enum ProviderInfo {
 		Name = 'VirtualSelect',
-		Version = '1.1.5',
+		Version = '1.2.0',
 	}
 
 	/**

--- a/src/scripts/Providers/OSUI/Dropdown/VirtualSelect/README.md
+++ b/src/scripts/Providers/OSUI/Dropdown/VirtualSelect/README.md
@@ -1,3 +1,3 @@
-# VirtualSelect · ![virtualselect version](https://img.shields.io/badge/version-v1.1.5-informational)
+# VirtualSelect · ![virtualselect version](https://img.shields.io/badge/version-v1.2.0-informational)
 
 All info about this Provider <a href="https://sa-si-dev.github.io/virtual-select/#/">here</a>.

--- a/src/scripts/Providers/OSUI/Dropdown/VirtualSelect/scss/_virtualselect_lib.scss
+++ b/src/scripts/Providers/OSUI/Dropdown/VirtualSelect/scss/_virtualselect_lib.scss
@@ -1,5 +1,5 @@
 /*!
- * Virtual Select v1.1.5
+ * Virtual Select v1.2.0
  * https://sa-si-dev.github.io/virtual-select
  * Licensed under MIT (https://github.com/sa-si-dev/virtual-select/blob/master/LICENSE)
  */
@@ -221,7 +221,6 @@
 	text-overflow: ellipsis;
 	white-space: nowrap;
 	-webkit-user-select: none;
-	-moz-user-select: none;
 	user-select: none;
 	width: 100%;
 }
@@ -277,7 +276,6 @@
 	height: 30px;
 	justify-content: center;
 	-webkit-user-select: none;
-	-moz-user-select: none;
 	user-select: none;
 	visibility: hidden;
 	width: 30px;
@@ -311,7 +309,6 @@
 .vscomp-ele[disabled] {
 	cursor: not-allowed;
 	-webkit-user-select: none;
-	-moz-user-select: none;
 	user-select: none;
 }
 .vscomp-ele[disabled] .vscomp-wrapper {


### PR DESCRIPTION
This PR is to update the VirtualSelect library to the latest pre-release **v1.2.0**

### What was done

- Updated Virtual Select provider to the latest pre-release **v1.2.0**
    - _Note:_  couldn’t create an npm since the GH failed for permission, and [this](https://github.com/OutSystems/outsystems-ui/blob/b207c90e3391e7030e3e252a8b53ee34f53a609e/package.json#L70 ) will be outdated   


### Checklist

-   [X] tested locally
-   [X] documented the code
-   [X] clean all warnings and errors of eslint
-   [X] requires changes in OutSystems (if so, provide a module with changes)
-   [ ] requires new sample page in OutSystems (if so, provide a module with changes)
