### PR TITLE
ROU-12838: change pagination rule to be conditional on a11y

### DIFF
--- a/src/scripts/OSFramework/OSUI/Pattern/Carousel/scss/_carousel.scss
+++ b/src/scripts/OSFramework/OSUI/Pattern/Carousel/scss/_carousel.scss
@@ -47,12 +47,6 @@
 			z-index: var(--layer-local-tier-1);
 
 			&__page {
-				// WCAG 2.5.8: Target offset of 6px on each side meets the 24px minimum
-				// (12px dot + 6px margin × 2 = 24px total territory per axis)
-				height: 12px;
-				margin: 6px;
-				width: 12px;
-
 				&.is-active {
 					background-color: get-background-color('primary');
 					z-index: var(--layer-local-tier-1);
@@ -153,6 +147,18 @@
 .has-accessible-features {
 	.splide__slide {
 		box-shadow: none;
+	}
+
+	.osui-carousel {
+		.splide {
+			&__pagination__page {
+					// WCAG 2.5.8: Target offset of 6px on each side meets the 24px minimum
+					// (12px dot + 6px margin × 2 = 24px total territory per axis)
+					height: 12px;
+					margin: 6px;
+					width: 12px;
+				}
+		}
 	}
 }
 


### PR DESCRIPTION
This pull request refactors the styling for the carousel pagination dots to improve maintainability and ensure WCAG accessibility compliance. The main change moves the CSS rules for pagination dot sizing and spacing to a more specific selector, ensuring they only apply within the carousel component.

**Accessibility and maintainability improvements:**

* Moved the WCAG 2.5.8-compliant sizing and margin rules for pagination dots from the general `.splide__pagination__page` selector to `.osui-carousel .splide__pagination__page`, ensuring the 12px size and 6px margin are only applied within the carousel component. [[1]](diffhunk://#diff-5a9309e9fc28fb9ff8cd865267b61af634618d13f06b91c4a7e987f7a7321326L50-L55) [[2]](diffhunk://#diff-5a9309e9fc28fb9ff8cd865267b61af634618d13f06b91c4a7e987f7a7321326R151-R162)

### Checklist

-   [ ] tested locally
-   [ ] documented the code
-   [ ] clean all warnings and errors of eslint
-   [ ] requires changes in OutSystems (if so, provide a module with changes)
-   [ ] requires new sample page in OutSystems (if so, provide a module with changes)
