### PR TITLE
ROU-12913: ButtonLoading - Adding new API method ForceIsLoadingDisabledState

### DIFF
--- a/src/scripts/OSFramework/OSUI/Pattern/ButtonLoading/ButtonLoading.ts
+++ b/src/scripts/OSFramework/OSUI/Pattern/ButtonLoading/ButtonLoading.ts
@@ -13,11 +13,27 @@ namespace OSFramework.OSUI.Patterns.ButtonLoading {
 		// Store the button html element that must exist inside ButtonLoading placeholder
 		private _buttonElement: HTMLElement;
 
+		// Flag to disable the management of the disabled attribute on the button element when the button is loading.
+		private _disableBtnWhenIsLoading = true;
+
 		// Store the spinner html element that shoul also exist since we've input params for it
 		private _spinnerElement: HTMLElement;
 
 		constructor(uniqueId: string, configs: JSON) {
 			super(uniqueId, new ButtonLoadingConfig(configs));
+		}
+
+		// Sets or removes the disabled attribute on the button element when management is enabled.
+		private _setButtonDisabled(isDisabled: boolean): void {
+			if (this._disableBtnWhenIsLoading === false || this.isBuilt === false) {
+				return;
+			}
+
+			if (isDisabled) {
+				Helper.Dom.Attribute.Set(this._buttonElement, GlobalEnum.HTMLAttributes.Disabled, 'true');
+			} else {
+				Helper.Dom.Attribute.Remove(this._buttonElement, GlobalEnum.HTMLAttributes.Disabled);
+			}
 		}
 
 		// Set the cssClasses that should be assigned to the element on it's initialization
@@ -30,16 +46,16 @@ namespace OSFramework.OSUI.Patterns.ButtonLoading {
 
 		// Sets the new state of the button. If it's loading or not loading.
 		private _setIsLoading(isLoading: boolean): void {
+			// Set the disabled attribute on the button element if expected
+			this._setButtonDisabled(isLoading);
+
 			if (isLoading) {
 				Helper.Dom.Styles.AddClass(this.selfElement, Enum.CssClass.IsLoading);
 				Helper.A11Y.AriaBusyTrue(this.selfElement);
-				this.isBuilt &&
-					Helper.Dom.Attribute.Set(this._buttonElement, GlobalEnum.HTMLAttributes.Disabled, 'true');
 				this._buttonElement.blur();
 			} else {
 				Helper.Dom.Styles.RemoveClass(this.selfElement, Enum.CssClass.IsLoading);
 				Helper.A11Y.AriaBusyFalse(this.selfElement);
-				this.isBuilt && Helper.Dom.Attribute.Remove(this._buttonElement, GlobalEnum.HTMLAttributes.Disabled);
 			}
 		}
 
@@ -163,6 +179,27 @@ namespace OSFramework.OSUI.Patterns.ButtonLoading {
 						this._setLoadingLabel(propertyValue as boolean);
 						break;
 				}
+			}
+		}
+
+		/**
+		 * Method to force the disabled attribute on the button element to be managed by IsLoading property.
+		 *
+		 * @param {boolean} isDisabled When true, the button is disabled while IsLoading is true.
+		 * @memberof OSFramework.Patterns.ButtonLoading.ButtonLoading
+		 */
+		public disabledStateOnIsLoading(isDisabled: boolean): void {
+			// Grant value is different from the current one
+			if (this._disableBtnWhenIsLoading === isDisabled) {
+				return;
+			}
+
+			// Update it
+			this._disableBtnWhenIsLoading = isDisabled;
+
+			// Make sure to set the disabled attribute on the button element if expected
+			if (this.isBuilt) {
+				this._setButtonDisabled(this.configs.IsLoading);
 			}
 		}
 

--- a/src/scripts/OSFramework/OSUI/Pattern/ButtonLoading/Enum.ts
+++ b/src/scripts/OSFramework/OSUI/Pattern/ButtonLoading/Enum.ts
@@ -8,6 +8,7 @@ namespace OSFramework.OSUI.Patterns.ButtonLoading.Enum {
 	 */
 	export enum Properties {
 		IsLoading = 'IsLoading',
+		ManageDisabledAttribute = 'ManageDisabledAttribute',
 		ShowLoadingAndLabel = 'ShowLoadingAndLabel',
 	}
 

--- a/src/scripts/OSFramework/OSUI/Pattern/ButtonLoading/IButtonLoading.ts
+++ b/src/scripts/OSFramework/OSUI/Pattern/ButtonLoading/IButtonLoading.ts
@@ -7,5 +7,12 @@ namespace OSFramework.OSUI.Patterns.ButtonLoading {
 	 * @interface IButtonLoading
 	 * @extends {Interface.IPattern}
 	 */
-	export type IButtonLoading = Interface.IPattern
+	export interface IButtonLoading extends Interface.IPattern {
+		/**
+		 * Forces the disabled attribute on the button element to be managed when IsLoading is true.
+		 *
+		 * @param {boolean} isDisabled When true, the button is disabled while IsLoading is true.
+		 */
+		disabledStateOnIsLoading(isDisabled: boolean): void;
+	}
 }

--- a/src/scripts/OSFramework/OSUI/Pattern/ButtonLoading/scss/_button-loading.scss
+++ b/src/scripts/OSFramework/OSUI/Pattern/ButtonLoading/scss/_button-loading.scss
@@ -27,11 +27,6 @@
 	}
 
 	&.osui-btn-loading--is-loading {
-		&,
-		& * {
-			pointer-events: none;
-		}
-
 		.btn {
 			.osui-btn-loading__spinner-animation {
 				display: inline-block;

--- a/src/scripts/OutSystems/OSUI/ErrorCodes.ts
+++ b/src/scripts/OutSystems/OSUI/ErrorCodes.ts
@@ -170,6 +170,7 @@ namespace OutSystems.OSUI.ErrorCodes {
 		FailChangeProperty: 'OSUI-API-15001',
 		FailDispose: 'OSUI-API-15002',
 		FailRegisterCallback: 'OSUI-API-15003',
+		FailForceDisabledStateOnIsLoading: 'OSUI-API-15004',
 	};
 
 	export const DropdownServerSideItem = {

--- a/src/scripts/OutSystems/OSUI/Patterns/ButtonLoadingAPI.ts
+++ b/src/scripts/OutSystems/OSUI/Patterns/ButtonLoadingAPI.ts
@@ -115,6 +115,27 @@ namespace OutSystems.OSUI.Patterns.ButtonLoadingAPI {
 	}
 
 	/**
+	 * Sets whether the disabled attribute on the button element should be managed when IsLoading is true.
+	 *
+	 * @export
+	 * @param {string} buttonLoadingId ID of the ButtonLoading instance.
+	 * @param {boolean} isDisabled When true, the button is disabled while loading.
+	 * @return {*}  {string}
+	 */
+	export function ForceIsLoadingDisabledState(buttonLoadingId: string, isDisabled: boolean): string {
+		const result = OutSystems.OSUI.Utils.CreateApiResponse({
+			errorCode: ErrorCodes.ButtonLoading.FailForceDisabledStateOnIsLoading,
+			callback: () => {
+				const buttonLoading = GetButtonLoadingById(buttonLoadingId);
+
+				buttonLoading.disabledStateOnIsLoading(isDisabled);
+			},
+		});
+
+		return result;
+	}
+
+	/**
 	 * Function to register a provider callback
 	 *
 	 * @export

--- a/src/scss/O11.OutSystemsUI.scss
+++ b/src/scss/O11.OutSystemsUI.scss
@@ -17,7 +17,7 @@ PS: This comment block will not be visible in the compiled version!
 =============================================================================== */
 
 /*!
-OutSystems UI 2.29.0 • O11 Platform
+OutSystems UI 2.30.0 • O11 Platform
 Website:
  • https://www.outsystems.com/outsystems-ui
 GitHub:

--- a/src/scss/ODC.OutSystemsUI.scss
+++ b/src/scss/ODC.OutSystemsUI.scss
@@ -17,7 +17,7 @@ PS: This comment block will not be visible in the compiled version!
 =============================================================================== */
 
 /*!
-OutSystems UI 2.29.0 • ODC Platform
+OutSystems UI 2.30.0 • ODC Platform
 Website:
  • https://www.outsystems.com/outsystems-ui
 GitHub:


### PR DESCRIPTION
This pull request introduces a new feature that allows developers to control whether the `disabled` attribute is managed on the button element when the ButtonLoading pattern is in a loading state. It also exposes a new API method for toggling this behavior, updates the interface and error codes accordingly, and makes a minor update to the SCSS versioning.

**New feature: Manage disabled attribute on loading**

* Added a private flag `_disableBtnWhenIsLoading` and related logic in `ButtonLoading.ts` to control whether the button is automatically disabled when loading (`IsLoading`). This is now handled by the `_setButtonDisabled` method, which is called whenever the loading state changes. [[1]](diffhunk://#diff-c7aa23255ef530d7cbc5cb9668b33524c7f8c749691afa2dc265ceb95c36f679R16-R38) [[2]](diffhunk://#diff-c7aa23255ef530d7cbc5cb9668b33524c7f8c749691afa2dc265ceb95c36f679R49-L42)
* Introduced a public method `disabledStateOnIsLoading(isDisabled: boolean)` to allow toggling this behavior at runtime.
* Updated the `IButtonLoading` interface to include the new method for controlling the disabled state management.
* Added a new property `ManageDisabledAttribute` to the ButtonLoading enum for future extensibility.

**API and error code updates**

* Added a new API function `ForceIsLoadingDisabledState` in `ButtonLoadingAPI.ts` to allow external consumers to enable or disable automatic management of the `disabled` attribute.
* Introduced a new error code `FailForceDisabledStateOnIsLoading` for error handling in the new API.

**Other changes**

* Removed the CSS rule that set `pointer-events: none` on all elements during loading in `_button-loading.scss`, which may affect interaction with child elements.
* Updated the OutSystems UI version comment in `O11.OutSystemsUI.scss` and `ODC.OutSystemsUI.scss` to 2.30.0. [[1]](diffhunk://#diff-174f4f41f4e00a37aeda3808ea1de989babee6ccc14cd0697f2da296df09b29dL20-R20) [[2]](diffhunk://#diff-6c7f8e4457c0fc934ce61eda8c5f830db77bdb343fb97bf67f6f3abd689e8559L20-R20)