### PR TITLE
ROU-12856: Correct behavior for Dropdown when properties update

### DIFF
--- a/src/scripts/Providers/OSUI/Dropdown/VirtualSelect/AbstractVirtualSelect.ts
+++ b/src/scripts/Providers/OSUI/Dropdown/VirtualSelect/AbstractVirtualSelect.ts
@@ -135,12 +135,6 @@ namespace Providers.OSUI.Dropdown.VirtualSelect {
 		 * @memberof Providers.OSUI.Dropdown.VirtualSelect.AbstractVirtualSelect
 		 */
 		protected createProviderInstance(): void {
-			// Stores the values selected before provider recreation
-			// when there is a rerender of this component.
-			if (this.provider !== undefined) {
-				this.configs.StartingSelection = this.provider.getSelectedOptions();
-			}
-
 			// Create the provider instance
 			this.provider = window.VirtualSelect.init(this.virtualselectOpts);
 
@@ -190,6 +184,26 @@ namespace Providers.OSUI.Dropdown.VirtualSelect {
 			 * - This way, Initialized Event will be triggered every time a redraw occurs.
 			 */
 			this.triggerPlatformInitializedEventCallback();
+		}
+
+		/**
+		 * Syncs selection from the live provider into {@link AbstractVirtualSelectConfig.StartingSelection},
+		 * then builds provider options and creates the instance.
+		 *
+		 * @protected
+		 * @memberof Providers.OSUI.Dropdown.VirtualSelect.AbstractVirtualSelect
+		 */
+		protected prepareConfigs(): void {
+			const selected = this.provider?.getSelectedOptions();
+			if (selected) {
+				this.configs.StartingSelection = [selected].flat() as DropDownOption[];
+			}
+
+			// Get the library configurations
+			this.virtualselectOpts = this.configs.getProviderConfig();
+
+			// Instance will be Created!
+			this.createProviderInstance();
 		}
 
 		/**
@@ -528,6 +542,5 @@ namespace Providers.OSUI.Dropdown.VirtualSelect {
 
 		// Common methods all Dropdowns must implement!
 		protected abstract getSelectedOptionsStructure(): DropDownOption[];
-		protected abstract prepareConfigs(): void;
 	}
 }

--- a/src/scripts/Providers/OSUI/Dropdown/VirtualSelect/Search/VirtualSelectSearch.ts
+++ b/src/scripts/Providers/OSUI/Dropdown/VirtualSelect/Search/VirtualSelectSearch.ts
@@ -32,20 +32,6 @@ namespace Providers.OSUI.Dropdown.VirtualSelect.Search {
 		}
 
 		/**
-		 * Method that will set the provider configurations in order to properly create its instance
-		 *
-		 * @protected
-		 * @memberof Providers.OSUI.Dropdown.VirtualSelect.Search.OSUIVirtualSelectSearch
-		 */
-		protected prepareConfigs(): void {
-			// Get the library configurations
-			this.virtualselectOpts = this.configs.getProviderConfig();
-
-			// Instance will be Created!
-			this.createProviderInstance();
-		}
-
-		/**
 		 * Update property value from a given property name at OnParametersChange
 		 *
 		 * @param {string} propertyName the name of the property that will be changed

--- a/src/scripts/Providers/OSUI/Dropdown/VirtualSelect/Tags/VirtualSelectTags.ts
+++ b/src/scripts/Providers/OSUI/Dropdown/VirtualSelect/Tags/VirtualSelectTags.ts
@@ -19,19 +19,5 @@ namespace Providers.OSUI.Dropdown.VirtualSelect.Tags {
 
 			return optionsSelected;
 		}
-
-		/**
-		 * Method that will set the provider configurations in order to properly create its instance
-		 *
-		 * @protected
-		 * @memberof Providers.OSUI.Dropdown.VirtualSelect.Tags.OSUIVirtualSelectTags
-		 */
-		protected prepareConfigs(): void {
-			// Get the library configurations
-			this.virtualselectOpts = this.configs.getProviderConfig();
-
-			// Instance will be Created!
-			this.createProviderInstance();
-		}
 	}
 }


### PR DESCRIPTION
This PR is to correct a misbehavior that removed the selected options when the list of Dropdown's options changes in the middle of execution

### What was happening

- When the Dropdown's options changed during execution the dropdown was recreated, but the values were not kept since they were being preserved too late and not in the right format.

### What was done

- The preservation of the selected values was anticipated
- Ensured that the selected options are always an array 

### Test Steps

1. Open the sample application
2. Select an option in dropdown 1, dropdown 2 and dropdown 3
3. Validate that in the end all Dropdowns have the correct value

### Checklist

-   [ ] tested locally
-   [ ] documented the code
-   [ ] clean all warnings and errors of eslint
-   [ ] requires changes in OutSystems (if so, provide a module with changes)
-   [ ] requires new sample page in OutSystems (if so, provide a module with changes)
