### PR TITLE
ROU-12882: Submenu hide arrow when there are no options

### DIFF
--- a/src/scss/01-foundations/_icon-library-odc.scss
+++ b/src/scss/01-foundations/_icon-library-odc.scss
@@ -123,6 +123,7 @@ body.iconLibrary-phosphor {
 // Submenu – header arrow
 .osui-submenu {
 	&__header__icon {
+		display: none;
 		margin-inline-start: var(--space-s);
 		transition: transform 200ms ease;
 		transform-origin: center;
@@ -130,6 +131,12 @@ body.iconLibrary-phosphor {
 		&:after {
 			content: var(--osui-icon-arrow-down);
 			font-family: var(--osui-icon-font-family);
+		}
+	}
+
+	&--is-dropdown {
+		.osui-submenu__header__icon {
+			display: inline-flex;
 		}
 	}
 


### PR DESCRIPTION
This PR is for fix the Submenu when there are no options available

### What was happening

- When there were no options in the Submenu the arrow was still present in ODC

### What was done

- A default CSS rule was added to ensure that the arrow is hidden and only visible if there are any option

### Test Steps

1. Open the sample application
2. Validate that the first submenu has options and the arrow icon
3. Validate that the second menu don't have options neither the arrow icon


### Checklist

-   [ ] tested locally
-   [ ] documented the code
-   [ ] clean all warnings and errors of eslint
-   [ ] requires changes in OutSystems (if so, provide a module with changes)
-   [ ] requires new sample page in OutSystems (if so, provide a module with changes)
