### PR TITLE
ROU-12881: Align table with Figma (table, bulk actions, sortable icon)

### DIFF
--- a/docs/css-api-reference.md
+++ b/docs/css-api-reference.md
@@ -223,14 +223,14 @@ _File: `src/scss/03-widgets/_table.scss`_
 
 | Property | Default |
 |---|---|
-| `--osui-table-border-color` | `var(--osui-border-subtle)` |
+| `--osui-table-border-color` | `var(--color-border)` |
 | `--osui-table-border-radius` | `var(--border-radius-soft)` |
 | `--osui-table-header-background` | `transparent` |
-| `--osui-table-header-color` | `var(--color-text)` |
+| `--osui-table-header-color` | `var(--color-text-subtlest)` |
 | `--osui-table-cell-background` | `var(--color-background-surface)` |
 | `--osui-table-row-hover-background` | `var(--color-background-input-disabled)` |
-| `--osui-table-row-stripe-background` | `#{$token-bg-neutral-subtlest-default}` |
-| `--osui-table-sorted-color` | `var(--color-primary)` |
+| `--osui-table-row-stripe-background` | `#{$token-bg-neutral-subtle-default}` |
+| `--osui-table-sorted-color` | `var(--color-text)` |
 | `--osui-table-row-selected-background` | `var(--color-primary-selected)` |
 
 ### Upload (`[data-upload]`)

--- a/src/scss/01-foundations/_icon-library-o11.scss
+++ b/src/scss/01-foundations/_icon-library-o11.scss
@@ -178,46 +178,15 @@
 		position: absolute;
 	}
 
+	// currentColor keeps the arrow in lockstep with the header text color
+	// (default/hover/.sorted) without a separate state rule per color
 	&:before {
-		border-bottom: 4px solid $token-primitives-neutral-800;
+		border-bottom: 4px solid currentColor;
 	}
 
 	&:after {
-		border-top: 4px solid $token-primitives-neutral-800;
+		border-top: 4px solid currentColor;
 		bottom: 0;
-	}
-}
-
-///
-.table-header {
-	th.sorted {
-		.sortable-icon {
-			&:before {
-				border-bottom: 4px solid $token-semantics-primary-base;
-			}
-
-			&:after {
-				border-top: 4px solid $token-semantics-primary-base;
-			}
-		}
-	}
-}
-
-// Responsive --------------------------------------------------------------------
-///
-.desktop {
-	.table-header {
-		th.sortable:hover {
-			.sortable-icon {
-				&:before {
-					border-bottom: 4px solid $token-semantics-primary-base;
-				}
-
-				&:after {
-					border-top: 4px solid $token-semantics-primary-base;
-				}
-			}
-		}
 	}
 }
 

--- a/src/scss/03-widgets/_bulk-actions.scss
+++ b/src/scss/03-widgets/_bulk-actions.scss
@@ -21,7 +21,7 @@
 			border-right: $token-border-size-0 !important;
 			border-top: $token-border-size-0 !important;
 			display: block;
-			height: 2px;
+			height: $token-scale-050;
 			left: $token-scale-100;
 			top: 5px;
 			width: 7px;

--- a/src/scss/03-widgets/_table.scss
+++ b/src/scss/03-widgets/_table.scss
@@ -6,18 +6,19 @@
 ///
 .table {
 	// ─── Component CSS API ─────────────────────────────────────────────
-	--osui-table-border-color: var(--osui-border-subtle);
+	--osui-table-border-color: var(--color-border);
 	--osui-table-border-radius: var(--border-radius-soft);
 	--osui-table-header-background: transparent;
-	--osui-table-header-color: var(--color-text);
+	--osui-table-header-color: var(--color-text-subtlest);
 	--osui-table-cell-background: var(--color-background-surface);
 	--osui-table-row-hover-background: var(--color-background-input-disabled);
-	--osui-table-row-stripe-background: #{$token-bg-neutral-subtlest-default};
-	--osui-table-sorted-color: var(--color-primary);
+	--osui-table-row-stripe-background: #{$token-bg-neutral-subtle-default};
+	--osui-table-sorted-color: var(--color-text);
 	--osui-table-row-selected-background: var(--color-primary-selected);
 	// ───────────────────────────────────────────────────────────────────
 
-	border: none;
+	border: $token-border-size-025 solid var(--osui-table-border-color);
+	border-radius: var(--osui-table-border-radius);
 	border-spacing: 0;
 	empty-cells: show;
 	white-space: nowrap;
@@ -35,7 +36,7 @@
 			border-bottom: $token-border-size-025 solid var(--osui-table-border-color);
 			color: var(--osui-table-header-color);
 			font-size: $token-font-size-350;
-			font-weight: $token-font-weight-semi-bold;
+			font-weight: $token-font-weight-regular;
 			height: $token-scale-1200;
 			padding: $token-scale-0 $token-scale-600;
 			text-align: left;
@@ -46,6 +47,7 @@
 
 			&.sorted {
 				color: var(--osui-table-sorted-color);
+				font-weight: $token-font-weight-semi-bold;
 			}
 		}
 	}
@@ -64,7 +66,7 @@
 			border-bottom: $token-border-size-025 solid var(--osui-table-border-color);
 			color: var(--color-text);
 			font-size: $token-font-size-350;
-			height: $token-scale-1400;
+			height: $token-scale-1600;
 			padding: $token-scale-200 $token-scale-600;
 			transition: background-color $token-transition-time-100 ease; // no token match for ease
 			vertical-align: inherit;
@@ -72,13 +74,13 @@
 
 		&-small {
 			td {
-				height: $token-scale-1200;
+				height: $token-scale-1000;
 			}
 		}
 
 		&-medium {
 			td {
-				height: $token-scale-1600;
+				height: $token-scale-1200;
 			}
 		}
 

--- a/stories/CssApiReference.mdx
+++ b/stories/CssApiReference.mdx
@@ -228,14 +228,14 @@ _File: `src/scss/03-widgets/_table.scss`_
 
 | Property | Default |
 |---|---|
-| `--osui-table-border-color` | `var(--osui-border-subtle)` |
+| `--osui-table-border-color` | `var(--color-border)` |
 | `--osui-table-border-radius` | `var(--border-radius-soft)` |
 | `--osui-table-header-background` | `transparent` |
-| `--osui-table-header-color` | `var(--color-text)` |
+| `--osui-table-header-color` | `var(--color-text-subtlest)` |
 | `--osui-table-cell-background` | `var(--color-background-surface)` |
 | `--osui-table-row-hover-background` | `var(--color-background-input-disabled)` |
-| `--osui-table-row-stripe-background` | `#{$token-bg-neutral-subtlest-default}` |
-| `--osui-table-sorted-color` | `var(--color-primary)` |
+| `--osui-table-row-stripe-background` | `#{$token-bg-neutral-subtle-default}` |
+| `--osui-table-sorted-color` | `var(--color-text)` |
 | `--osui-table-row-selected-background` | `var(--color-primary-selected)` |
 
 ### Upload (`[data-upload]`)

--- a/stories/widgets/Table.stories.ts
+++ b/stories/widgets/Table.stories.ts
@@ -1,0 +1,46 @@
+import type { Meta, StoryObj } from '@storybook/html-vite';
+import { renderStatic } from '../_helpers/osui';
+
+/**
+ * Table Records — the OutSystems platform **widget** (`TableRecords` from
+ * `@outsystems/runtime-widgets-js`) is an iterator bound to `source: IList`,
+ * rendering `headerRow`/`row` placeholder content per record. Mounting it for
+ * real would require mocking that list + placeholder plumbing, so — same as
+ * List (see Widgets/List) — this is a CSS-only render of the DOM/class
+ * contract the widget ships from src/scss/03-widgets/_table.scss:
+ *   `table.table[role=grid]` > `thead > tr.table-header > th(.sortable.sorted + .sortable-icon)`;
+ *   `tbody > tr.table-row(.table-row-selected|.table-row-stripping) > td[data-header](.table-cell-secondary)`.
+ */
+const meta: Meta = { title: 'Widgets/Table' };
+export default meta;
+type Story = StoryObj;
+
+const row = (name: string, status: string, email: string) => `
+	<tr class="table-row table-row-stripping">
+		<td data-header="Name">${name}</td>
+		<td data-header="Status">${status}</td>
+		<td data-header="Email" class="table-cell-secondary">${email}</td>
+	</tr>`;
+
+export const Default: Story = {
+	render: () =>
+		renderStatic(`
+			<table class="table" role="grid" style="width:100%;max-width:560px;">
+				<thead>
+					<tr class="table-header">
+						<th class="sortable sorted" tabindex="0">Name<div class="sortable-icon"></div></th>
+						<th class="sortable" tabindex="0">Status<div class="sortable-icon"></div></th>
+						<th>Email</th>
+					</tr>
+				</thead>
+				<tbody>
+					${row('John Doe', 'Active', 'john@example.com')}
+					${row('Jane Smith', 'Inactive', 'jane@example.com')}
+					${row('Bob Johnson', 'Active', 'bob@example.com')}
+					${row('Alice Brown', 'Active', 'alice@example.com')}
+					${row('James Sullivan', 'Active', 'james@example.com')}
+					${row('William Cullen', 'Active', 'william@example.com')}
+					${row('Amanda Lawrence', 'Active', 'amanda@example.com')}
+				</tbody>
+			</table>`),
+};


### PR DESCRIPTION
This PR is for aligning the Table widget (and its bulk-actions checkbox + sortable icon) with the Figma spec.

### What was happening
* Table border color referenced a dead `--osui-border-subtle` variable; the header text used the default (too dark) color and a heavier weight; the zebra-stripe token resolved to white (same as the base background → striping invisible); the container had no border/rounded corners.
* The bulk-actions checkbox height was a hardcoded pixel value.
* The sortable-icon (CSS-triangle arrows) had a fixed gray color plus a duplicate `.sorted` rule, so the arrow didn't follow the header text color when hovered/sorted.

### What was done
* **Table** (`_table.scss`): border color → `--color-border`; header text → subtlest tier + lighter weight; zebra-stripe token → `bg-neutral-subtle-default` (visible gray); added container border + radius.
* **Bulk actions** (`_bulk-actions.scss`): checkbox height uses a scale token.
* **Sortable icon** (`_icon-library-o11.scss`): removed the obsolete duplicate `.sorted` rule; the triangle arrows use `currentColor` so they track the header text color in every state.
* Added a Table widget story; regenerated the CSS API reference.

### Test Steps
Open the **Widgets/Table** story. The table is `<table class="table">` with header row `<tr class="table-header">` and header cells `<th class="sortable">Name<div class="sortable-icon"></div></th>`; body rows are `<tr class="table-row">`.

1. **Zebra striping**: add class `table-row-stripping` to the `<tr class="table-row">` rows → even rows show a visible light-gray background (previously white/invisible).
2. **Container**: the `.table` element should have a 1px border and rounded corners.
3. **Header**: the `<th>` text should be the subtler gray at a lighter weight.
4. **Sorted column**: add class `sorted` to a `<th class="sortable">` → both the text **and** the `.sortable-icon` arrow turn the sorted color.
5. **Hover sort** (page needs `.desktop` on `<body>`; force `:hover` on the `th.sortable`) → text and arrow recolour together.

### Screenshots
(prefer animated gif)

### Checklist
* [ ] tested locally
* [ ] documented the code
* [ ] clean all warnings and errors of eslint
* [ ] requires changes in OutSystems (if so, provide a module with changes)
* [ ] requires new sample page in OutSystems (if so, provide a module with changes)
