### PR TITLE
ROU-12881: Align toggle widgets with Figma (checkbox, radio, switch)

### DIFF
--- a/docs/css-api-reference.md
+++ b/docs/css-api-reference.md
@@ -198,7 +198,7 @@ _File: `src/scss/03-widgets/_radio-button.scss`_
 | `--osui-radio-border-color` | `#{$token-border-default}` |
 | `--osui-radio-checked-color` | `var(--color-primary)` |
 | `--osui-radio-indicator-border` | `#{$token-scale-150}` |
-| `--osui-radio-error-border-color` | `#{$token-border-danger-default}` |
+| `--osui-radio-error-border-color` | `var(--color-border-danger)` |
 | `--osui-radio-disabled-border-color` | `#{$token-border-disabled}` |
 
 ### Switch (`[data-switch]`)
@@ -212,9 +212,8 @@ _File: `src/scss/03-widgets/_switch.scss`_
 | `--osui-switch-thumb-offset-start` | `2px` |
 | `--osui-switch-thumb-offset-end` | `18px` |
 | `--osui-switch-track-color` | `#{$token-bg-neutral-base-default}` |
-| `--osui-switch-track-border-color` | `#{$token-bg-neutral-base-default}` |
-| `--osui-switch-disabled-track-color` | `var(--color-background-input-disabled)` |
 | `--osui-switch-checked-track-color` | `var(--color-primary)` |
+| `--osui-switch-disabled-overlay` | `#{$token-state-disabled}` |
 | `--osui-switch-thumb-color` | `#{$token-bg-surface-inverse}` |
 | `--osui-switch-thumb-shadow` | `#{$token-elevation-1}` |
 
@@ -900,4 +899,4 @@ _File: `src/scss/01-foundations/_root.scss`_
 
 ---
 
-<sub>385 properties across 75 components, generated from `src/scss`.</sub>
+<sub>384 properties across 75 components, generated from `src/scss`.</sub>

--- a/src/scss/01-foundations/_root.scss
+++ b/src/scss/01-foundations/_root.scss
@@ -32,11 +32,13 @@
 	--color-border-subtlest: #{$token-border-subtlest};
 	--color-border-input: #{$token-border-input-default};
 	--color-border-input-press: #{$token-border-input-press};
+	--color-border-primary: #{$token-border-primary}; // border-specific primary tier (focus rings)
 
 	// ─── Theme layer · brand / status / neutral (also read by TS GetColorValueFromColorType) ──
 	--color-primary: #{$token-semantics-primary-base};
 	--color-primary-hover: #{$token-semantics-primary-800};
-	--color-primary-selected: #{$token-semantics-primary-900};
+	--color-primary-selected: #{$token-semantics-primary-900}; // translucent-wash role for selected rows/items; apps override this
+	--color-primary-active: #{$token-semantics-primary-900}; // solid pressed/active-state role — do not alias to -selected above
 	--color-secondary: #303d60;
 	--color-neutral: #{$token-primitives-neutral-500};
 	--color-neutral-0: #{$token-primitives-neutral-100};
@@ -51,6 +53,8 @@
 	--color-neutral-9: #{$token-primitives-neutral-1100};
 	--color-neutral-10: #{$token-primitives-neutral-1200};
 	--color-error: #{$token-semantics-danger-base};
+	--color-border-danger: #{$token-border-danger-default}; // border-specific danger tier (form validation)
+	--color-text-danger: #{$token-text-danger}; // text-specific danger tier (form validation)
 	--color-warning: #{$token-semantics-warning-base};
 	--color-success: #{$token-semantics-success-base};
 	--color-info: #{$token-semantics-info-base};

--- a/src/scss/03-widgets/_checkbox.scss
+++ b/src/scss/03-widgets/_checkbox.scss
@@ -92,13 +92,15 @@
 	[data-checkbox] {
 		border-radius: var(--osui-checkbox-border-radius);
 
-		&:before {
-			border-color: var(--color-border-input);
-		}
-
 		&:hover {
 			&:before {
 				border-color: var(--color-border-input-press);
+			}
+		}
+
+		&[disabled]:checked {
+			&:before {
+				border-color: var(--color-border);
 			}
 		}
 

--- a/src/scss/03-widgets/_radio-button.scss
+++ b/src/scss/03-widgets/_radio-button.scss
@@ -11,7 +11,7 @@
 	--osui-radio-border-color: #{$token-border-default};
 	--osui-radio-checked-color: var(--color-primary);
 	--osui-radio-indicator-border: #{$token-scale-150};
-	--osui-radio-error-border-color: #{$token-border-danger-default};
+	--osui-radio-error-border-color: var(--color-border-danger);
 	--osui-radio-disabled-border-color: #{$token-border-disabled};
 	// ───────────────────────────────────────────────────────────────────
 
@@ -71,7 +71,6 @@
 
 		& + label {
 			pointer-events: none;
-			color: var(--color-text-disabled);
 		}
 
 		&:before {
@@ -80,8 +79,10 @@
 		}
 
 		&:checked:before {
-			background-color: var(--color-background-input-disabled);
-			border: var(--osui-radio-indicator-border) solid var(--osui-radio-disabled-border-color);
+			background-color: var(--osui-radio-background);
+			// the indicator is drawn as a border, so the disabled overlay is blended into its color directly —
+			// an inset box-shadow would be clipped to the padding box and never paint over the border itself
+			border: var(--osui-radio-indicator-border) solid color-mix(in srgb, var(--osui-radio-checked-color) 40%, #{$token-primitives-base-white} 60%);
 		}
 	}
 }

--- a/src/scss/03-widgets/_switch.scss
+++ b/src/scss/03-widgets/_switch.scss
@@ -12,9 +12,8 @@
 	--osui-switch-thumb-offset-start: 2px;
 	--osui-switch-thumb-offset-end: 18px;
 	--osui-switch-track-color: #{$token-bg-neutral-base-default};
-	--osui-switch-track-border-color: #{$token-bg-neutral-base-default};
-	--osui-switch-disabled-track-color: var(--color-background-input-disabled);
 	--osui-switch-checked-track-color: var(--color-primary);
+	--osui-switch-disabled-overlay: #{$token-state-disabled};
 	--osui-switch-thumb-color: #{$token-bg-surface-inverse};
 	--osui-switch-thumb-shadow: #{$token-elevation-1};
 	// ───────────────────────────────────────────────────────────────────
@@ -66,20 +65,20 @@
 
 		&:empty {
 			&:before {
-				background-color: var(--osui-switch-disabled-track-color);
+				background-color: var(--osui-switch-track-color);
 				border: 0;
+				box-shadow: inset 0 0 0 999px var(--osui-switch-disabled-overlay);
 			}
 
 			&:after {
-				background-color: color-mix(in srgb, #{$token-primitives-base-white} 60%, transparent);
+				background-color: var(--osui-switch-thumb-color);
 				border: 0;
-				box-shadow: var(--osui-elevation-25);
+				box-shadow: var(--osui-switch-thumb-shadow);
 			}
 		}
 
 		&:checked:empty:before {
 			background-color: var(--osui-switch-checked-track-color);
-			opacity: var(--osui-opacity-disabled);
 		}
 	}
 

--- a/stories/CssApiReference.mdx
+++ b/stories/CssApiReference.mdx
@@ -203,7 +203,7 @@ _File: `src/scss/03-widgets/_radio-button.scss`_
 | `--osui-radio-border-color` | `#{$token-border-default}` |
 | `--osui-radio-checked-color` | `var(--color-primary)` |
 | `--osui-radio-indicator-border` | `#{$token-scale-150}` |
-| `--osui-radio-error-border-color` | `#{$token-border-danger-default}` |
+| `--osui-radio-error-border-color` | `var(--color-border-danger)` |
 | `--osui-radio-disabled-border-color` | `#{$token-border-disabled}` |
 
 ### Switch (`[data-switch]`)
@@ -217,9 +217,8 @@ _File: `src/scss/03-widgets/_switch.scss`_
 | `--osui-switch-thumb-offset-start` | `2px` |
 | `--osui-switch-thumb-offset-end` | `18px` |
 | `--osui-switch-track-color` | `#{$token-bg-neutral-base-default}` |
-| `--osui-switch-track-border-color` | `#{$token-bg-neutral-base-default}` |
-| `--osui-switch-disabled-track-color` | `var(--color-background-input-disabled)` |
 | `--osui-switch-checked-track-color` | `var(--color-primary)` |
+| `--osui-switch-disabled-overlay` | `#{$token-state-disabled}` |
 | `--osui-switch-thumb-color` | `#{$token-bg-surface-inverse}` |
 | `--osui-switch-thumb-shadow` | `#{$token-elevation-1}` |
 
@@ -905,4 +904,4 @@ _File: `src/scss/01-foundations/_root.scss`_
 
 ---
 
-<sub>385 properties across 75 components, generated from `src/scss`.</sub>
+<sub>384 properties across 75 components, generated from `src/scss`.</sub>


### PR DESCRIPTION
This PR is for aligning the toggle widgets (Checkbox, Radio Button, Switch) with their Figma specs.

> **Depends on** the theme-layer roles PR (`ROU-12881-foundation`) for the radio button's `--color-border-danger`. Merge that first — this branch is stacked on it.

### What was happening
* Checkbox hover/disabled states used slightly off tokens.
* Radio Button: a disabled **selected** radio turned flat gray (lost its selected identity); its error border used the wrong red tier; the label recoloured to disabled-gray when the radio was disabled.
* Switch: the disabled state (on or off) swapped to a solid gray track, and the file carried two dead custom properties.

### What was done
* **Checkbox** (`_checkbox.scss`): hover and disabled token consistency.
* **Radio Button** (`_radio-button.scss`): error border → `--color-border-danger`; disabled+selected keeps the primary color (rendered lighter) instead of gray; label keeps its normal color when disabled.
* **Switch** (`_switch.scss`): disabled uses a translucent white overlay over the normal color; removed the two dead props and added `--osui-switch-disabled-overlay`.
* Regenerated the CSS API reference.

### Test Steps
Open the **Widgets/Checkbox**, **Widgets/RadioGroup**, and **Widgets/Switch** stories.

**Checkbox** — root `<input type="checkbox" data-checkbox>`:
1. **Hover** (force `:hover`): border tone.
2. **Checked** (`checked` attribute): primary fill + check mark.
3. **Disabled** (`disabled` attribute), and disabled+checked: muted appearance.

**Radio Button** — root `<input type="radio" class="radio-button">`, error is driven by an ancestor `[data-radio-group].not-valid`:
1. **Selected** (`checked` attribute): blue ring + dot.
2. **Disabled + selected** (`checked` + `disabled`): ring stays blue but lighter — **not** gray. Its sibling `<label>` keeps its normal text color (force it and confirm the label isn't dimmed).
3. **Error**: wrap the group in `<div data-radio-group class="not-valid">` → the radio border turns danger-red.

**Switch** — root `<input type="checkbox" data-switch>` (renders as a track+thumb):
1. **On** (`checked`): primary track.
2. **Disabled off** (`disabled`): light-gray washed track.
3. **Disabled on** (`checked` + `disabled`): the primary track shows through a translucent white wash (a washed light-blue), consistent with the off state — not a different/broken gray.

### Screenshots
(prefer animated gif)

### Checklist
* [ ] tested locally
* [ ] documented the code
* [ ] clean all warnings and errors of eslint
* [ ] requires changes in OutSystems (if so, provide a module with changes)
* [ ] requires new sample page in OutSystems (if so, provide a module with changes)
