### PR TITLE
ROU-12834: Add correct dropdown error placement

### DIFF
--- a/src/scss/01-foundations/_icon-library-o11.scss
+++ b/src/scss/01-foundations/_icon-library-o11.scss
@@ -152,10 +152,6 @@
 	}
 }
 
-.form .dropdown-container:after {
-	top: calc(50% - var(--space-m) / 2);
-}
-
 .is-rtl {
 	.dropdown-container {
 		&:after {

--- a/src/scss/01-foundations/_icon-library-o11.scss
+++ b/src/scss/01-foundations/_icon-library-o11.scss
@@ -152,6 +152,10 @@
 	}
 }
 
+.form .dropdown-container:after {
+	top: calc(50% - var(--space-m) / 2);
+}
+
 .is-rtl {
 	.dropdown-container {
 		&:after {
@@ -221,7 +225,7 @@
 	}
 }
 
-.osui-datepicker-calendar-ss-preview, 
+.osui-datepicker-calendar-ss-preview,
 .osui-monthpicker-ss-preview {
 	--osui-icon-font-family: 'FontAwesome';
 	--osui-icon-arrow-left: '\f104';

--- a/src/scss/01-foundations/_icon-library-odc.scss
+++ b/src/scss/01-foundations/_icon-library-odc.scss
@@ -110,7 +110,7 @@ body.iconLibrary-phosphor {
 // ---------------------------------------------------------------------------
 // Component selectors – use CSS variables (with FontAwesome as fallback when no library class is set)
 // ---------------------------------------------------------------------------
-.icon.ph{
+.icon.ph {
 	display: inline-block;
 }
 
@@ -119,7 +119,6 @@ body.iconLibrary-phosphor {
 	content: var(--osui-icon-arrow-down);
 	font-family: var(--osui-icon-font-family);
 }
-
 
 // Submenu – header arrow
 .osui-submenu {
@@ -156,11 +155,7 @@ body.iconLibrary-phosphor {
 	transition: transform 200ms ease;
 }
 
-.form .dropdown-container:after {
-	top: calc(50% - var(--space-m) / 2);
-}
-
-.is-rtl .dropdown-container:after { 
+.is-rtl .dropdown-container:after {
 	left: var(--space-base);
 	right: auto;
 }

--- a/src/scss/01-foundations/_icon-library-odc.scss
+++ b/src/scss/01-foundations/_icon-library-odc.scss
@@ -156,6 +156,10 @@ body.iconLibrary-phosphor {
 	transition: transform 200ms ease;
 }
 
+.form .dropdown-container:after {
+	top: calc(50% - var(--space-m) / 2);
+}
+
 .is-rtl .dropdown-container:after { 
 	left: var(--space-base);
 	right: auto;

--- a/src/scss/03-widgets/_form.scss
+++ b/src/scss/03-widgets/_form.scss
@@ -57,6 +57,10 @@
 	}
 
 	.dropdown-container {
+		&:after {
+			top: calc(50% - var(--space-m) / 2);
+		}
+
 		&[class*='ThemeGrid_Width'].not-valid span.validation-message {
 			bottom: 4px;
 		}


### PR DESCRIPTION
This PR aims to fix the misplacement of the arrow inside the dropdown on ODC.

### What was happening

- In ODC, when the dropdown is used inside a form, and the width is set to a col value, the dropdown arrow becomes misplaced.

### What was done

- An anchor name was defined on the dropdown select
- The anchor name was then used to place the arrow in the correct place

### Test Steps

1. Open the sample application
2. Validate that the dropdown has the arrow on the right place


### Checklist

-   [ ] tested locally
-   [ ] documented the code
-   [ ] clean all warnings and errors of eslint
-   [ ] requires changes in OutSystems (if so, provide a module with changes)
-   [ ] requires new sample page in OutSystems (if so, provide a module with changes)
