### PR TITLE
ROU-12843: Update Virtual Select to v1.3.0

### DIFF
--- a/src/scripts/Providers/OSUI/Dropdown/VirtualSelect/AbstractVirtualSelectConfig.ts
+++ b/src/scripts/Providers/OSUI/Dropdown/VirtualSelect/AbstractVirtualSelectConfig.ts
@@ -7,8 +7,9 @@ namespace Providers.OSUI.Dropdown.VirtualSelect {
 	 * @class AbstractVirtualSelectConfig
 	 * @extends {AbstractDropdownConfig}
 	 */
-	export abstract class AbstractVirtualSelectConfig extends OSFramework.OSUI.Patterns.Dropdown
-		.AbstractDropdownConfig {
+	export abstract class AbstractVirtualSelectConfig
+		extends OSFramework.OSUI.Patterns.Dropdown.AbstractDropdownConfig
+	{
 		// Store grouped options
 		private _groupedOptionsList: GroupDropDownOption[];
 		// Store the Provider Options
@@ -199,6 +200,7 @@ namespace Providers.OSUI.Dropdown.VirtualSelect {
 				selectedValue: this.getSelectedValues() as [],
 				showDropboxAsPopup: this.ShowDropboxAsPopup,
 				popupDropboxBreakpoint: this.PopupDropboxBreakpoint,
+				showSecureTextWarning: false,
 				silentInitialValueSet: true,
 				textDirection: OutSystems.OSUI.Utils.GetIsRTL()
 					? OSFramework.OSUI.GlobalEnum.Direction.RTL

--- a/src/scripts/Providers/OSUI/Dropdown/VirtualSelect/AbstractVirtualSelectEnum.ts
+++ b/src/scripts/Providers/OSUI/Dropdown/VirtualSelect/AbstractVirtualSelectEnum.ts
@@ -5,7 +5,7 @@ namespace Providers.OSUI.Dropdown.VirtualSelect.Enum {
 	 */
 	export enum ProviderInfo {
 		Name = 'VirtualSelect',
-		Version = '1.2.0',
+		Version = '1.3.0',
 	}
 
 	/**

--- a/src/scripts/Providers/OSUI/Dropdown/VirtualSelect/README.md
+++ b/src/scripts/Providers/OSUI/Dropdown/VirtualSelect/README.md
@@ -1,3 +1,3 @@
-# VirtualSelect · ![virtualselect version](https://img.shields.io/badge/version-v1.2.0-informational)
+# VirtualSelect · ![virtualselect version](https://img.shields.io/badge/version-v1.3.0-informational)
 
 All info about this Provider <a href="https://sa-si-dev.github.io/virtual-select/#/">here</a>.

--- a/src/scripts/Providers/OSUI/Dropdown/VirtualSelect/VirtualSelect.d.ts
+++ b/src/scripts/Providers/OSUI/Dropdown/VirtualSelect/VirtualSelect.d.ts
@@ -105,6 +105,7 @@ namespace Providers.OSUI.Dropdown.VirtualSelect {
 		setValueAsArray?: boolean;
 		showDropboxAsPopup?: boolean;
 		showOptionsOnlyOnSearch?: boolean;
+		showSecureTextWarning?: boolean;
 		showSelectedOptionsFirst?: boolean;
 		showValueAsTags?: boolean;
 		silentInitialValueSet?: boolean;

--- a/src/scripts/Providers/OSUI/Dropdown/VirtualSelect/scss/_virtualselect_lib.scss
+++ b/src/scripts/Providers/OSUI/Dropdown/VirtualSelect/scss/_virtualselect_lib.scss
@@ -1,5 +1,5 @@
 /*!
- * Virtual Select v1.2.0
+ * Virtual Select v1.3.0
  * https://sa-si-dev.github.io/virtual-select
  * Licensed under MIT (https://github.com/sa-si-dev/virtual-select/blob/master/LICENSE)
  */


### PR DESCRIPTION
This PR is to update the VirtualSelect library to the latest pre-release **v1.3.0**

### What was done

- Updated Virtual Select provider to the latest pre-release **v1.3.0**
    - _Note:_  couldn’t create an npm since the GH failed for permission, and [this](https://github.com/OutSystems/outsystems-ui/blob/b207c90e3391e7030e3e252a8b53ee34f53a609e/package.json#L70 ) will be outdated   


### Checklist

-   [X] tested locally
-   [X] documented the code
-   [X] clean all warnings and errors of eslint
-   [X] requires changes in OutSystems (if so, provide a module with changes)
-   [ ] requires new sample page in OutSystems (if so, provide a module with changes)
