### PR TITLE
ROU-11724: Update TypeScript and Typedoc to use the latest stable versions 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -113,3 +113,6 @@ new-version-artf.txt
 
 # Distribution files folder
 dist/**
+
+# Generated TypeDoc output
+docs/

--- a/package.json
+++ b/package.json
@@ -63,10 +63,10 @@
 		"stylelint": "^14.16.1",
 		"stylelint-config-prettier": "^9.0.5",
 		"stylelint-order": "^6.0.4",
-		"typedoc": "^0.23.28",
-		"typedoc-plugin-merge-modules": "^4.1.0",
-		"typedoc-umlclass": "^0.7.1",
-		"typescript": "^4.9.5",
+		"typedoc": "^0.28.19",
+		"typedoc-plugin-merge-modules": "^7.0.0",
+		"typedoc-umlclass": "^0.10.2",
+		"typescript": "^5.9.3",
 		"virtual-select-plugin": "^1.1.0"
 	}
 }

--- a/typedoc.json
+++ b/typedoc.json
@@ -5,11 +5,43 @@
         "./src/scripts/Providers/OSUI//*.ts"
     ],
     "entryPointStrategy": "expand",
+    "plugin": [
+        "typedoc-umlclass",
+        "typedoc-plugin-merge-modules"
+    ],
     "includeVersion": true,
     "hideGenerator": true,
     "out": "./docs",
     "sort": [
         "source-order"
+    ],
+    "blockTags": [
+        "@alpha",
+        "@beta",
+        "@defaultValue",
+        "@deprecated",
+        "@example",
+        "@experimental",
+        "@internal",
+        "@override",
+        "@param",
+        "@privateRemarks",
+        "@public",
+        "@remarks",
+        "@returns",
+        "@sealed",
+        "@see",
+        "@throws",
+        "@virtual",
+        "@memberof",
+        "@export",
+        "@static",
+        "@todo",
+        "@return",
+        "@extends",
+        "@template",
+        "@type",
+        "@implements"
     ],
     "umlClassDiagram": {
         "type": "detailed",
@@ -19,5 +51,10 @@
         "boxBackgroundColor": "#fff",
         "boxBorderColor": "#272b30",
         "arrowColor": "#272b30"
+    },
+    "validation": {
+        "notExported": false,
+        "invalidLink": true,
+        "notDocumented": false
     }
 }


### PR DESCRIPTION


### What was done
- update typescript, typedoc and its plugins;

### Test Steps

1. Run npm run docs and check there are no errors.

### Checklist

-   [x] tested locally
-   [ ] documented the code
-   [ ] clean all warnings and errors of eslint
-   [ ] requires changes in OutSystems (if so, provide a module with changes)
-   [ ] requires new sample page in OutSystems (if so, provide a module with changes)
