### PR TITLE
ROU-12881: Rework button and button group states to match Figma

### DIFF
--- a/docs/css-api-reference.md
+++ b/docs/css-api-reference.md
@@ -41,10 +41,14 @@ _File: `src/scss/03-widgets/_btn.scss`_
 | Property | Default |
 |---|---|
 | `--osui-btn-height` | `#{$token-scale-1000}` |
-| `--osui-btn-background` | `var(--color-background-surface)` |
-| `--osui-btn-color` | `var(--color-primary)` |
-| `--osui-btn-border-color` | `currentColor` |
+| `--osui-btn-background` | `#{$token-bg-neutral-bold-default}` |
+| `--osui-btn-color` | `var(--color-text-inverse)` |
+| `--osui-btn-border-color` | `#{$token-bg-neutral-bold-default}` |
+| `--osui-btn-hover-background` | `#{$token-bg-neutral-bold-hover}` |
+| `--osui-btn-active-background` | `#{$token-bg-neutral-bold-press}` |
+| `--osui-btn-border-width` | `#{$token-border-size-025}` |
 | `--osui-btn-border-radius` | `var(--border-radius-soft)` |
+| `--osui-btn-disabled-overlay` | `#{$token-state-disabled}` |
 | `--osui-btn-primary-background` | `var(--color-primary)` |
 | `--osui-btn-primary-border-color` | `var(--color-primary)` |
 | `--osui-btn-primary-color` | `var(--color-text-inverse)` |
@@ -54,6 +58,9 @@ _File: `src/scss/03-widgets/_btn.scss`_
 | `--osui-btn-error-background` | `#{$token-bg-danger-base-default}` |
 | `--osui-btn-error-border-color` | `#{$token-bg-danger-base-default}` |
 | `--osui-btn-error-color` | `var(--color-text-inverse)` |
+| `--osui-btn-focus-shadow-width` | `#{$token-border-size-050}` |
+| `--osui-btn-focus-shadow-gap` | `#{$token-scale-050}` |
+| `--osui-btn-focus-shadow-color` | `#{$token-border-focus-default}` |
 
 ### Bulk Actions (`.table`)
 _File: `src/scss/03-widgets/_bulk-actions.scss`_
@@ -69,7 +76,8 @@ _File: `src/scss/03-widgets/_button-group.scss`_
 |---|---|
 | `--osui-button-group-background` | `var(--color-background-surface)` |
 | `--osui-button-group-border-color` | `var(--color-border)` |
-| `--osui-button-group-color` | `var(--color-text)` |
+| `--osui-button-group-color` | `var(--color-text-subtle)` |
+| `--osui-button-group-disabled-overlay` | `#{$token-state-disabled}` |
 
 ### Checkbox (`[data-checkbox]`)
 _File: `src/scss/03-widgets/_checkbox.scss`_
@@ -900,4 +908,4 @@ _File: `src/scss/01-foundations/_root.scss`_
 
 ---
 
-<sub>385 properties across 75 components, generated from `src/scss`.</sub>
+<sub>393 properties across 75 components, generated from `src/scss`.</sub>

--- a/src/scss/01-foundations/_root.scss
+++ b/src/scss/01-foundations/_root.scss
@@ -32,11 +32,13 @@
 	--color-border-subtlest: #{$token-border-subtlest};
 	--color-border-input: #{$token-border-input-default};
 	--color-border-input-press: #{$token-border-input-press};
+	--color-border-primary: #{$token-border-primary}; // border-specific primary tier (focus rings)
 
 	// ─── Theme layer · brand / status / neutral (also read by TS GetColorValueFromColorType) ──
 	--color-primary: #{$token-semantics-primary-base};
 	--color-primary-hover: #{$token-semantics-primary-800};
-	--color-primary-selected: #{$token-semantics-primary-900};
+	--color-primary-selected: #{$token-semantics-primary-900}; // translucent-wash role for selected rows/items; apps override this
+	--color-primary-active: #{$token-semantics-primary-900}; // solid pressed/active-state role — do not alias to -selected above
 	--color-secondary: #303d60;
 	--color-neutral: #{$token-primitives-neutral-500};
 	--color-neutral-0: #{$token-primitives-neutral-100};
@@ -51,6 +53,8 @@
 	--color-neutral-9: #{$token-primitives-neutral-1100};
 	--color-neutral-10: #{$token-primitives-neutral-1200};
 	--color-error: #{$token-semantics-danger-base};
+	--color-border-danger: #{$token-border-danger-default}; // border-specific danger tier (form validation)
+	--color-text-danger: #{$token-text-danger}; // text-specific danger tier (form validation)
 	--color-warning: #{$token-semantics-warning-base};
 	--color-success: #{$token-semantics-success-base};
 	--color-info: #{$token-semantics-info-base};

--- a/src/scss/03-widgets/_btn.scss
+++ b/src/scss/03-widgets/_btn.scss
@@ -6,11 +6,21 @@
 ///
 .btn {
 	// ─── Component CSS API ─────────────────────────────────────────────
+	// Unmodified .btn maps to the Figma "Secondary" type: solid neutral-bold fill,
+	// inverse text, border-color matching the fill (no visible outline).
 	--osui-btn-height: #{$token-scale-1000};
-	--osui-btn-background: var(--color-background-surface);
-	--osui-btn-color: var(--color-primary);
-	--osui-btn-border-color: currentColor;
+	--osui-btn-background: #{$token-bg-neutral-bold-default};
+	--osui-btn-color: var(--color-text-inverse);
+	--osui-btn-border-color: #{$token-bg-neutral-bold-default};
+	// Hover/active read through these two vars regardless of variant — each
+	// variant below only needs to override them with its own token tier.
+	--osui-btn-hover-background: #{$token-bg-neutral-bold-hover};
+	--osui-btn-active-background: #{$token-bg-neutral-bold-press};
+	--osui-btn-border-width: #{$token-border-size-025};
 	--osui-btn-border-radius: var(--border-radius-soft);
+	// Disabled keeps the variant's own color visible underneath this wash,
+	// instead of dimming toward the page background via opacity.
+	--osui-btn-disabled-overlay: #{$token-state-disabled};
 	// Primary variant
 	--osui-btn-primary-background: var(--color-primary);
 	--osui-btn-primary-border-color: var(--color-primary);
@@ -23,11 +33,15 @@
 	--osui-btn-error-background: #{$token-bg-danger-base-default};
 	--osui-btn-error-border-color: #{$token-bg-danger-base-default};
 	--osui-btn-error-color: var(--color-text-inverse);
+	// Focus state
+	--osui-btn-focus-shadow-width: #{$token-border-size-050};
+	--osui-btn-focus-shadow-gap: #{$token-scale-050};
+	--osui-btn-focus-shadow-color: #{$token-border-focus-default};
 	// ───────────────────────────────────────────────────────────────────
 
 	align-items: center;
 	background-color: var(--osui-btn-background);
-	border: $token-border-size-025 solid var(--osui-btn-border-color);
+	border: var(--osui-btn-border-width) solid var(--osui-btn-border-color);
 	border-radius: var(--osui-btn-border-radius);
 	color: var(--osui-btn-color);
 	cursor: pointer;
@@ -40,13 +54,23 @@
 	line-height: var(--osui-font-line-height-full);
 	margin: 0;
 	padding: $token-scale-0 $token-scale-400;
+	position: relative;
 	transition:
 		background-color $token-transition-time-100 $token-transition-curve-base,
 		border-color $token-transition-time-100 $token-transition-curve-base,
+		box-shadow $token-transition-time-100 $token-transition-curve-base,
 		color $token-transition-time-100 $token-transition-curve-base;
 
-	&:hover:active {
-		filter: brightness(0.8);
+	&:active {
+		background-color: var(--osui-btn-active-background);
+		border-color: var(--osui-btn-active-background);
+	}
+
+	&:focus-visible {
+		box-shadow:
+			0 0 0 var(--osui-btn-focus-shadow-gap) var(--color-background-surface),
+			0 0 0 calc(var(--osui-btn-focus-shadow-gap) + var(--osui-btn-focus-shadow-width)) var(--osui-btn-focus-shadow-color);
+		outline: none;
 	}
 
 	& > span:empty {
@@ -54,13 +78,17 @@
 	}
 
 	&[class*='background-'] {
-		border: $token-border-size-025 solid transparent;
+		border: var(--osui-btn-border-width) solid transparent;
 		color: var(--color-text-inverse);
+
+		&:active {
+			filter: brightness(0.8);
+		}
 	}
 
 	&[class*='text-'] {
 		background-color: var(--osui-btn-background);
-		border: $token-border-size-025 solid currentColor;
+		border: var(--osui-btn-border-width) solid currentColor;
 	}
 
 	& + .btn {
@@ -69,8 +97,11 @@
 
 	// Variants
 	&-primary {
+		--osui-btn-hover-background: var(--color-primary-hover);
+		--osui-btn-active-background: var(--color-primary-active);
+
 		background-color: var(--osui-btn-primary-background);
-		border: $token-border-size-025 solid var(--osui-btn-primary-border-color);
+		border: var(--osui-btn-border-width) solid var(--osui-btn-primary-border-color);
 		color: var(--osui-btn-primary-color);
 	}
 
@@ -89,28 +120,52 @@
 		--osui-btn-background: var(--color-background-surface);
 		--osui-btn-color: var(--color-text-subtle);
 		--osui-btn-border-color: var(--color-border);
+		// Cancel's border never changes across states — only the background
+		// steps through the neutral-subtlest tiers, so the shared :active
+		// rule's border-color needs undoing right here.
+		--osui-btn-hover-background: #{$token-bg-neutral-subtlest-hover};
+		--osui-btn-active-background: #{$token-bg-neutral-subtlest-press};
 
 		background-color: var(--osui-btn-background);
-		border: $token-border-size-025 solid var(--osui-btn-border-color);
+		border: var(--osui-btn-border-width) solid var(--osui-btn-border-color);
 		color: var(--osui-btn-color);
 		transition: border-color $token-transition-time-150 $token-transition-curve-base;
+
+		&:active {
+			border-color: var(--color-border);
+		}
 	}
 
 	&-success {
+		--osui-btn-hover-background: #{$token-bg-success-base-hover};
+		--osui-btn-active-background: #{$token-bg-success-base-press};
+
 		background-color: var(--osui-btn-success-background);
-		border: $token-border-size-025 solid var(--osui-btn-success-border-color);
+		border: var(--osui-btn-border-width) solid var(--osui-btn-success-border-color);
 		color: var(--osui-btn-success-color);
 	}
 
 	&-error {
+		--osui-btn-hover-background: #{$token-bg-danger-base-hover};
+		--osui-btn-active-background: #{$token-bg-danger-base-press};
+
 		background-color: var(--osui-btn-error-background);
-		border: $token-border-size-025 solid var(--osui-btn-error-border-color);
+		border: var(--osui-btn-border-width) solid var(--osui-btn-error-border-color);
 		color: var(--osui-btn-error-color);
 	}
 
 	&[disabled] {
-		opacity: var(--osui-opacity-disabled);
 		pointer-events: none;
+
+		&:after {
+			background-color: var(--osui-btn-disabled-overlay);
+			border-radius: inherit;
+			content: '';
+			// extends past the padding box by the border width so the wash covers
+			// the border ring too, not just the fill inside it
+			inset: calc(var(--osui-btn-border-width) * -1);
+			position: absolute;
+		}
 	}
 }
 
@@ -119,36 +174,31 @@
 ///
 .desktop {
 	.btn {
-		// Secondary (default outline): border darkens
+		// Background + border darken to each variant's own hover tier
 		&:hover {
-			border-color: var(--color-primary-hover);
+			background-color: var(--osui-btn-hover-background);
+			border-color: var(--osui-btn-hover-background);
 		}
 
-		// Cancel: neutral border darkens (same specificity, later → wins)
+		// Cancel: background darkens through its own tiers, border stays fixed
+		// (same specificity as the base rules above, later → wins)
 		&-cancel:hover {
-			border-color: var(--color-border-input);
-		}
-
-		// Primary: explicit darker background + border (same specificity, later → wins)
-		&-primary:hover {
-			background-color: var(--color-primary-hover);
-			border-color: var(--color-primary-hover);
-		}
-
-		// Success + error: darken via filter; restore own border-color so base hover doesn't bleed
-		&-success:hover {
-			border-color: var(--osui-btn-success-border-color);
-			filter: brightness(0.9);
-		}
-
-		&-error:hover {
-			border-color: var(--osui-btn-error-border-color);
-			filter: brightness(0.9);
+			border-color: var(--color-border);
 		}
 
 		// Utility background-* classes: darken via filter
 		&[class*='background-']:hover {
 			filter: brightness(0.9);
+		}
+
+		// Pressed while hovering: higher specificity than :hover above, always wins
+		&:hover:active {
+			background-color: var(--osui-btn-active-background);
+			border-color: var(--osui-btn-active-background);
+		}
+
+		&-cancel:hover:active {
+			border-color: var(--color-border);
 		}
 	}
 }
@@ -168,7 +218,7 @@
 		}
 
 		&-large {
-			height: 56px;
+			height: $token-scale-1400;
 		}
 	}
 }
@@ -199,7 +249,9 @@
 ///
 .has-accessible-features {
 	& .btn:focus {
-		border-color: $token-semantics-primary-base;
+		box-shadow:
+			0 0 0 var(--osui-btn-focus-shadow-gap) var(--color-background-surface),
+			0 0 0 calc(var(--osui-btn-focus-shadow-gap) + var(--osui-btn-focus-shadow-width)) var(--osui-btn-focus-shadow-color);
 	}
 }
 

--- a/src/scss/03-widgets/_button-group.scss
+++ b/src/scss/03-widgets/_button-group.scss
@@ -13,7 +13,8 @@
 		// ─── Component CSS API ─────────────────────────────────────────────
 		--osui-button-group-background: var(--color-background-surface);
 		--osui-button-group-border-color: var(--color-border);
-		--osui-button-group-color: var(--color-text);
+		--osui-button-group-color: var(--color-text-subtle);
+		--osui-button-group-disabled-overlay: #{$token-state-disabled};
 		// ───────────────────────────────────────────────────────────────────
 
 		background-color: var(--osui-button-group-background);
@@ -21,9 +22,9 @@
 		border-radius: 0;
 		color: var(--osui-button-group-color);
 		cursor: pointer;
-		font-size: $token-font-size-350;
-		font-weight: $token-font-weight-semi-bold;
-		height: $token-scale-1000;
+		font-size: $token-font-size-400;
+		font-weight: $token-font-weight-medium;
+		height: $token-scale-1200;
 		padding: $token-scale-0 $token-scale-400;
 		position: relative;
 		white-space: nowrap;
@@ -33,23 +34,14 @@
 				$token-border-radius-200;
 		}
 
-		&:not(.button-group-selected-item):not([disabled]):hover {
-			background-color: var(--color-border-subtle);
-		}
-
 		&[disabled] {
-			--osui-button-group-background: var(--color-background-surface);
-			--osui-button-group-border-color: var(--color-border);
-			--osui-button-group-color: var(--color-text-disabled);
-
-			background-color: var(--osui-button-group-background);
-			border: $token-border-size-025 solid var(--osui-button-group-border-color);
-			color: var(--osui-button-group-color);
 			pointer-events: none;
 
-			&.button-group-selected-item {
-				background-color: var(--color-background-input-disabled);
-				color: var(--color-text-disabled);
+			&:after {
+				background-color: var(--osui-button-group-disabled-overlay);
+				content: '';
+				inset: 0;
+				position: absolute;
 			}
 		}
 
@@ -64,7 +56,7 @@
 		}
 
 		&.button-group-selected-item {
-			background-color: $token-semantics-primary-base;
+			background-color: var(--color-primary);
 			color: var(--color-text-inverse);
 		}
 	}
@@ -76,6 +68,23 @@
 		.validation-message {
 			bottom: -12px;
 			position: relative;
+		}
+	}
+}
+
+// Hover -------------------------------------------------------------------------
+///
+.desktop {
+	.button-group-item {
+		// Neutral (non-selected): border darkens — same technique as .btn-cancel:hover
+		&:not(.button-group-selected-item):not([disabled]):hover {
+			border-color: var(--color-border-input);
+		}
+
+		// Selected: darker background + border — same technique as .btn-primary:hover
+		&.button-group-selected-item:hover {
+			background-color: var(--color-primary-hover);
+			border-color: var(--color-primary-hover);
 		}
 	}
 }

--- a/src/scss/03-widgets/_button-group.scss
+++ b/src/scss/03-widgets/_button-group.scss
@@ -76,9 +76,11 @@
 ///
 .desktop {
 	.button-group-item {
-		// Neutral (non-selected): border darkens — same technique as .btn-cancel:hover
+		// Neutral (non-selected): matches .btn-cancel:hover — background darkens
+		// one tier, border stays on the resting --color-border role
 		&:not(.button-group-selected-item):not([disabled]):hover {
-			border-color: var(--color-border-input);
+			background-color: $token-bg-neutral-subtlest-hover;
+			border-color: var(--color-border);
 		}
 
 		// Selected: darker background + border — same technique as .btn-primary:hover

--- a/stories/CssApiReference.mdx
+++ b/stories/CssApiReference.mdx
@@ -46,10 +46,14 @@ _File: `src/scss/03-widgets/_btn.scss`_
 | Property | Default |
 |---|---|
 | `--osui-btn-height` | `#{$token-scale-1000}` |
-| `--osui-btn-background` | `var(--color-background-surface)` |
-| `--osui-btn-color` | `var(--color-primary)` |
-| `--osui-btn-border-color` | `currentColor` |
+| `--osui-btn-background` | `#{$token-bg-neutral-bold-default}` |
+| `--osui-btn-color` | `var(--color-text-inverse)` |
+| `--osui-btn-border-color` | `#{$token-bg-neutral-bold-default}` |
+| `--osui-btn-hover-background` | `#{$token-bg-neutral-bold-hover}` |
+| `--osui-btn-active-background` | `#{$token-bg-neutral-bold-press}` |
+| `--osui-btn-border-width` | `#{$token-border-size-025}` |
 | `--osui-btn-border-radius` | `var(--border-radius-soft)` |
+| `--osui-btn-disabled-overlay` | `#{$token-state-disabled}` |
 | `--osui-btn-primary-background` | `var(--color-primary)` |
 | `--osui-btn-primary-border-color` | `var(--color-primary)` |
 | `--osui-btn-primary-color` | `var(--color-text-inverse)` |
@@ -59,6 +63,9 @@ _File: `src/scss/03-widgets/_btn.scss`_
 | `--osui-btn-error-background` | `#{$token-bg-danger-base-default}` |
 | `--osui-btn-error-border-color` | `#{$token-bg-danger-base-default}` |
 | `--osui-btn-error-color` | `var(--color-text-inverse)` |
+| `--osui-btn-focus-shadow-width` | `#{$token-border-size-050}` |
+| `--osui-btn-focus-shadow-gap` | `#{$token-scale-050}` |
+| `--osui-btn-focus-shadow-color` | `#{$token-border-focus-default}` |
 
 ### Bulk Actions (`.table`)
 _File: `src/scss/03-widgets/_bulk-actions.scss`_
@@ -74,7 +81,8 @@ _File: `src/scss/03-widgets/_button-group.scss`_
 |---|---|
 | `--osui-button-group-background` | `var(--color-background-surface)` |
 | `--osui-button-group-border-color` | `var(--color-border)` |
-| `--osui-button-group-color` | `var(--color-text)` |
+| `--osui-button-group-color` | `var(--color-text-subtle)` |
+| `--osui-button-group-disabled-overlay` | `#{$token-state-disabled}` |
 
 ### Checkbox (`[data-checkbox]`)
 _File: `src/scss/03-widgets/_checkbox.scss`_
@@ -905,4 +913,4 @@ _File: `src/scss/01-foundations/_root.scss`_
 
 ---
 
-<sub>385 properties across 75 components, generated from `src/scss`.</sub>
+<sub>393 properties across 75 components, generated from `src/scss`.</sub>

--- a/stories/widgets/Button.stories.ts
+++ b/stories/widgets/Button.stories.ts
@@ -7,7 +7,11 @@ export default meta;
 type Story = StoryObj;
 
 const btn = (style: string, label: string, extra: Record<string, unknown> = {}) =>
-	createElement(Button as never, { ...widgetBaseProps('button'), style, enabled: true, onClick: () => {}, key: label, ...extra }, label);
+	createElement(
+		Button as never,
+		{ ...widgetBaseProps('button'), style, enabled: true, onClick: () => {}, key: label, ...extra },
+		label
+	);
 
 export const Variants: Story = {
 	render: () =>
@@ -15,6 +19,7 @@ export const Variants: Story = {
 			createElement('div', { style: { display: 'flex', gap: '8px', flexWrap: 'wrap', alignItems: 'center' } }, [
 				btn('btn btn-primary', 'Primary'),
 				btn('btn', 'Secondary'),
+				btn('btn btn-cancel', 'Cancel'),
 				btn('btn btn-success', 'Confirm'),
 				btn('btn btn-error', 'Delete'),
 				btn('btn btn-primary', 'Disabled', { enabled: false }),


### PR DESCRIPTION
This PR is for aligning Button and Button Group interactive states with their Figma specs.

> **Depends on** the theme-layer roles PR (`ROU-12881-foundation`) for `--color-primary-active`. Merge that first — this branch is stacked on it.

### What was happening
* The unmodified `.btn` rendered as a blue **outline** button, but none of the 5 Figma button types look like that — Figma's "Secondary" is a solid dark-gray (neutral-bold) fill with white text.
* Hover on Success/Error and the pressed state on every type used a generic `brightness()` filter with no dedicated color — so no type had a real Figma-matching hover/pressed color.
* Cancel's hover changed the border instead of the background.
* The focus ring only appeared under `.has-accessible-features`.
* Disabled dimmed the whole button toward the page background via `opacity`.
* Button Group's hover tinted the wrong element, and the selected item used the raw `$token-semantics-primary-base` token instead of the `--color-primary` role.

### What was done
* **Button** (`_btn.scss`): base `.btn` reskinned to Secondary (solid neutral-bold fill + inverse text); each variant gets its own hover and pressed color via shared `--osui-btn-hover-background`/`--osui-btn-active-background` vars (Primary pressed → `--color-primary-active`); Cancel keeps a fixed border and only steps the background tier; always-on `:focus-visible` ring; disabled switched to a translucent overlay covering fill + border.
* **Button Group** (`_button-group.scss`): hover matches the button technique (neutral items darken border, selected item darkens background + border); selected background → `--color-primary`.
* Regenerated the CSS API reference.

### Test Steps
Open the **Widgets/Button** and **Widgets/ButtonGroup** stories. The button element is `<button class="btn …">`.

**Button** — check each type by class:
1. `class="btn"` (Secondary): solid dark-gray fill, white text.
2. `class="btn btn-primary"`, `btn-cancel`, `btn-success`, `btn-error`: each its own fill.
3. **Hover** (force `:hover` in DevTools, page must have `.desktop` on `<body>` — the Storybook decorator sets it): each type darkens to its own hover tier; Cancel darkens only the background, border stays.
4. **Pressed** (force `:active`): each type shows a distinct, darker pressed color. For Primary, confirm it's a solid darker blue (`--color-primary-active`), not a washed-out translucent tint.
5. **Focus** (Tab to the button, or force `:focus-visible`): a focus ring (gap + colored halo) appears — no longer requires `.has-accessible-features`.
6. **Disabled** (add the `disabled` attribute): the button keeps its own color under a translucent white wash, covering both fill and border (no saturated border ring).

**Button Group** — items are `<button class="button-group-item">` inside `.button-group`:
1. Add class `button-group-selected-item` to one item → its background is `--color-primary`.
2. **Hover** (force `:hover`, `.desktop` on body): a non-selected item darkens its border; the selected item darkens background + border.
3. **Disabled** (`disabled` attribute on an item): translucent wash over it.

### Screenshots
(prefer animated gif)

### Checklist
* [ ] tested locally
* [ ] documented the code
* [ ] clean all warnings and errors of eslint
* [ ] requires changes in OutSystems (if so, provide a module with changes)
* [ ] requires new sample page in OutSystems (if so, provide a module with changes)
