### PR TITLE
ROU-12881: Align overlay widgets with Figma (popover, popup)

### DIFF
--- a/docs/css-api-reference.md
+++ b/docs/css-api-reference.md
@@ -171,10 +171,9 @@ _File: `src/scss/03-widgets/_popover.scss`_
 | Property | Default |
 |---|---|
 | `--osui-popover-background` | `var(--color-background-surface)` |
-| `--osui-popover-border-color` | `var(--color-border)` |
 | `--osui-popover-color` | `var(--color-text)` |
 | `--osui-popover-border-radius` | `var(--border-radius-soft)` |
-| `--osui-popover-shadow` | `#{$token-elevation-1}` |
+| `--osui-popover-shadow` | `#{$token-elevation-2}` |
 | `--osui-popover-max-width` | `350px` |
 
 ### Popup (`.popup`)
@@ -183,6 +182,8 @@ _File: `src/scss/03-widgets/_popup.scss`_
 | Property | Default |
 |---|---|
 | `--osui-popup-background` | `var(--color-background-surface)` |
+| `--osui-popup-border-color` | `transparent` |
+| `--osui-popup-border-width` | `#{$token-border-size-025}` |
 | `--osui-popup-border-radius` | `var(--border-radius-soft)` |
 | `--osui-popup-shadow` | `#{$token-elevation-4}` |
 | `--osui-popup-padding` | `#{$token-scale-600}` |
@@ -900,4 +901,4 @@ _File: `src/scss/01-foundations/_root.scss`_
 
 ---
 
-<sub>385 properties across 75 components, generated from `src/scss`.</sub>
+<sub>386 properties across 75 components, generated from `src/scss`.</sub>

--- a/src/scss/03-widgets/_popover.scss
+++ b/src/scss/03-widgets/_popover.scss
@@ -17,22 +17,20 @@
 
 		&-bottom {
 			// ─── Component CSS API ─────────────────────────────────────────────
-			--osui-popover-background:    var(--color-background-surface);
-			--osui-popover-border-color:  var(--color-border);
-			--osui-popover-color:         var(--color-text);
-			--osui-popover-border-radius: var(--border-radius-soft);
-			--osui-popover-shadow:        #{$token-elevation-1};
-			--osui-popover-max-width:     350px;
+			--osui-popover-background:     var(--color-background-surface);
+			--osui-popover-color:          var(--color-text);
+			--osui-popover-border-radius:  var(--border-radius-soft);
+			--osui-popover-shadow:         #{$token-elevation-2};
+			--osui-popover-max-width:      350px;
 			// ───────────────────────────────────────────────────────────────────
 
 			background-color: var(--osui-popover-background);
-			border: $token-border-size-025 solid var(--osui-popover-border-color);
 			border-radius: var(--osui-popover-border-radius);
 			box-shadow: var(--osui-popover-shadow);
 			color: var(--osui-popover-color);
 			max-width: var(--osui-popover-max-width);
 			min-width: auto;
-			padding: $token-scale-400;
+			padding: $token-scale-600;
 			z-index: var(--layer-elevated);
 		}
 	}

--- a/src/scss/03-widgets/_popup.scss
+++ b/src/scss/03-widgets/_popup.scss
@@ -25,6 +25,8 @@
 	&-dialog {
 		// ─── Component CSS API ─────────────────────────────────────────────
 		--osui-popup-background:    var(--color-background-surface);
+		--osui-popup-border-color:  transparent;
+		--osui-popup-border-width:  #{$token-border-size-025};
 		--osui-popup-border-radius: var(--border-radius-soft);
 		--osui-popup-shadow:        #{$token-elevation-4};
 		--osui-popup-padding:       #{$token-scale-600};
@@ -32,7 +34,7 @@
 		// ───────────────────────────────────────────────────────────────────
 
 		background-color: var(--osui-popup-background);
-		border: 0;
+		border: var(--osui-popup-border-width) solid var(--osui-popup-border-color);
 		border-radius: var(--osui-popup-border-radius);
 		box-shadow: var(--osui-popup-shadow);
 		margin: $token-scale-600;
@@ -64,7 +66,7 @@
 ///
 .os-high-contrast {
 	.popup-dialog {
-		border: $token-border-size-025 solid $token-bg-surface-default;
+		border: $token-border-size-025 solid #{$token-bg-surface-default};
 		border-radius: var(--border-radius-soft);
 	}
 }

--- a/stories/CssApiReference.mdx
+++ b/stories/CssApiReference.mdx
@@ -176,10 +176,9 @@ _File: `src/scss/03-widgets/_popover.scss`_
 | Property | Default |
 |---|---|
 | `--osui-popover-background` | `var(--color-background-surface)` |
-| `--osui-popover-border-color` | `var(--color-border)` |
 | `--osui-popover-color` | `var(--color-text)` |
 | `--osui-popover-border-radius` | `var(--border-radius-soft)` |
-| `--osui-popover-shadow` | `#{$token-elevation-1}` |
+| `--osui-popover-shadow` | `#{$token-elevation-2}` |
 | `--osui-popover-max-width` | `350px` |
 
 ### Popup (`.popup`)
@@ -188,6 +187,8 @@ _File: `src/scss/03-widgets/_popup.scss`_
 | Property | Default |
 |---|---|
 | `--osui-popup-background` | `var(--color-background-surface)` |
+| `--osui-popup-border-color` | `transparent` |
+| `--osui-popup-border-width` | `#{$token-border-size-025}` |
 | `--osui-popup-border-radius` | `var(--border-radius-soft)` |
 | `--osui-popup-shadow` | `#{$token-elevation-4}` |
 | `--osui-popup-padding` | `#{$token-scale-600}` |
@@ -905,4 +906,4 @@ _File: `src/scss/01-foundations/_root.scss`_
 
 ---
 
-<sub>385 properties across 75 components, generated from `src/scss`.</sub>
+<sub>386 properties across 75 components, generated from `src/scss`.</sub>

--- a/stories/widgets/Popup.stories.ts
+++ b/stories/widgets/Popup.stories.ts
@@ -10,10 +10,10 @@ export const Default: Story = {
 	render: () =>
 		mountTree(
 			createElement(Popup as never, { ...widgetBaseProps('popup'), showPopup: true, style: '' },
-				createElement('div', { style: { padding: '24px', maxWidth: '420px' } }, [
+				[
 					createElement('h2', { key: 'h', style: { marginTop: 0 } }, 'Confirm action'),
 					createElement('p', { key: 'p' }, 'The platform Popup widget renders a centered dialog over a backdrop.'),
-				])
+				]
 			)
 		),
 };


### PR DESCRIPTION
This PR is for aligning the overlay widgets (Popover, Popup) with their Figma specs.

### What was happening
* Popover had a 1px border that the Figma spec doesn't include (spec relies on shadow only), used the wrong shadow elevation, and slightly-off padding.
* Popup's border-reservation defaults weren't exposed as CSS API properties.

### What was done
* **Popover** (`_popover.scss`): removed the border; shadow `elevation-1` → `elevation-2`; padding adjusted.
* **Popup** (`_popup.scss`): added the `--osui-popup-border-color`/`--osui-popup-border-width` properties (transparent by default, swapped to a visible border under `.os-high-contrast`); tidied the story.
* Regenerated the CSS API reference.

### Test Steps
Open the **Widgets/Popover** and **Widgets/Popup** stories.

**Popover** — root `<div data-popover>` containing `.popover-bottom` (the visible bubble):
1. Confirm the `.popover-bottom` bubble has **no border** — only a drop shadow.
2. The shadow should be the slightly stronger `elevation-2`.

**Popup** — dialog root `.popup-dialog` inside `.popup`:
1. Default: no visible border (transparent), rounded corners + shadow.
2. **High-contrast**: add class `os-high-contrast` to a wrapping element (e.g. `<body>` or the story root) → the `.popup-dialog` border becomes visible, with no layout shift (the width was already reserved).

### Screenshots
(prefer animated gif)

### Checklist
* [ ] tested locally
* [ ] documented the code
* [ ] clean all warnings and errors of eslint
* [ ] requires changes in OutSystems (if so, provide a module with changes)
* [ ] requires new sample page in OutSystems (if so, provide a module with changes)
