### PR TITLE
ROU-12566: InlineSVG - Add new A11Y config api

### DIFF
--- a/src/scripts/OSFramework/OSUI/Constants.ts
+++ b/src/scripts/OSFramework/OSUI/Constants.ts
@@ -46,6 +46,7 @@ namespace OSFramework.OSUI.Constants {
 			Button: 'button',
 			Complementary: 'complementary',
 			Dialog: 'dialog',
+			Img: 'img',
 			List: 'list',
 			Listbox: 'listbox',
 			Listitem: 'listitem',

--- a/src/scripts/OSFramework/OSUI/GlobalEnum.ts
+++ b/src/scripts/OSFramework/OSUI/GlobalEnum.ts
@@ -187,6 +187,7 @@ namespace OSFramework.OSUI.GlobalEnum {
 		Inert = 'inert',
 		Lang = 'lang',
 		Name = 'name',
+		Role = 'role',
 		StatusBar = 'data-status-bar-height',
 		Style = 'style',
 		Type = 'type',

--- a/src/scripts/OSFramework/OSUI/Pattern/InlineSvg/Enum.ts
+++ b/src/scripts/OSFramework/OSUI/Pattern/InlineSvg/Enum.ts
@@ -13,4 +13,10 @@ namespace OSFramework.OSUI.Patterns.InlineSvg.Enum {
 	export enum Properties {
 		SVGCode = 'SVGCode',
 	}
+
+	export enum A11YType {
+		Decorative = 'Decorative',
+		Informative = 'Informative',
+		Interactive = 'Interactive',
+	}
 }

--- a/src/scripts/OSFramework/OSUI/Pattern/InlineSvg/InlineSvg.ts
+++ b/src/scripts/OSFramework/OSUI/Pattern/InlineSvg/InlineSvg.ts
@@ -1,9 +1,18 @@
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 namespace OSFramework.OSUI.Patterns.InlineSvg {
+	// Type for the A11Y options
+	export type InlineSvgA11YOptions = {
+		label?: string;
+		type: Enum.A11YType;
+	};
+
 	/**
 	 * Defines the interface for OutSystemsUI Patterns
 	 */
 	export class InlineSvg extends AbstractPattern<InlineSvgConfig> implements IInlineSvg {
+		// Store the svg html element
+		private _svgElement: HTMLElement;
+
 		/**
 		 * Creates an instance of InlineSvg.
 		 *
@@ -22,6 +31,7 @@ namespace OSFramework.OSUI.Patterns.InlineSvg {
 				console.error('Please provide a valid SVGCode.');
 			} else {
 				this.selfElement.innerHTML = this.configs.SVGCode;
+				this._svgElement = this.selfElement.querySelector('svg') as unknown as HTMLElement;
 			}
 		}
 
@@ -73,6 +83,53 @@ namespace OSFramework.OSUI.Patterns.InlineSvg {
 		 */
 		protected unsetHtmlElements(): void {
 			console.log(GlobalEnum.WarningMessages.MethodNotImplemented);
+		}
+
+		/**
+		 * Method to apply the A11Y properties to the InlineSvg
+		 *
+		 * @param {string} options
+		 * @memberof OSFramework.Patterns.InlineSvg.InlineSvg
+		 */
+		public applyA11YProperties(options: string): void {
+			try {
+				const a11yOptions = JSON.parse(options) as InlineSvgA11YOptions;
+
+				switch (a11yOptions.type) {
+					case Enum.A11YType.Decorative:
+						Helper.A11Y.AriaHiddenTrue(this._svgElement);
+						Helper.Dom.Attribute.Remove(this._svgElement, GlobalEnum.HTMLAttributes.Role);
+						break;
+
+					case Enum.A11YType.Informative:
+						Helper.Dom.Attribute.Set(
+							this._svgElement,
+							GlobalEnum.HTMLAttributes.Role,
+							Constants.A11YAttributes.Role.Img
+						);
+						if (a11yOptions.label) Helper.A11Y.AriaLabel(this._svgElement, a11yOptions.label);
+						break;
+
+					case Enum.A11YType.Interactive:
+						Helper.Dom.Attribute.Set(
+							this._svgElement,
+							GlobalEnum.HTMLAttributes.Role,
+							Constants.A11YAttributes.Role.Button
+						);
+						Helper.Dom.Attribute.Set(
+							this._svgElement,
+							Constants.A11YAttributes.TabIndex,
+							Constants.A11YAttributes.States.TabIndexShow
+						);
+						if (a11yOptions.label) Helper.A11Y.AriaLabel(this._svgElement, a11yOptions.label);
+						break;
+
+					default:
+						throw new Error(`Invalid accessibility type: ${a11yOptions.type}`);
+				}
+			} catch (error) {
+				throw new Error(`Error on set accessibility properties: ${error}`);
+			}
 		}
 
 		/**

--- a/src/scripts/OutSystems/OSUI/ErrorCodes.ts
+++ b/src/scripts/OutSystems/OSUI/ErrorCodes.ts
@@ -314,6 +314,7 @@ namespace OutSystems.OSUI.ErrorCodes {
 		FailChangeProperty: 'OSUI-API-29001',
 		FailDispose: 'OSUI-API-29002',
 		FailRegisterCallback: 'OSUI-API-29003',
+		FailSetAccessibilityProperties: 'OSUI-API-29004',
 	};
 
 	export const OverflowMenu = {

--- a/src/scripts/OutSystems/OSUI/Patterns/InlineSvgAPI.ts
+++ b/src/scripts/OutSystems/OSUI/Patterns/InlineSvgAPI.ts
@@ -128,4 +128,25 @@ namespace OutSystems.OSUI.Patterns.InlineSvgAPI {
 
 		return result;
 	}
+
+	/**
+	 * Function to set the accessibility properties of the InlineSvg
+	 *
+	 * @export
+	 * @param {string} inlineSvgId
+	 * @param {string} a11yOptions
+	 * @return {*} {string} Return Message Success or message of error info if it's the case.
+	 */
+	export function SetAccessibilityProperties(inlineSvgId: string, a11yOptions: string): string {
+		const result = OutSystems.OSUI.Utils.CreateApiResponse({
+			errorCode: ErrorCodes.InlineSvg.FailSetAccessibilityProperties,
+			callback: () => {
+				const _InlineSvgItem = this.GetInlineSvgById(inlineSvgId);
+
+				_InlineSvgItem.applyA11YProperties(a11yOptions);
+			},
+		});
+
+		return result;
+	}
 }


### PR DESCRIPTION
This pull request introduces accessibility (a11y) improvements for the `InlineSvg` pattern, allowing developers to specify and programmatically set accessibility properties for SVG elements. The changes add support for decorative, informative, and interactive SVGs, and expose a new API for setting these properties. 

**Accessibility Enhancements for InlineSvg:**

* Added an `A11YType` enum to `InlineSvg` for specifying SVG accessibility roles: Decorative, Informative, and Interactive.
* Introduced the `InlineSvgA11YOptions` type and the `applyA11YProperties` method to the `InlineSvg` class, enabling dynamic application of accessibility attributes (such as `aria-hidden`, `role`, `aria-label`, and `tabindex`) based on the specified type and label. [[1]](diffhunk://#diff-5a800a28a2c9cf2ec1514547caa051c9a0303ab04c129fb213762449bba1d58aR3-R15) [[2]](diffhunk://#diff-5a800a28a2c9cf2ec1514547caa051c9a0303ab04c129fb213762449bba1d58aR88-R134) [[3]](diffhunk://#diff-5a800a28a2c9cf2ec1514547caa051c9a0303ab04c129fb213762449bba1d58aR34)

**API and Error Handling:**

* Added a new API function `SetAccessibilityProperties` in `InlineSvgAPI` to allow programmatic setting of accessibility properties for a given InlineSvg instance, with error handling.
