### PR TITLE
ROU-12888: fix dropdown arrow position inside form

### DIFF
--- a/src/scss/01-foundations/_icon-library-odc.scss
+++ b/src/scss/01-foundations/_icon-library-odc.scss
@@ -167,6 +167,12 @@ body.iconLibrary-phosphor {
 	}
 }
 
+.form {
+	.dropdown-container[class*="ThemeGrid_Width"]:has(select):after {
+		top: calc(50% - var(--space-m) / 2);
+	}
+}
+
 // Table Widget - Sortable Icon
 .sortable-icon {
 	display: inline-block;

--- a/src/scss/03-widgets/_form.scss
+++ b/src/scss/03-widgets/_form.scss
@@ -57,9 +57,6 @@
 	}
 
 	.dropdown-container {
-		&:after {
-			top: calc(50% - var(--space-m) / 2);
-		}
 
 		&[class*='ThemeGrid_Width'].not-valid span.validation-message {
 			bottom: 4px;


### PR DESCRIPTION
This pull request updates the vertical alignment of the dropdown arrow in form dropdowns by moving the relevant CSS rule from the general widget styles to a more specific context. This helps ensure the alignment is only applied when appropriate and avoids unintended side effects.

**Form dropdown alignment fix:**

* Moved the CSS rule that sets the vertical alignment of the dropdown arrow (`top: calc(50% - var(--space-m) / 2);`) from the general `.dropdown-container:after` selector in `_form.scss` to a more specific selector under `.form` in `_icon-library-odc.scss`, targeting only dropdowns inside forms with a `select` element. [[1]](diffhunk://#diff-61eecf4111f97c170d87099b74d226b4d5676900443ee2ba57203dcef9608853R170-R175) [[2]](diffhunk://#diff-ce8faac88bc2528ee319538422babcd20677237966636d29c9047f269b664a70L60-L62)

### Checklist

-   [x] tested locally
-   [ ] documented the code
-   [ ] clean all warnings and errors of eslint
-   [ ] requires changes in OutSystems (if so, provide a module with changes)
-   [ ] requires new sample page in OutSystems (if so, provide a module with changes)
