### PR TITLE
ROU-12716: Fix notch space on tablet for sideMenu App title

### DIFF
--- a/src/scss/02-layout/_header-layout-native.scss
+++ b/src/scss/02-layout/_header-layout-native.scss
@@ -77,10 +77,6 @@
 			padding-left: var(--os-safe-area-left);
 			padding-right: var(--os-safe-area-right);
 		}
-
-		.app-menu {
-			padding-bottom: var(--os-safe-area-bottom);
-		}
 	}
 }
 
@@ -121,7 +117,7 @@
 		}
 
 		.header,
-		.app-menu {
+		.app-menu-content {
 			padding-top: #{android-safe-area-top()};
 			padding-right: var(--safe-area-inset-right, 0px);
 			padding-left: var(--safe-area-inset-left, 0px);

--- a/src/scss/02-layout/_menu.scss
+++ b/src/scss/02-layout/_menu.scss
@@ -147,8 +147,11 @@
 		display: block;
 	}
 
-	.app-menu-content.is--open {
-		left: 0;
+	.app-menu-content {
+		&,
+		&.is--open {
+			left: 0;
+		}
 	}
 }
 


### PR DESCRIPTION
This PR is for fixing edge to edge side menu. 

### What was happening

- On some devices, on generated apps via cordova, MABs 12, that use OutSystemsUI and an Android 14+ version. On some contexts the side menu was appearing behind the status header bar.  

### What was done

- update app-menu class selector so android-safe-area-top() is in fact used;

### Test Steps

1. Open Sample on a Android 14+ version device. 
2. Rotate if needed, so the menu is transform into a side menu. 
3. Check if the menu open has whitespace preventing the header status bar of the device; 

### Checklist

-   [x] tested locally
-   [ ] documented the code
-   [ ] clean all warnings and errors of eslint
-   [ ] requires changes in OutSystems (if so, provide a module with changes)
-   [ ] requires new sample page in OutSystems (if so, provide a module with changes)
