### PR TITLE
ROU-12880: Align Dropdown Server Side input with Figma

### DIFF
--- a/src/scss/01-foundations/_icon-library-o11.scss
+++ b/src/scss/01-foundations/_icon-library-o11.scss
@@ -199,6 +199,18 @@
 
 // DropdownServerSide
 .osui-dropdown-serverside {
+	&__balloon {
+		// Search placeholder
+		&-search {
+			&:before {
+				content: '\f002';
+				font: normal normal normal 14px/1 FontAwesome;
+			}
+		}
+	}
+}
+
+.osui-dropdown-serverside {
 	&__selected-values {
 		&:after {
 			content: '\f107';

--- a/src/scss/01-foundations/_icon-library-o11.scss
+++ b/src/scss/01-foundations/_icon-library-o11.scss
@@ -199,18 +199,6 @@
 
 // DropdownServerSide
 .osui-dropdown-serverside {
-	&__balloon {
-		// Search placeholder
-		&-search {
-			&:before {
-				content: '\f002';
-				font: normal normal normal 14px/1 FontAwesome;
-			}
-		}
-	}
-}
-
-.osui-dropdown-serverside {
 	&__selected-values {
 		&:after {
 			content: '\f107';

--- a/src/scss/01-foundations/_root.scss
+++ b/src/scss/01-foundations/_root.scss
@@ -31,6 +31,7 @@
 	--color-border-subtle: #{$token-border-subtle};
 	--color-border-subtlest: #{$token-border-subtlest};
 	--color-border-input: #{$token-border-input-default};
+	--color-border-input-hover: #{$token-border-input-hover};
 	--color-border-input-press: #{$token-border-input-press};
 	--color-border-primary: #{$token-border-primary}; // border-specific primary tier (focus rings)
 

--- a/src/scss/03-widgets/_dropdown.scss
+++ b/src/scss/03-widgets/_dropdown.scss
@@ -11,6 +11,8 @@
 		--osui-dropdown-border-width: #{$token-border-size-025};
 		--osui-dropdown-color: var(--color-text);
 		--osui-dropdown-border-radius: var(--border-radius-soft);
+		--osui-dropdown-hover-border-color: var(--color-border-input-hover);
+		--osui-dropdown-prompt-color: var(--color-text-subtlest);
 		--osui-dropdown-list-background: var(--color-background-surface);
 		--osui-dropdown-list-border-color: var(--color-border);
 		--osui-dropdown-list-max-height: 240px;
@@ -40,11 +42,26 @@
 				padding: $token-scale-0 $token-scale-400;
 				width: 100%;
 
+				&:hover {
+					border-color: var(--osui-dropdown-hover-border-color);
+				}
+
 				&:focus {
 					border: var(--osui-dropdown-border-width) solid var(--osui-dropdown-focus-border-color);
 					box-shadow: 0 0 0 $token-border-size-050 var(--osui-dropdown-focus-ring-color);
 					outline: none;
 				}
+			}
+		}
+
+		// Prompt (empty) state for the native <select> variant — muted by default,
+		// darkens to text-default on hover (matches Figma). Detected by the empty-value
+		// prompt option being the checked one.
+		& > select.dropdown-display:has(option:checked[value='']) {
+			color: var(--osui-dropdown-prompt-color);
+
+			&:hover {
+				color: var(--osui-dropdown-color);
 			}
 		}
 

--- a/src/scss/04-patterns/03-interaction/dropdown/_dropdown-serverside.scss
+++ b/src/scss/04-patterns/03-interaction/dropdown/_dropdown-serverside.scss
@@ -10,11 +10,17 @@ $balloonMobileTopMargin: 5vh;
 ///
 .osui-dropdown-serverside {
 	// ─── Component CSS API ─────────────────────────────────────────────
-	--osui-dropdown-ss-background: var(--color-background-surface);
+	--osui-dropdown-ss-arrow-color: #{$token-icon-subtlest};
+	--osui-dropdown-ss-background: var(--color-background-input);
 	--osui-dropdown-ss-border-color: var(--color-border-input);
+	--osui-dropdown-ss-border-radius: var(--border-radius-soft);
 	--osui-dropdown-ss-color: var(--color-text);
 	--osui-dropdown-ss-disabled-background: var(--color-background-input-disabled);
 	--osui-dropdown-ss-disabled-color: var(--color-text-disabled);
+	--osui-dropdown-ss-focus-border-color: var(--color-border-primary);
+	--osui-dropdown-ss-focus-ring-color: #{$token-border-focus-default};
+	--osui-dropdown-ss-hover-border-color: var(--color-border-input-hover);
+	--osui-dropdown-ss-prompt-color: var(--color-text-subtlest);
 	// ───────────────────────────────────────────────────────────────────
 
 	--osui-dropdown-ss-balloon-max-height: 300px;
@@ -24,9 +30,11 @@ $balloonMobileTopMargin: 5vh;
 	position: relative;
 
 	.osui-balloon {
-		--osui-balloon-shadow: none;
+		// Match the widget Dropdown list container: soft radius, overlay shadow, neutral border
+		--osui-balloon-shadow: var(--osui-elevation-overlay);
+		--osui-balloon-shape: var(--border-radius-soft);
 
-		border: $token-border-size-025 solid var(--color-border-input);
+		border: $token-border-size-025 solid var(--color-border);
 		display: flex;
 		flex-direction: column;
 		flex: 1;
@@ -56,13 +64,9 @@ $balloonMobileTopMargin: 5vh;
 		margin-right: $token-scale-400;
 		overflow: hidden;
 
-		&:hover {
-			border-color: var(--color-border-input);
-		}
-
 		&:after {
 			align-items: center;
-			color: var(--color-text-subtlest);
+			color: var(--osui-dropdown-ss-arrow-color);
 			display: flex;
 			height: 100%;
 			pointer-events: none;
@@ -88,7 +92,7 @@ $balloonMobileTopMargin: 5vh;
 		&-wrapper {
 			align-items: center;
 			background-color: var(--osui-dropdown-ss-background);
-			border-radius: $token-border-radius-100;
+			border-radius: var(--osui-dropdown-ss-border-radius);
 			border: $token-border-size-025 solid var(--osui-dropdown-ss-border-color);
 			color: var(--osui-dropdown-ss-color);
 			cursor: pointer;
@@ -99,6 +103,19 @@ $balloonMobileTopMargin: 5vh;
 			position: relative;
 			transition: border $token-transition-time-300 $token-transition-curve-expressive;
 			width: 100%;
+
+			// Hover — border darkens (matches Figma border/input/hover)
+			&:hover {
+				border-color: var(--osui-dropdown-ss-hover-border-color);
+			}
+
+			// Focus ring
+			&:focus,
+			&:focus-visible {
+				border-color: var(--osui-dropdown-ss-focus-border-color);
+				box-shadow: 0 0 0 $token-border-size-050 var(--osui-dropdown-ss-focus-ring-color);
+				outline: none;
+			}
 
 			// Service Studio Preview
 			& {
@@ -149,7 +166,7 @@ $balloonMobileTopMargin: 5vh;
 				color: inherit;
 				font-size: $token-font-size-350;
 				height: $token-scale-1000;
-				padding: $token-scale-0 $token-scale-200 $token-scale-0 $token-scale-1000;
+				padding: $token-scale-0 $token-scale-200 $token-scale-0 $token-scale-400;
 				width: 100%;
 
 				&:focus,
@@ -215,13 +232,13 @@ $balloonMobileTopMargin: 5vh;
 		.osui-dropdown-serverside {
 			// "Input" section wrapper - SelectedValues container wrapper
 			&__selected-values-wrapper {
-				border-color: $token-semantics-primary-base;
+				border-color: var(--osui-dropdown-ss-focus-border-color);
+				box-shadow: 0 0 0 $token-border-size-050 var(--osui-dropdown-ss-focus-ring-color);
 			}
 
 			// "Input" section - SelectedValues container
 			&__selected-values {
 				&:after {
-					color: $token-semantics-primary-base;
 					transform: rotate(180deg);
 				}
 			}
@@ -252,7 +269,7 @@ $balloonMobileTopMargin: 5vh;
 	&--not-valid {
 		.osui-dropdown-serverside__selected-values-wrapper {
 			/* !important should be here in order to grant more specific selectors be overriding border color at this context. */
-			border-color: $token-semantics-danger-base !important;
+			border-color: var(--color-border-danger) !important;
 		}
 
 		& + .osui-dropdown-serverside-error-message {
@@ -260,6 +277,18 @@ $balloonMobileTopMargin: 5vh;
 			font-size: $token-font-size-300;
 			margin-left: $token-scale-0;
 			margin-top: $token-scale-075;
+		}
+	}
+
+	// Prompt (empty) state — muted text by default, darkens to text-default on hover (matches Figma).
+	// Empty is detected by the absence of a selected option item under the root.
+	&:not(.osui-dropdown-serverside--is-disabled):not(:has(.osui-dropdown-serverside-item--is-selected)) {
+		.osui-dropdown-serverside__text {
+			color: var(--osui-dropdown-ss-prompt-color);
+		}
+
+		.osui-dropdown-serverside__selected-values-wrapper:hover .osui-dropdown-serverside__text {
+			color: var(--osui-dropdown-ss-color);
 		}
 	}
 }
@@ -409,7 +438,7 @@ $balloonMobileTopMargin: 5vh;
 
 				input,
 				.form-control[data-input] {
-					padding: $token-scale-0 $token-scale-1000 $token-scale-0 $token-scale-200;
+					padding: $token-scale-0 $token-scale-400 $token-scale-0 $token-scale-200;
 				}
 			}
 		}

--- a/src/scss/04-patterns/03-interaction/dropdown/_dropdownserversideitem.scss
+++ b/src/scss/04-patterns/03-interaction/dropdown/_dropdownserversideitem.scss
@@ -8,7 +8,7 @@
 	// ─── Component CSS API ─────────────────────────────────────────────
 	--osui-dropdown-item-background: transparent;
 	--osui-dropdown-item-color: var(--color-text);
-	--osui-dropdown-item-hover-bg: #{$token-bg-neutral-subtle-default};
+	--osui-dropdown-item-hover-bg: var(--color-border-subtle);
 	// ───────────────────────────────────────────────────────────────────
 
 	align-items: center;


### PR DESCRIPTION
This PR is for aligning the Dropdown Server Side input and search field with the Figma design.

### What was happening
* The input used the surface background instead of the input background token.
* There was no hover/focus border nor focus ring on the input wrapper.
* The dropdown arrow turned primary/blue when the dropdown was open instead of keeping the subtle icon colour.
* The empty (prompt) state text was not muted and did not darken on hover.
* The balloon container did not match the widget Dropdown list (radius, shadow, border).
* The search input had an excessive left padding.
* Item hover background and balloon used mismatched tokens.

### What was done
* Routed the input styling through the component CSS API vars (--osui-dropdown-ss-*) and aligned defaults to Figma.
* Input background now uses the input background token; added hover border, focus border and focus ring.
* Added --osui-dropdown-ss-arrow-color (icon-subtlest); the arrow keeps its colour when open and only rotates.
* Added a muted prompt state that darkens to text-default on hover.
* Matched the balloon to the widget Dropdown list (soft radius, overlay shadow, neutral border).
* Reduced the search input left padding to align with the search-wrapper inset.
* Aligned the item hover background token and added --color-border-input-hover to the foundations root.

### Test Steps
1. Open a screen with a Dropdown Server Side pattern.
2. Confirm the closed input matches Figma (input background, border, muted prompt text that darkens on hover).
3. Hover the input and confirm the border darkens; focus it and confirm the focus border + ring appear.
4. Open the dropdown and confirm the arrow keeps the subtle grey colour (#838383) and only rotates.
5. Open the search and confirm the left padding/alignment is correct in both LTR and RTL.

### Screenshots
(prefer animated gif)

### Checklist
* [ ] tested locally
* [ ] documented the code
* [ ] clean all warnings and errors of eslint
* [ ] requires changes in OutSystems (if so, provide a module with changes)
* [ ] requires new sample page in OutSystems (if so, provide a module with changes)
