### PR TITLE
ROU-12807: Fix carousel page jumps when inside forms

### DIFF
--- a/src/scripts/Providers/OSUI/Carousel/Splide/scss/splide-core.scss
+++ b/src/scripts/Providers/OSUI/Carousel/Splide/scss/splide-core.scss
@@ -84,6 +84,9 @@
 	position: absolute;
 	width: 1px;
 }
+.form .splide__sr {
+	position: absolute;
+}
 .splide__toggle.is-active .splide__toggle__play,
 .splide__toggle__pause {
 	display: none;


### PR DESCRIPTION
This PR is to fix a bug that made the page jump when using the carousel inside a form

### What was happening

- When a carousel was placed inside a form, a `span` inserted by the Splide component, for accessibility proposes was made visible by the form's CSS rules.

### What was done

- A more specific CSS rule was added to ensure the span remains invisible when inside a form

### Test Steps

1. Open the sample application
2. Navigate to the carousel inside a form
3. Navigate through the carousel
4. Validate that the page does not jump

### Checklist

-   [x] tested locally
-   [ ] documented the code
-   [ ] clean all warnings and errors of eslint
-   [ ] requires changes in OutSystems (if so, provide a module with changes)
-   [ ] requires new sample page in OutSystems (if so, provide a module with changes)
