### PR TITLE
ROU-12881: Align form-field widgets with Figma (input, textarea, dropdown, form)

### DIFF
--- a/docs/css-api-reference.md
+++ b/docs/css-api-reference.md
@@ -95,10 +95,15 @@ _File: `src/scss/03-widgets/_dropdown.scss`_
 | Property | Default |
 |---|---|
 | `--osui-dropdown-background` | `var(--color-background-input)` |
-| `--osui-dropdown-border-color` | `var(--color-border)` |
+| `--osui-dropdown-border-color` | `var(--color-border-input)` |
+| `--osui-dropdown-border-width` | `#{$token-border-size-025}` |
 | `--osui-dropdown-color` | `var(--color-text)` |
 | `--osui-dropdown-border-radius` | `var(--border-radius-soft)` |
+| `--osui-dropdown-list-background` | `var(--color-background-surface)` |
+| `--osui-dropdown-list-border-color` | `var(--color-border)` |
 | `--osui-dropdown-list-max-height` | `240px` |
+| `--osui-dropdown-focus-border-color` | `var(--color-border-primary)` |
+| `--osui-dropdown-focus-ring-color` | `#{$token-border-focus-default}` |
 
 ### Feedback Message (`.feedback-message`)
 _File: `src/scss/03-widgets/_feedback-message.scss`_
@@ -149,11 +154,13 @@ _File: `src/scss/03-widgets/_inputs-and-textareas.scss`_
 | Property | Default |
 |---|---|
 | `--osui-input-background` | `var(--color-background-input)` |
-| `--osui-input-border-color` | `var(--color-border)` |
+| `--osui-input-border-color` | `var(--color-border-input)` |
+| `--osui-input-hover-border-color` | `var(--color-border-input-press)` |
 | `--osui-input-color` | `var(--color-text)` |
 | `--osui-input-border-radius` | `var(--border-radius-soft)` |
-| `--osui-input-focus-border-color` | `var(--color-primary)` |
-| `--osui-input-error-border-color` | `var(--color-error)` |
+| `--osui-input-focus-border-color` | `var(--color-border-primary)` |
+| `--osui-input-focus-ring-color` | `#{$token-border-focus-default}` |
+| `--osui-input-error-border-color` | `var(--color-border-danger)` |
 
 ### List Item (`.list-item`)
 _File: `src/scss/03-widgets/_list-item.scss`_
@@ -900,4 +907,4 @@ _File: `src/scss/01-foundations/_root.scss`_
 
 ---
 
-<sub>385 properties across 75 components, generated from `src/scss`.</sub>
+<sub>392 properties across 75 components, generated from `src/scss`.</sub>

--- a/src/scss/01-foundations/_root.scss
+++ b/src/scss/01-foundations/_root.scss
@@ -32,11 +32,13 @@
 	--color-border-subtlest: #{$token-border-subtlest};
 	--color-border-input: #{$token-border-input-default};
 	--color-border-input-press: #{$token-border-input-press};
+	--color-border-primary: #{$token-border-primary}; // border-specific primary tier (focus rings)
 
 	// ─── Theme layer · brand / status / neutral (also read by TS GetColorValueFromColorType) ──
 	--color-primary: #{$token-semantics-primary-base};
 	--color-primary-hover: #{$token-semantics-primary-800};
-	--color-primary-selected: #{$token-semantics-primary-900};
+	--color-primary-selected: #{$token-semantics-primary-900}; // translucent-wash role for selected rows/items; apps override this
+	--color-primary-active: #{$token-semantics-primary-900}; // solid pressed/active-state role — do not alias to -selected above
 	--color-secondary: #303d60;
 	--color-neutral: #{$token-primitives-neutral-500};
 	--color-neutral-0: #{$token-primitives-neutral-100};
@@ -51,6 +53,8 @@
 	--color-neutral-9: #{$token-primitives-neutral-1100};
 	--color-neutral-10: #{$token-primitives-neutral-1200};
 	--color-error: #{$token-semantics-danger-base};
+	--color-border-danger: #{$token-border-danger-default}; // border-specific danger tier (form validation)
+	--color-text-danger: #{$token-text-danger}; // text-specific danger tier (form validation)
 	--color-warning: #{$token-semantics-warning-base};
 	--color-success: #{$token-semantics-success-base};
 	--color-info: #{$token-semantics-info-base};

--- a/src/scss/03-widgets/_dropdown.scss
+++ b/src/scss/03-widgets/_dropdown.scss
@@ -87,7 +87,7 @@
 		.dropdown-popup-row {
 			align-items: center;
 			color: var(--color-text);
-				cursor: pointer;
+			cursor: pointer;
 			display: flex;
 			justify-content: space-between;
 			padding: #{$token-scale-200} #{$token-scale-400};

--- a/src/scss/03-widgets/_dropdown.scss
+++ b/src/scss/03-widgets/_dropdown.scss
@@ -108,15 +108,15 @@
 					font-family: var(--osui-icon-font-family);
 					font-size: $token-font-size-400;
 					margin-left: $token-scale-200;
-						}
+				}
 			}
 
 			span {
 				overflow: hidden;
 				text-overflow: ellipsis;
 				white-space: nowrap;
-				}
 			}
+		}
 
 		.scrollable-list-with-scroll {
 			background: none;
@@ -129,7 +129,7 @@
 				content: none;
 			}
 		}
-		}
+	}
 
 	// Is expanded
 	&-expanded {

--- a/src/scss/03-widgets/_dropdown.scss
+++ b/src/scss/03-widgets/_dropdown.scss
@@ -7,10 +7,15 @@
 	&-container {
 		// ─── Component CSS API ─────────────────────────────────────────────
 		--osui-dropdown-background: var(--color-background-input);
-		--osui-dropdown-border-color: var(--color-border);
+		--osui-dropdown-border-color: var(--color-border-input);
+		--osui-dropdown-border-width: #{$token-border-size-025};
 		--osui-dropdown-color: var(--color-text);
 		--osui-dropdown-border-radius: var(--border-radius-soft);
+		--osui-dropdown-list-background: var(--color-background-surface);
+		--osui-dropdown-list-border-color: var(--color-border);
 		--osui-dropdown-list-max-height: 240px;
+		--osui-dropdown-focus-border-color: var(--color-border-primary);
+		--osui-dropdown-focus-ring-color: #{$token-border-focus-default};
 		// ───────────────────────────────────────────────────────────────────
 
 		cursor: initial;
@@ -25,7 +30,7 @@
 			&.dropdown-display {
 				align-items: center;
 				background-color: var(--osui-dropdown-background);
-				border: $token-border-size-025 solid var(--osui-dropdown-border-color);
+				border: var(--osui-dropdown-border-width) solid var(--osui-dropdown-border-color);
 				border-radius: var(--osui-dropdown-border-radius);
 				color: var(--osui-dropdown-color);
 				cursor: pointer;
@@ -35,30 +40,30 @@
 				padding: $token-scale-0 $token-scale-400;
 				width: 100%;
 
-				&:hover {
-					border: $token-border-size-025 solid var(--color-border-input);
-				}
-
 				&:focus {
-					border: $token-border-size-025 solid $token-semantics-primary-base;
+					border: var(--osui-dropdown-border-width) solid var(--osui-dropdown-focus-border-color);
+					box-shadow: 0 0 0 $token-border-size-050 var(--osui-dropdown-focus-ring-color);
+					outline: none;
 				}
 			}
 		}
 
 		&.not-valid {
-			&.dropdown-expanded > div.dropdown-display,
+			div.dropdown-display,
 			& > select.dropdown-display {
-				border: $token-border-size-025 solid $token-semantics-danger-base;
+				border: var(--osui-dropdown-border-width) solid var(--color-border-danger);
 			}
 		}
 
 		&.dropdown-expanded > div.dropdown-display {
-			border: $token-border-size-025 solid $token-semantics-primary-base;
+			border: var(--osui-dropdown-border-width) solid var(--osui-dropdown-focus-border-color);
+			box-shadow: 0 0 0 $token-border-size-050 var(--osui-dropdown-focus-ring-color);
 		}
 
 		& > div.dropdown-list {
-			border: $token-border-size-025 solid var(--color-border);
-			border-radius: var(--border-radius-soft);
+			background-color: var(--osui-dropdown-list-background);
+			border: var(--osui-dropdown-border-width) solid var(--osui-dropdown-list-border-color);
+			border-radius: var(--osui-dropdown-border-radius);
 			box-shadow: var(--osui-elevation-overlay);
 			left: 0 !important;
 			max-height: var(--osui-dropdown-list-max-height);
@@ -83,9 +88,8 @@
 			align-items: center;
 			color: var(--color-text);
 			display: flex;
-			height: $token-scale-1100;
 			justify-content: space-between;
-			padding: $token-scale-0 $token-scale-400;
+			padding: #{$token-scale-200} #{$token-scale-400};
 
 			&:hover,
 			&-selected:hover {
@@ -95,7 +99,6 @@
 			&-selected {
 				background: none;
 				color: var(--color-text);
-				font-weight: $token-font-weight-semi-bold;
 
 				// Right-side checkmark — requires --osui-icon-check + --osui-icon-font-family (icon library)
 				&::after {
@@ -105,15 +108,15 @@
 					font-family: var(--osui-icon-font-family);
 					font-size: $token-font-size-400;
 					margin-left: $token-scale-200;
-				}
+						}
 			}
 
 			span {
 				overflow: hidden;
 				text-overflow: ellipsis;
 				white-space: nowrap;
+				}
 			}
-		}
 
 		.scrollable-list-with-scroll {
 			background: none;
@@ -126,7 +129,7 @@
 				content: none;
 			}
 		}
-	}
+		}
 
 	// Is expanded
 	&-expanded {
@@ -206,10 +209,6 @@ select.dropdown-display[disabled] {
 		& > select {
 			&.dropdown-display {
 				border-color: var(--color-border-input);
-
-				&:hover {
-					border-color: var(--color-border-input-press);
-				}
 			}
 		}
 

--- a/src/scss/03-widgets/_dropdown.scss
+++ b/src/scss/03-widgets/_dropdown.scss
@@ -87,6 +87,7 @@
 		.dropdown-popup-row {
 			align-items: center;
 			color: var(--color-text);
+				cursor: pointer;
 			display: flex;
 			justify-content: space-between;
 			padding: #{$token-scale-200} #{$token-scale-400};

--- a/src/scss/03-widgets/_form.scss
+++ b/src/scss/03-widgets/_form.scss
@@ -91,7 +91,7 @@
 
 ///
 span.validation-message {
-	color: $token-semantics-danger-base;
+	color: var(--color-text-danger);
 	font-size: $token-font-size-300;
 	margin-left: $token-scale-0;
 }

--- a/src/scss/03-widgets/_inputs-and-textareas.scss
+++ b/src/scss/03-widgets/_inputs-and-textareas.scss
@@ -21,11 +21,13 @@
 .form-control {
 	// ─── Component CSS API ─────────────────────────────────────────────
 	--osui-input-background:          var(--color-background-input);
-	--osui-input-border-color:        var(--color-border);
+	--osui-input-border-color:        var(--color-border-input);
+	--osui-input-hover-border-color:  var(--color-border-input-press);
 	--osui-input-color:               var(--color-text);
 	--osui-input-border-radius:       var(--border-radius-soft);
-	--osui-input-focus-border-color:  var(--color-primary);
-	--osui-input-error-border-color:  var(--color-error);
+	--osui-input-focus-border-color:  var(--color-border-primary);
+	--osui-input-focus-ring-color:    #{$token-border-focus-default};
+	--osui-input-error-border-color:  var(--color-border-danger);
 	// ───────────────────────────────────────────────────────────────────
 
 	&[data-input],
@@ -38,17 +40,18 @@
 		transition: border-color $token-transition-time-100 $token-transition-curve-base, background-color $token-transition-time-100 $token-transition-curve-base;
 
 		&:hover {
-			border-color: var(--color-border-input);
+			border-color: var(--osui-input-hover-border-color);
 		}
 
 		&:focus {
 			border-color: var(--osui-input-focus-border-color);
+			box-shadow: 0 0 0 $token-border-size-050 var(--osui-input-focus-ring-color);
 			outline: none;
 		}
 
 		&[disabled] {
 			--osui-input-background:   var(--color-background-input-disabled);
-			--osui-input-border-color: var(--color-border);
+			--osui-input-border-color: var(--color-border-input);
 			--osui-input-color:        var(--color-text-disabled);
 
 			background-color: var(--osui-input-background);
@@ -109,9 +112,9 @@
 ///
 .form label,
 [data-label] {
-	color: var(--color-text);
+	color: var(--color-text-subtlest);
 	font-size: $token-font-size-350;
-	font-weight: $token-font-weight-semi-bold;
+	font-weight: $token-font-weight-regular;
 	line-height: var(--osui-font-line-height-default);
 }
 
@@ -124,7 +127,7 @@
 }
 
 span.validation-message {
-	color: $token-semantics-danger-base;
+	color: var(--color-text-danger);
 	display: block;
 	font-size: $token-font-size-300;
 	margin-top: $token-scale-100;

--- a/stories/CssApiReference.mdx
+++ b/stories/CssApiReference.mdx
@@ -100,10 +100,15 @@ _File: `src/scss/03-widgets/_dropdown.scss`_
 | Property | Default |
 |---|---|
 | `--osui-dropdown-background` | `var(--color-background-input)` |
-| `--osui-dropdown-border-color` | `var(--color-border)` |
+| `--osui-dropdown-border-color` | `var(--color-border-input)` |
+| `--osui-dropdown-border-width` | `#{$token-border-size-025}` |
 | `--osui-dropdown-color` | `var(--color-text)` |
 | `--osui-dropdown-border-radius` | `var(--border-radius-soft)` |
+| `--osui-dropdown-list-background` | `var(--color-background-surface)` |
+| `--osui-dropdown-list-border-color` | `var(--color-border)` |
 | `--osui-dropdown-list-max-height` | `240px` |
+| `--osui-dropdown-focus-border-color` | `var(--color-border-primary)` |
+| `--osui-dropdown-focus-ring-color` | `#{$token-border-focus-default}` |
 
 ### Feedback Message (`.feedback-message`)
 _File: `src/scss/03-widgets/_feedback-message.scss`_
@@ -154,11 +159,13 @@ _File: `src/scss/03-widgets/_inputs-and-textareas.scss`_
 | Property | Default |
 |---|---|
 | `--osui-input-background` | `var(--color-background-input)` |
-| `--osui-input-border-color` | `var(--color-border)` |
+| `--osui-input-border-color` | `var(--color-border-input)` |
+| `--osui-input-hover-border-color` | `var(--color-border-input-press)` |
 | `--osui-input-color` | `var(--color-text)` |
 | `--osui-input-border-radius` | `var(--border-radius-soft)` |
-| `--osui-input-focus-border-color` | `var(--color-primary)` |
-| `--osui-input-error-border-color` | `var(--color-error)` |
+| `--osui-input-focus-border-color` | `var(--color-border-primary)` |
+| `--osui-input-focus-ring-color` | `#{$token-border-focus-default}` |
+| `--osui-input-error-border-color` | `var(--color-border-danger)` |
 
 ### List Item (`.list-item`)
 _File: `src/scss/03-widgets/_list-item.scss`_
@@ -905,4 +912,4 @@ _File: `src/scss/01-foundations/_root.scss`_
 
 ---
 
-<sub>385 properties across 75 components, generated from `src/scss`.</sub>
+<sub>392 properties across 75 components, generated from `src/scss`.</sub>

--- a/stories/widgets/Dropdown.stories.ts
+++ b/stories/widgets/Dropdown.stories.ts
@@ -1,32 +1,85 @@
 import type { Meta, StoryObj } from '@storybook/html-vite';
+import { Fragment } from 'react';
 import { Dropdown } from '@outsystems/runtime-widgets-js';
-import { createVariable, DataTypes, mountWidget, runtimeMock, widgetBaseProps } from '../_helpers/widget';
+import { createVariable, DataTypes, createElement, mountWidget, runtimeMock, widgetBaseProps } from '../_helpers/widget';
 
 // DropdownMode const enum → numeric: Text(native) 0, Custom 1.
 const OPTIONS = [
-	{ value: 'apple', label: 'Apple' },
-	{ value: 'banana', label: 'Banana' },
-	{ value: 'cherry', label: 'Cherry' },
+	{ value: 'Apple', label: 'Apple' },
+	{ value: 'Banana', label: 'Banana' },
+	{ value: 'Cherry', label: 'Cherry' },
 ];
 const meta: Meta = { title: 'Widgets/Dropdown' };
 export default meta;
 type Story = StoryObj;
 
+// Wrapper component that holds both dropdowns
+function DropdownsWrapper(props: any) {
+	const list = runtimeMock({ length: OPTIONS.length, getItem: (i: number) => OPTIONS[i] });
+
+	return createElement(Fragment, null,
+		// Container
+		createElement(
+			'div',
+			{ style: { display: 'flex', gap: '40px', padding: '20px', position: 'relative' } },
+			// Custom column
+			createElement(
+				'div',
+				{ style: { flex: '1', overflow: 'visible', position: 'relative' } },
+				createElement('h3', null, 'Custom (Mode 1)'),
+				createElement(Dropdown, {
+					...widgetBaseProps('dropdown-custom'),
+					...props,
+					variable: createVariable(DataTypes.DataTypes.Text, 'Banana'),
+					list,
+					dropdownMode: 1,
+					labels: (item: { label: string }) => item.label,
+					values: (item: { value: string }) => item.value,
+					emptyValue: '-- Select --',
+					mandatory: false,
+					enabled: true,
+					style: '',
+					onChange: () => {},
+					placeholders: runtimeMock({
+						content: runtimeMock({
+							render: (widget: any, itemList: any, callback: any) => {
+								const items: any[] = [];
+								for (let i = 0; i < itemList.length; i++) {
+									const item = itemList.getItem(i);
+									const label = item.label;
+									items.push(callback(label, i));
+								}
+								return items;
+							},
+						}),
+					}),
+				}),
+			),
+			// Native column
+			createElement(
+				'div',
+				{ style: { flex: '1' } },
+				createElement('h3', null, 'Native (Mode 0)'),
+				createElement(Dropdown, {
+					...widgetBaseProps('dropdown-native'),
+					...props,
+					variable: createVariable(DataTypes.DataTypes.Text, 'Banana'),
+					list,
+					dropdownMode: 0,
+					labels: (item: { label: string }) => item.label,
+					values: (item: { value: string }) => item.value,
+					emptyValue: '-- Select --',
+					mandatory: false,
+					enabled: true,
+					style: '',
+					onChange: () => {},
+					placeholders: null,
+				}),
+			),
+		),
+	);
+}
+
 export const Default: Story = {
-	render: () => {
-		const list = runtimeMock({ length: OPTIONS.length, getItem: (i: number) => OPTIONS[i] });
-		return mountWidget(Dropdown as never, {
-			...widgetBaseProps('dropdown'),
-			variable: createVariable(DataTypes.DataTypes.Text, 'banana'),
-			list,
-			dropdownMode: 0,
-			labels: (item: { label: string }) => item.label,
-			values: (item: { value: string }) => item.value,
-			emptyValue: '-- Select --',
-			mandatory: false,
-			enabled: true,
-			style: '',
-			onChange: () => {},
-		});
-	},
+	render: () => mountWidget(DropdownsWrapper as never, {}),
 };


### PR DESCRIPTION
This PR is for aligning the form-field widgets (Input, TextArea, Dropdown, Form validation) with their Figma specs.

> **Depends on** the theme-layer roles PR (`ROU-12881-foundation`). Merge that first — this branch is stacked on it.

### What was happening
* Input/TextArea idle & disabled border used the generic `--color-border` role instead of the input-specific border token; there was no hover-border color and no focus ring; the label was too dark/heavy; the error border and validation message used the wrong red tier; the textarea `resize` value was invalid (`resize: auto`) so the drag handle didn't work.
* Dropdown had no focus ring, and its error border used the wrong red tier.
* The Form's `span.validation-message` rule silently overrode the input's validation color with the wrong red tone (equal specificity, loaded later).

### What was done
* **Input/TextArea** (`_inputs-and-textareas.scss`): input-specific border token for idle/disabled, dedicated hover-border color, new 2px focus ring via `--color-border-primary`, label recoloured to `--color-text-subtlest` + regular weight, error border → `--color-border-danger`, validation message → `--color-text-danger`, and `resize: vertical` fix.
* **Dropdown** (`_dropdown.scss`): error border → `--color-border-danger`; new 2px focus ring on both the native `<select>` and the expanded custom dropdown.
* **Form** (`_form.scss`): validation-message color → `--color-text-danger`.
* Regenerated the CSS API reference.

### Test Steps
Open the **Widgets/Input**, **Widgets/TextArea**, **Widgets/Dropdown**, and **Widgets/Form** stories in Storybook, then use DevTools to force states.

**Input / TextArea** — the control root is `<input data-input class="form-control">` / `<textarea data-textarea class="form-control">`:
1. **Hover**: hover the input → border should darken (input-press tone).
2. **Focus**: click/Tab into it → 1px primary border + a 2px light-blue halo (`box-shadow`). In DevTools you can force `:focus` on the element.
3. **Error**: add class `not-valid` to the `.form-control` element → border turns danger-red. A sibling `<span class="validation-message">` should render its text in the same danger-red.
4. **Disabled**: add the `disabled` attribute → muted background + border.
5. **Label**: the `[data-label]` / `.form label` element should be gray (subtlest) and regular weight.
6. **Textarea resize**: drag the bottom-right handle of the textarea → it should resize vertically.

**Dropdown** — root is `<div class="dropdown-container" data-dropdown>` wrapping either `<select class="dropdown-display">` (native) or a `<div class="dropdown-display">` (custom):
1. **Focus (native)**: Tab into the `<select>` → 1px primary border + 2px halo. Force `:focus` in DevTools if needed.
2. **Focus (custom)**: add class `dropdown-expanded` to `.dropdown-container` → the `.dropdown-display` shows the same border + halo.
3. **Error**: add class `not-valid` to `.dropdown-container` → `.dropdown-display` border turns danger-red.

### Screenshots
(prefer animated gif)

### Checklist
* [ ] tested locally
* [ ] documented the code
* [ ] clean all warnings and errors of eslint
* [ ] requires changes in OutSystems (if so, provide a module with changes)
* [ ] requires new sample page in OutSystems (if so, provide a module with changes)
