### PR TITLE
ROU-12778: Menu flicker when screen scroll

### DIFF
--- a/src/scripts/OutSystems/OSUI/Utils/Menu.ts
+++ b/src/scripts/OutSystems/OSUI/Utils/Menu.ts
@@ -248,12 +248,15 @@ namespace OutSystems.OSUI.Utils.Menu {
 		if (_appProp.menu.isOpen) {
 			OSFramework.OSUI.Helper.A11Y.TabIndexTrue(menu);
 			OSFramework.OSUI.Helper.A11Y.AriaExpandedTrue(menu);
+			OSFramework.OSUI.Helper.Dom.Styles.AddClass(menu, 'is--open');
 		} else if (OSFramework.OSUI.Helper.DeviceInfo.IsDesktop) {
 			OSFramework.OSUI.Helper.Dom.Attribute.Remove(menu, OSFramework.OSUI.Constants.A11YAttributes.TabIndex);
 			OSFramework.OSUI.Helper.Dom.Attribute.Remove(menu, OSFramework.OSUI.Constants.A11YAttributes.Aria.Expanded);
+			OSFramework.OSUI.Helper.Dom.Styles.RemoveClass(menu, 'is--open');
 		} else {
 			OSFramework.OSUI.Helper.A11Y.TabIndexFalse(menu);
 			OSFramework.OSUI.Helper.A11Y.AriaExpandedFalse(menu);
+			OSFramework.OSUI.Helper.Dom.Styles.RemoveClass(menu, 'is--open');
 		}
 	};
 

--- a/src/scss/02-layout/_menu-layout-side.scss
+++ b/src/scss/02-layout/_menu-layout-side.scss
@@ -39,12 +39,13 @@
 		z-index: var(--osui-menu-layer);
 	}
 
-	&.menu-visible {
-		.app-menu-content {
-			transform: translateX(var(--side-menu-size)) translateZ(0);
-			transition: transform 330ms ease-out;
-		}
+	
+	.app-menu-content.is--open {
+		left: calc(-1 * var(--side-menu-size));
+		transform: translateX(var(--side-menu-size)) translateZ(0);
+		transition: transform 330ms ease-out;
 	}
+	
 }
 
 // Responsive --------------------------------------------------------------------
@@ -54,6 +55,7 @@
 		&:not(.layout-native):not(.aside-overlay) .app-menu-content {
 			left: 0;
 			right: 0;
+			transform: none;
 		}
 
 		&.aside-expandable:not(.fixed-header) .app-menu-content {
@@ -80,19 +82,17 @@
 }
 
 ///
-.tablet {
-	&.landscape {
-		.layout-native {
-			&.aside-expandable.menu-visible {
-				.app-menu-content {
-					display: flex;
-					transform: none;
-					transition: none;
-				}
-			}
+.desktop, 
+.tablet.landscape {
+	.layout-native.aside-expandable.menu-visible {
+		.app-menu-content.is--open {
+			display: flex;
+			transform: none;
+			transition: none;
 		}
-	}
+	}	
 }
+
 
 // IsRTL -------------------------------------------------------------------------
 ///
@@ -105,36 +105,28 @@
 			}
 		}
 	}
-
-	&.tablet,
-	&.phone {
-		.app-menu-content {
-			right: calc(-1 * var(--side-menu-size));
-			transition: all 330ms ease-out;
-		}
-	}
-
-	&:not(.portrait) {
-		.layout-side {
-			&.layout-native {
-				&.aside-visible {
-					.app-menu-content {
-						right: 0;
-					}
-				}
-			}
-		}
-	}
-
 	.layout-side .app-menu-content {
 		left: auto;
 	}
 
-	.aside-overlay.menu-visible {
-		.app-menu-content {
-			right: 0;
-			transform: translateX(0) translateZ(0);
-			transition: all 330ms ease-out;
+	.app-menu-content {
+		right: calc(-1 * var(--side-menu-size));
+		transition: transform 330ms ease-in;
+	}
+	
+	.app-menu-content.is--open {
+		right: 0;
+		transform: translateX(0) translateZ(0);
+		transition: transform 130ms ease-out;
+	}
+
+	&:not(.portrait) {
+		.layout-side.layout-native.aside-visible {
+			.app-menu-content {
+				right: 0;
+			}
 		}
 	}
+
+
 }

--- a/src/scss/02-layout/_menu.scss
+++ b/src/scss/02-layout/_menu.scss
@@ -14,6 +14,17 @@
 	}
 }
 
+.app-menu-content {
+	left: calc(-1 * var(--side-menu-size));
+	transform: translateX(0) translateZ(0);
+	transition: transform 130ms ease-in;
+
+	&.is--open {
+		transform: translateX(var(--side-menu-size)) translateZ(0);
+		transition: transform 330ms ease-out;
+	}
+}
+
 ///
 .app-menu-overlay {
 	background-color: get-background-color('overlay');
@@ -135,6 +146,10 @@
 	.aside-overlay .app-menu-overlay {
 		display: block;
 	}
+
+	.app-menu-content.is--open {
+		left: 0;
+	}
 }
 
 ///
@@ -148,21 +163,11 @@
 		background-color: get-background-color('neutral-0');
 		flex-direction: column;
 		height: 100%;
-		left: calc(-1 * var(--side-menu-size));
 		position: fixed;
 		top: 0;
-		transform: translateX(0) translateZ(0);
-		transition: transform 130ms ease-in;
 		width: var(--side-menu-size);
-
 		will-change: transform;
 		z-index: var(--osui-menu-layer);
-	}
-
-	// .menu-visible is a class added into the .layout element
-	.menu-visible .app-menu-content {
-		transform: translateX(var(--side-menu-size)) translateZ(0);
-		transition: transform 330ms ease-out;
 	}
 
 	.layout-side {
@@ -225,22 +230,13 @@
 	.app-menu-content {
 		left: auto;
 		right: calc(-1 * var(--side-menu-size));
+		transition: transform 130ms ease-in;
 	}
 
-	.menu-visible {
-		.app-menu-content {
-			right: 0;
-			-webkit-transform: translateX(0) translateZ(0);
-			transform: translateX(0) translateZ(0);
-		}
-	}
-
-	&.tablet,
-	&.phone {
-		.menu-visible .app-menu-content {
-			right: 0;
-			transform: translateX(0) translateZ(0);
-			transition: all 330ms ease-out;
-		}
+	.app-menu-content.is--open {
+		left: auto;
+		right: 0;
+		transform: translateX(0) translateZ(0);
+		transition: transform 130ms ease-out;
 	}
 }


### PR DESCRIPTION
This PR is for fixing a menu misbehavior on mobile;

### What was happening
- We detect that on some mobile devices if we scroll the screen while the menu was open it starts flickering. This was due to app-menu content is fixed and its height tracks the viewport, Chrome needs to recalculate its styles when the viewport height changes.

### What was done
- add open variation class on menu level;
- change css accordingly;

### Test Steps

1. Check that all the different layouts on desktop behave as expected (LTR and RTL)
2. Open the all samples on a mobile device
3. Open the menu and scroll the page
4. Check everything is working (LTR and RTL)

### Checklist

-   [x] tested locally
-   [ ] documented the code
-   [ ] clean all warnings and errors of eslint
-   [ ] requires changes in OutSystems (if so, provide a module with changes)
-   [ ] requires new sample page in OutSystems (if so, provide a module with changes)
