### PR TITLE
ROU-12881: Add danger/border-primary/primary-active theme-layer roles

### DIFF
--- a/src/scss/01-foundations/_root.scss
+++ b/src/scss/01-foundations/_root.scss
@@ -32,11 +32,13 @@
 	--color-border-subtlest: #{$token-border-subtlest};
 	--color-border-input: #{$token-border-input-default};
 	--color-border-input-press: #{$token-border-input-press};
+	--color-border-primary: #{$token-border-primary}; // border-specific primary tier (focus rings)
 
 	// ─── Theme layer · brand / status / neutral (also read by TS GetColorValueFromColorType) ──
 	--color-primary: #{$token-semantics-primary-base};
 	--color-primary-hover: #{$token-semantics-primary-800};
-	--color-primary-selected: #{$token-semantics-primary-900};
+	--color-primary-selected: #{$token-semantics-primary-900}; // translucent-wash role for selected rows/items; apps override this
+	--color-primary-active: #{$token-semantics-primary-900}; // solid pressed/active-state role — do not alias to -selected above
 	--color-secondary: #303d60;
 	--color-neutral: #{$token-primitives-neutral-500};
 	--color-neutral-0: #{$token-primitives-neutral-100};
@@ -51,6 +53,8 @@
 	--color-neutral-9: #{$token-primitives-neutral-1100};
 	--color-neutral-10: #{$token-primitives-neutral-1200};
 	--color-error: #{$token-semantics-danger-base};
+	--color-border-danger: #{$token-border-danger-default}; // border-specific danger tier (form validation)
+	--color-text-danger: #{$token-text-danger}; // text-specific danger tier (form validation)
 	--color-warning: #{$token-semantics-warning-base};
 	--color-success: #{$token-semantics-success-base};
 	--color-info: #{$token-semantics-info-base};


### PR DESCRIPTION
This PR is for adding the shared theme-layer color roles that the widget CSS-API alignment PRs build on.

### What was happening
* The framework theme layer (`_root.scss`) had no dedicated role for a danger-tier **border**, a danger-tier **text** color, a primary-tier **focus-ring border**, or a solid **pressed/active** primary color.
* Widgets that needed those states were hardcoding the underlying `$token-*` tier locally (drift risk), or reusing `--color-primary-selected` — whose established meaning is a *translucent selection wash* that OutSystems apps override in their default `:root` theme, which leaked into pressed states.

### What was done
* Added four theme-layer role knobs to `src/scss/01-foundations/_root.scss`, each defaulting through the matching design token:
  * `--color-border-danger` → border-specific danger tier (form-validation borders)
  * `--color-text-danger` → text-specific danger tier (validation messages)
  * `--color-border-primary` → primary tier for focus-ring borders
  * `--color-primary-active` → solid pressed/active state, distinct from the translucent `--color-primary-selected` wash
* No component rule touched — **no visual change on its own**. The follow-up widget PRs adopt these roles.

### Test Steps
This PR has no visual output to verify; it only introduces CSS custom properties. To confirm they resolve:
1. Build/serve Storybook and open any page.
2. In DevTools, inspect `:root` (the `<html>` element) → **Computed** / **Styles**.
3. Confirm these custom properties are present and resolve to a color:
   * `--color-border-danger`
   * `--color-text-danger`
   * `--color-border-primary`
   * `--color-primary-active`
4. Confirm the pre-existing `--color-primary-selected` still resolves to its previous value (unchanged).

### Screenshots
(prefer animated gif)

### Checklist
* [ ] tested locally
* [ ] documented the code
* [ ] clean all warnings and errors of eslint
* [ ] requires changes in OutSystems (if so, provide a module with changes)
* [ ] requires new sample page in OutSystems (if so, provide a module with changes)
