### PR TITLE
ROU-12835: Fix tooltip behavior after switching tabs

### DIFF
--- a/src/scripts/OSFramework/OSUI/Pattern/Tooltip/Tooltip.ts
+++ b/src/scripts/OSFramework/OSUI/Pattern/Tooltip/Tooltip.ts
@@ -51,6 +51,14 @@ namespace OSFramework.OSUI.Patterns.Tooltip {
 
 		// Method to handle the custom BalloonOnToggle callback
 		private _balloonOnToggleCallback(_args: string, e: CustomEvent): void {
+			// Close when another balloon opens. Body click on document.body never runs for clicks on
+			// another tooltip trigger because _onClick uses stopPropagation, so blur was the only path
+			// and it is not guaranteed (e.g. tab visibility, focus inside balloon).
+			if (e.detail.isOpen && e.detail.balloonElem !== this._balloonElem && this._isOpen) {
+				this._triggerClose(false);
+				return;
+			}
+
 			// If the balloon closed is the one from this pattern, toggle the isOpen
 			if (e.detail.balloonElem === this._balloonElem && e.detail.isOpen !== this._isOpen) {
 				this._triggerClose(true);


### PR DESCRIPTION
This PR is to fix the tooltip behavior after switching browser tabs

### What was happening

- When the browser tab or window lost and regained focus, the element blur did not always run in a way the tooltip could rely on, so a tooltip could stay open even though the user had moved on.
- With more than one tooltip on the page, clicking another tooltip’s trigger calls `stopPropagation()` on the click, so the `document.body` click handler used by the Balloon feature never saw that click.

### What was done

- In BalloonOnToggle, when any other balloon opens, the tooltip is closed with a normal close path, so closing no longer depends only on `onblur()`.

### Test Steps

1. Open the sample application
2. Click on the first tooltip
3. Switch the browser tab
4. Go back to the tooltip tab
5. Click on the first tooltip
6. Click on the second tooltip
7. Click on the first tooltip again
8. Validate that the tooltips' behavior is always in accordance

### Checklist

-   [ ] tested locally
-   [ ] documented the code
-   [ ] clean all warnings and errors of eslint
-   [ ] requires changes in OutSystems (if so, provide a module with changes)
-   [ ] requires new sample page in OutSystems (if so, provide a module with changes)
