### PR TITLE
ROU-12937: Fix Carousel removeChild NotFoundError on data refresh

### DIFF
--- a/src/scripts/Providers/OSUI/Carousel/Splide/Splide.ts
+++ b/src/scripts/Providers/OSUI/Carousel/Splide/Splide.ts
@@ -142,8 +142,8 @@ namespace Providers.OSUI.Carousel.Splide {
 				for (const item of _childrenList) {
 					if (!item.classList.contains(Enum.CssClass.SplideSlide)) {
 						// Never create or move platform-owned nodes here (ROU-12937): reparenting an <img>
-						// (e.g. wrapping it in a <div>) invalidates React's fiber bookkeeping on ODC and
-						// crashes the next reconcile with NotFoundError on removeChild. Only mutate classes;
+						// (e.g. wrapping it in a <div>) invalidates React's fiber bookkeeping and crashes
+						// the next reconcile with NotFoundError on removeChild. Only mutate classes;
 						// invalid ARIA roles on <img> slides are handled non-destructively in _setListRoles.
 						item.classList.add(Enum.CssClass.SplideSlide);
 					}
@@ -192,22 +192,33 @@ namespace Providers.OSUI.Carousel.Splide {
 		private _setListRoles(): void {
 			// Remove role="tabpanel" from slides that contain img, ul, ol, or li — elements for
 			// which tabpanel ownership is invalid or creates conflicting semantics
-			this.selfElement.querySelectorAll(OSFramework.OSUI.Constants.Dot + Enum.CssClass.SplideSlide).forEach((slide) => {
-				const _slideEl = slide as HTMLElement;
-				// A bare <img> slide (no wrapper — see ROU-12937) can hold no valid list/tab role, so
-				// strip whatever role Splide assigned to it (e.g. presentation/tabpanel). Mirrors the
-				// tabpanel strip below for slides that merely contain media — attribute-only, no reparenting.
-				if (_slideEl.tagName === 'IMG') {
-					OSFramework.OSUI.Helper.Dom.Attribute.Remove(_slideEl, OSFramework.OSUI.Constants.A11YAttributes.Role.AttrName);
-					return;
-				}
-				if (
-					OSFramework.OSUI.Helper.Dom.Attribute.Get(_slideEl, OSFramework.OSUI.Constants.A11YAttributes.Role.AttrName) === OSFramework.OSUI.Constants.A11YAttributes.Role.TabPanel &&
-					_slideEl.querySelector('img, ul, ol, li')
-				) {
-					OSFramework.OSUI.Helper.Dom.Attribute.Remove(_slideEl, OSFramework.OSUI.Constants.A11YAttributes.Role.AttrName);
-				}
-			});
+			this.selfElement
+				.querySelectorAll(OSFramework.OSUI.Constants.Dot + Enum.CssClass.SplideSlide)
+				.forEach((slide) => {
+					const _slideEl = slide as HTMLElement;
+					// A bare <img> slide (no wrapper — see ROU-12937) can hold no valid list/tab role, so
+					// strip whatever role Splide assigned to it (e.g. presentation/tabpanel). Mirrors the
+					// tabpanel strip below for slides that merely contain media — attribute-only, no reparenting.
+					if (_slideEl.tagName === 'IMG') {
+						OSFramework.OSUI.Helper.Dom.Attribute.Remove(
+							_slideEl,
+							OSFramework.OSUI.Constants.A11YAttributes.Role.AttrName
+						);
+						return;
+					}
+					if (
+						OSFramework.OSUI.Helper.Dom.Attribute.Get(
+							_slideEl,
+							OSFramework.OSUI.Constants.A11YAttributes.Role.AttrName
+						) === OSFramework.OSUI.Constants.A11YAttributes.Role.TabPanel &&
+						_slideEl.querySelector('img, ul, ol, li')
+					) {
+						OSFramework.OSUI.Helper.Dom.Attribute.Remove(
+							_slideEl,
+							OSFramework.OSUI.Constants.A11YAttributes.Role.AttrName
+						);
+					}
+				});
 
 			if (this._hasList && this._carouselListWidgetElem) {
 				// Dynamic content: poll until the List widget finishes loading before applying roles

--- a/src/scripts/Providers/OSUI/Carousel/Splide/Splide.ts
+++ b/src/scripts/Providers/OSUI/Carousel/Splide/Splide.ts
@@ -43,13 +43,10 @@ namespace Providers.OSUI.Carousel.Splide {
 		// aren't list items is invalid — the images stay exposed to screen readers via alt text.
 		private _applyListRoles(listEl: HTMLElement): void {
 			const _isNativeList = listEl.tagName === 'UL' || listEl.tagName === 'OL';
-			// The direct children are the slides that would receive the list item role. This check
-			// must stay direct-child-only (a wrapped image, div > img, must still get list roles),
-			// which the Dom helpers can't express — ClassSelector matches by class, TagSelector
-			// matches any descendant — so read the direct children and check them by tag.
-			const _slides = Array.from(listEl.children);
-			const _hasNativeListChildren = _slides.some((slide) => ['LI', 'OL', 'UL'].includes(slide.tagName));
-			const _hasImageSlides = _slides.some((slide) => slide.tagName === 'IMG');
+			const _hasNativeListChildren = listEl.querySelector(':scope > li, :scope > ul, :scope > ol') !== null;
+			// Direct-child <img> slides only: a wrapped image (div > img) must still get list roles,
+			// so this can't use ClassSelector (class-based) or TagSelector (matches any descendant).
+			const _hasImageSlides = listEl.querySelector(':scope > img') !== null;
 
 			if (_isNativeList || _hasNativeListChildren || _hasImageSlides) {
 				// Content can change across platform refreshes (e.g. List widget data) — drop a list
@@ -74,13 +71,13 @@ namespace Providers.OSUI.Carousel.Splide {
 				OSFramework.OSUI.Constants.A11YAttributes.Role.AttrName,
 				OSFramework.OSUI.Constants.A11YAttributes.Role.List
 			);
-			for (const slide of _slides) {
+			listEl.querySelectorAll(':scope > *').forEach((item) => {
 				OSFramework.OSUI.Helper.Dom.Attribute.Set(
-					slide as HTMLElement,
+					item as HTMLElement,
 					OSFramework.OSUI.Constants.A11YAttributes.Role.AttrName,
 					OSFramework.OSUI.Constants.A11YAttributes.Role.Listitem
 				);
-			}
+			});
 		}
 
 		// Method to wait for the OutSystems List widget to finish loading before applying roles

--- a/src/scripts/Providers/OSUI/Carousel/Splide/Splide.ts
+++ b/src/scripts/Providers/OSUI/Carousel/Splide/Splide.ts
@@ -71,9 +71,9 @@ namespace Providers.OSUI.Carousel.Splide {
 				OSFramework.OSUI.Constants.A11YAttributes.Role.AttrName,
 				OSFramework.OSUI.Constants.A11YAttributes.Role.List
 			);
-			listEl.querySelectorAll(':scope > *').forEach((item) => {
+			listEl.querySelectorAll(':scope > *').forEach((slide) => {
 				OSFramework.OSUI.Helper.Dom.Attribute.Set(
-					item as HTMLElement,
+					slide as HTMLElement,
 					OSFramework.OSUI.Constants.A11YAttributes.Role.AttrName,
 					OSFramework.OSUI.Constants.A11YAttributes.Role.Listitem
 				);
@@ -103,9 +103,12 @@ namespace Providers.OSUI.Carousel.Splide {
 			this._hasList = OutSystems.OSUI.Utils.GetHasListInside(this._carouselPlaceholderElem);
 
 			if (this._hasList) {
-				this._carouselListWidgetElem = this.selfElement.querySelector(
+				const listElem = this.selfElement.querySelector(
 					OSFramework.OSUI.Constants.Dot + OSFramework.OSUI.GlobalEnum.CssClassElements.List
 				);
+				if (listElem) {
+					this._carouselListWidgetElem = listElem as HTMLElement;
+				}
 
 				this._carouselProviderElem = this._carouselTrackElem;
 			} else {
@@ -162,7 +165,12 @@ namespace Providers.OSUI.Carousel.Splide {
 			if (_childrenList.length > 0) {
 				// Add the placeholder content already with the correct html structure per item, expected by the library
 				for (const item of _childrenList) {
-					if (!OSFramework.OSUI.Helper.Dom.Styles.ContainsClass(item as HTMLElement, Enum.CssClass.SplideSlide)) {
+					if (
+						!OSFramework.OSUI.Helper.Dom.Styles.ContainsClass(
+							item as HTMLElement,
+							Enum.CssClass.SplideSlide
+						)
+					) {
 						// Never create or move platform-owned nodes here: reparenting an <img>
 						// (e.g. wrapping it in a <div>) invalidates React's fiber bookkeeping and crashes
 						// the next reconcile with NotFoundError on removeChild. Only mutate classes;

--- a/src/scripts/Providers/OSUI/Carousel/Splide/Splide.ts
+++ b/src/scripts/Providers/OSUI/Carousel/Splide/Splide.ts
@@ -71,9 +71,9 @@ namespace Providers.OSUI.Carousel.Splide {
 				OSFramework.OSUI.Constants.A11YAttributes.Role.AttrName,
 				OSFramework.OSUI.Constants.A11YAttributes.Role.List
 			);
-			listEl.querySelectorAll(':scope > *').forEach((item) => {
+			listEl.querySelectorAll(':scope > *').forEach((slide) => {
 				OSFramework.OSUI.Helper.Dom.Attribute.Set(
-					item as HTMLElement,
+					slide as HTMLElement,
 					OSFramework.OSUI.Constants.A11YAttributes.Role.AttrName,
 					OSFramework.OSUI.Constants.A11YAttributes.Role.Listitem
 				);
@@ -162,7 +162,12 @@ namespace Providers.OSUI.Carousel.Splide {
 			if (_childrenList.length > 0) {
 				// Add the placeholder content already with the correct html structure per item, expected by the library
 				for (const item of _childrenList) {
-					if (!OSFramework.OSUI.Helper.Dom.Styles.ContainsClass(item as HTMLElement, Enum.CssClass.SplideSlide)) {
+					if (
+						!OSFramework.OSUI.Helper.Dom.Styles.ContainsClass(
+							item as HTMLElement,
+							Enum.CssClass.SplideSlide
+						)
+					) {
 						// Never create or move platform-owned nodes here: reparenting an <img>
 						// (e.g. wrapping it in a <div>) invalidates React's fiber bookkeeping and crashes
 						// the next reconcile with NotFoundError on removeChild. Only mutate classes;

--- a/src/scripts/Providers/OSUI/Carousel/Splide/Splide.ts
+++ b/src/scripts/Providers/OSUI/Carousel/Splide/Splide.ts
@@ -43,10 +43,11 @@ namespace Providers.OSUI.Carousel.Splide {
 		// aren't list items is invalid — the images stay exposed to screen readers via alt text.
 		private _applyListRoles(listEl: HTMLElement): void {
 			const _isNativeList = listEl.tagName === 'UL' || listEl.tagName === 'OL';
-			const _hasNativeListChildren = listEl.querySelector(':scope > li, :scope > ul, :scope > ol') !== null;
-			// Direct-child <img> slides only: a wrapped image (div > img) must still get list roles,
-			// so this can't use ClassSelector (class-based) or TagSelector (matches any descendant).
-			const _hasImageSlides = listEl.querySelector(':scope > img') !== null;
+			const _hasNativeListChildren =
+				OSFramework.OSUI.Helper.Dom.TagSelector(listEl, ':scope > li, :scope > ul, :scope > ol') !== undefined;
+			// Direct-child <img> slides only — a wrapped image (div > img) must still get list roles,
+			// so the selector is scoped with ':scope >' instead of matching any descendant.
+			const _hasImageSlides = OSFramework.OSUI.Helper.Dom.TagSelector(listEl, ':scope > img') !== undefined;
 
 			if (_isNativeList || _hasNativeListChildren || _hasImageSlides) {
 				// Content can change across platform refreshes (e.g. List widget data) — drop a list
@@ -71,9 +72,9 @@ namespace Providers.OSUI.Carousel.Splide {
 				OSFramework.OSUI.Constants.A11YAttributes.Role.AttrName,
 				OSFramework.OSUI.Constants.A11YAttributes.Role.List
 			);
-			listEl.querySelectorAll(':scope > *').forEach((slide) => {
+			OSFramework.OSUI.Helper.Dom.TagSelectorAll(listEl, ':scope > *')?.forEach((slide) => {
 				OSFramework.OSUI.Helper.Dom.Attribute.Set(
-					slide as HTMLElement,
+					slide,
 					OSFramework.OSUI.Constants.A11YAttributes.Role.AttrName,
 					OSFramework.OSUI.Constants.A11YAttributes.Role.Listitem
 				);

--- a/src/scripts/Providers/OSUI/Carousel/Splide/Splide.ts
+++ b/src/scripts/Providers/OSUI/Carousel/Splide/Splide.ts
@@ -37,24 +37,27 @@ namespace Providers.OSUI.Carousel.Splide {
 
 		// Method to apply role="list" and role="listitem" to the list element and its direct children.
 		// Skips native list elements (ul/ol) and elements whose direct children are native list
-		// elements (li/ul/ol), since those already carry implicit list semantics.
+		// elements (li/ul/ol), since those already carry implicit list semantics. Also skips lists
+		// with bare <img> slides: images can't take role="listitem" without replacing their image
+		// semantics, wrapping them is off-limits, and a role="list" whose children
+		// aren't list items is invalid — the images stay exposed to screen readers via alt text.
 		private _applyListRoles(listEl: HTMLElement): void {
 			const _isNativeList = listEl.tagName === 'UL' || listEl.tagName === 'OL';
 			const _hasNativeListChildren = listEl.querySelector(':scope > li, :scope > ul, :scope > ol') !== null;
+			const _hasImageSlides = listEl.querySelector(':scope > img') !== null;
 
-			if (_isNativeList || _hasNativeListChildren) {
+			if (_isNativeList || _hasNativeListChildren || _hasImageSlides) {
+				// Content can change across platform refreshes (e.g. List widget data) — drop a list
+				// role applied on a previous pass so it never wraps children that aren't list items
+				if (_hasImageSlides && listEl.getAttribute('role') === 'list') {
+					listEl.removeAttribute('role');
+				}
 				return;
 			}
 
 			listEl.setAttribute('role', 'list');
 			listEl.querySelectorAll(':scope > *').forEach((item) => {
-				// Never assign a list role to a bare <img> slide: neither role="listitem" nor Splide's
-				// role="presentation" is valid on an image. Strip any assigned role instead (ROU-12937).
-				if (item.tagName === 'IMG') {
-					item.removeAttribute('role');
-				} else {
-					item.setAttribute('role', 'listitem');
-				}
+				item.setAttribute('role', 'listitem');
 			});
 		}
 
@@ -141,10 +144,10 @@ namespace Providers.OSUI.Carousel.Splide {
 				// Add the placeholder content already with the correct html structure per item, expected by the library
 				for (const item of _childrenList) {
 					if (!item.classList.contains(Enum.CssClass.SplideSlide)) {
-						// Never create or move platform-owned nodes here (ROU-12937): reparenting an <img>
+						// Never create or move platform-owned nodes here: reparenting an <img>
 						// (e.g. wrapping it in a <div>) invalidates React's fiber bookkeeping and crashes
 						// the next reconcile with NotFoundError on removeChild. Only mutate classes;
-						// invalid ARIA roles on <img> slides are handled non-destructively in _setListRoles.
+						// ARIA roles on <img> slides are stripped non-destructively in _setListRoles.
 						item.classList.add(Enum.CssClass.SplideSlide);
 					}
 				}
@@ -190,15 +193,16 @@ namespace Providers.OSUI.Carousel.Splide {
 
 		// Method to assign correct ARIA list roles so screen readers interpret carousel lists properly
 		private _setListRoles(): void {
-			// Remove role="tabpanel" from slides that contain img, ul, ol, or li — elements for
-			// which tabpanel ownership is invalid or creates conflicting semantics
+			// Remove role="tabpanel" from slides that are native list elements (ul/ol/li) — the same
+			// cases where _applyListRoles skips custom roles, so nothing overrides the conflicting
+			// tabpanel afterwards
 			this.selfElement
 				.querySelectorAll(OSFramework.OSUI.Constants.Dot + Enum.CssClass.SplideSlide)
 				.forEach((slide) => {
 					const _slideEl = slide as HTMLElement;
-					// A bare <img> slide (no wrapper — see ROU-12937) can hold no valid list/tab role, so
-					// strip whatever role Splide assigned to it (e.g. presentation/tabpanel). Mirrors the
-					// tabpanel strip below for slides that merely contain media — attribute-only, no reparenting.
+					// A bare <img> slide keeps no assigned role (ROU-12937): role="presentation" is valid
+					// on an image, but it removes the image from the accessibility tree, hiding it from
+					// screen readers. Stripping the role keeps the image announced via its alt text.
 					if (_slideEl.tagName === 'IMG') {
 						OSFramework.OSUI.Helper.Dom.Attribute.Remove(
 							_slideEl,
@@ -211,7 +215,7 @@ namespace Providers.OSUI.Carousel.Splide {
 							_slideEl,
 							OSFramework.OSUI.Constants.A11YAttributes.Role.AttrName
 						) === OSFramework.OSUI.Constants.A11YAttributes.Role.TabPanel &&
-						_slideEl.querySelector('img, ul, ol, li')
+						['UL', 'OL', 'LI'].includes(_slideEl.tagName)
 					) {
 						OSFramework.OSUI.Helper.Dom.Attribute.Remove(
 							_slideEl,

--- a/src/scripts/Providers/OSUI/Carousel/Splide/Splide.ts
+++ b/src/scripts/Providers/OSUI/Carousel/Splide/Splide.ts
@@ -48,7 +48,13 @@ namespace Providers.OSUI.Carousel.Splide {
 
 			listEl.setAttribute('role', 'list');
 			listEl.querySelectorAll(':scope > *').forEach((item) => {
-				item.setAttribute('role', 'listitem');
+				// Never assign a list role to a bare <img> slide: neither role="listitem" nor Splide's
+				// role="presentation" is valid on an image. Strip any assigned role instead (ROU-12937).
+				if (item.tagName === 'IMG') {
+					item.removeAttribute('role');
+				} else {
+					item.setAttribute('role', 'listitem');
+				}
 			});
 		}
 
@@ -135,17 +141,11 @@ namespace Providers.OSUI.Carousel.Splide {
 				// Add the placeholder content already with the correct html structure per item, expected by the library
 				for (const item of _childrenList) {
 					if (!item.classList.contains(Enum.CssClass.SplideSlide)) {
-						// Splide assigns role="presentation" to each splide__slide element, which is then
-						// overridden with role="listitem" by the OSUIListRoles extension. Neither role
-						// is valid on an <img>. Wrap bare images in a <div> so the role lands on the container.
-						if (item.tagName === 'IMG') {
-							const wrapper = document.createElement(OSFramework.OSUI.GlobalEnum.HTMLElement.Div);
-							item.replaceWith(wrapper);
-							wrapper.appendChild(item);
-							wrapper.classList.add(Enum.CssClass.SplideSlide);
-						} else {
-							item.classList.add(Enum.CssClass.SplideSlide);
-						}
+						// Never create or move platform-owned nodes here (ROU-12937): reparenting an <img>
+						// (e.g. wrapping it in a <div>) invalidates React's fiber bookkeeping on ODC and
+						// crashes the next reconcile with NotFoundError on removeChild. Only mutate classes;
+						// invalid ARIA roles on <img> slides are handled non-destructively in _setListRoles.
+						item.classList.add(Enum.CssClass.SplideSlide);
 					}
 				}
 			}
@@ -194,6 +194,13 @@ namespace Providers.OSUI.Carousel.Splide {
 			// which tabpanel ownership is invalid or creates conflicting semantics
 			this.selfElement.querySelectorAll(OSFramework.OSUI.Constants.Dot + Enum.CssClass.SplideSlide).forEach((slide) => {
 				const _slideEl = slide as HTMLElement;
+				// A bare <img> slide (no wrapper — see ROU-12937) can hold no valid list/tab role, so
+				// strip whatever role Splide assigned to it (e.g. presentation/tabpanel). Mirrors the
+				// tabpanel strip below for slides that merely contain media — attribute-only, no reparenting.
+				if (_slideEl.tagName === 'IMG') {
+					OSFramework.OSUI.Helper.Dom.Attribute.Remove(_slideEl, OSFramework.OSUI.Constants.A11YAttributes.Role.AttrName);
+					return;
+				}
 				if (
 					OSFramework.OSUI.Helper.Dom.Attribute.Get(_slideEl, OSFramework.OSUI.Constants.A11YAttributes.Role.AttrName) === OSFramework.OSUI.Constants.A11YAttributes.Role.TabPanel &&
 					_slideEl.querySelector('img, ul, ol, li')

--- a/src/scripts/Providers/OSUI/Carousel/Splide/Splide.ts
+++ b/src/scripts/Providers/OSUI/Carousel/Splide/Splide.ts
@@ -71,9 +71,9 @@ namespace Providers.OSUI.Carousel.Splide {
 				OSFramework.OSUI.Constants.A11YAttributes.Role.AttrName,
 				OSFramework.OSUI.Constants.A11YAttributes.Role.List
 			);
-			listEl.querySelectorAll(':scope > *').forEach((slide) => {
+			listEl.querySelectorAll(':scope > *').forEach((item) => {
 				OSFramework.OSUI.Helper.Dom.Attribute.Set(
-					slide as HTMLElement,
+					item as HTMLElement,
 					OSFramework.OSUI.Constants.A11YAttributes.Role.AttrName,
 					OSFramework.OSUI.Constants.A11YAttributes.Role.Listitem
 				);
@@ -103,12 +103,9 @@ namespace Providers.OSUI.Carousel.Splide {
 			this._hasList = OutSystems.OSUI.Utils.GetHasListInside(this._carouselPlaceholderElem);
 
 			if (this._hasList) {
-				const listElem = this.selfElement.querySelector(
+				this._carouselListWidgetElem = this.selfElement.querySelector(
 					OSFramework.OSUI.Constants.Dot + OSFramework.OSUI.GlobalEnum.CssClassElements.List
 				);
-				if (listElem) {
-					this._carouselListWidgetElem = listElem as HTMLElement;
-				}
 
 				this._carouselProviderElem = this._carouselTrackElem;
 			} else {
@@ -165,12 +162,7 @@ namespace Providers.OSUI.Carousel.Splide {
 			if (_childrenList.length > 0) {
 				// Add the placeholder content already with the correct html structure per item, expected by the library
 				for (const item of _childrenList) {
-					if (
-						!OSFramework.OSUI.Helper.Dom.Styles.ContainsClass(
-							item as HTMLElement,
-							Enum.CssClass.SplideSlide
-						)
-					) {
+					if (!OSFramework.OSUI.Helper.Dom.Styles.ContainsClass(item as HTMLElement, Enum.CssClass.SplideSlide)) {
 						// Never create or move platform-owned nodes here: reparenting an <img>
 						// (e.g. wrapping it in a <div>) invalidates React's fiber bookkeeping and crashes
 						// the next reconcile with NotFoundError on removeChild. Only mutate classes;

--- a/src/scripts/Providers/OSUI/Carousel/Splide/Splide.ts
+++ b/src/scripts/Providers/OSUI/Carousel/Splide/Splide.ts
@@ -43,22 +43,44 @@ namespace Providers.OSUI.Carousel.Splide {
 		// aren't list items is invalid — the images stay exposed to screen readers via alt text.
 		private _applyListRoles(listEl: HTMLElement): void {
 			const _isNativeList = listEl.tagName === 'UL' || listEl.tagName === 'OL';
-			const _hasNativeListChildren = listEl.querySelector(':scope > li, :scope > ul, :scope > ol') !== null;
-			const _hasImageSlides = listEl.querySelector(':scope > img') !== null;
+			// The direct children are the slides that would receive the list item role. This check
+			// must stay direct-child-only (a wrapped image, div > img, must still get list roles),
+			// which the Dom helpers can't express — ClassSelector matches by class, TagSelector
+			// matches any descendant — so read the direct children and check them by tag.
+			const _slides = Array.from(listEl.children);
+			const _hasNativeListChildren = _slides.some((slide) => ['LI', 'OL', 'UL'].includes(slide.tagName));
+			const _hasImageSlides = _slides.some((slide) => slide.tagName === 'IMG');
 
 			if (_isNativeList || _hasNativeListChildren || _hasImageSlides) {
 				// Content can change across platform refreshes (e.g. List widget data) — drop a list
 				// role applied on a previous pass so it never wraps children that aren't list items
-				if (_hasImageSlides && listEl.getAttribute('role') === 'list') {
-					listEl.removeAttribute('role');
+				if (
+					_hasImageSlides &&
+					OSFramework.OSUI.Helper.Dom.Attribute.Get(
+						listEl,
+						OSFramework.OSUI.Constants.A11YAttributes.Role.AttrName
+					) === OSFramework.OSUI.Constants.A11YAttributes.Role.List
+				) {
+					OSFramework.OSUI.Helper.Dom.Attribute.Remove(
+						listEl,
+						OSFramework.OSUI.Constants.A11YAttributes.Role.AttrName
+					);
 				}
 				return;
 			}
 
-			listEl.setAttribute('role', 'list');
-			listEl.querySelectorAll(':scope > *').forEach((item) => {
-				item.setAttribute('role', 'listitem');
-			});
+			OSFramework.OSUI.Helper.Dom.Attribute.Set(
+				listEl,
+				OSFramework.OSUI.Constants.A11YAttributes.Role.AttrName,
+				OSFramework.OSUI.Constants.A11YAttributes.Role.List
+			);
+			for (const slide of _slides) {
+				OSFramework.OSUI.Helper.Dom.Attribute.Set(
+					slide as HTMLElement,
+					OSFramework.OSUI.Constants.A11YAttributes.Role.AttrName,
+					OSFramework.OSUI.Constants.A11YAttributes.Role.Listitem
+				);
+			}
 		}
 
 		// Method to wait for the OutSystems List widget to finish loading before applying roles
@@ -143,12 +165,12 @@ namespace Providers.OSUI.Carousel.Splide {
 			if (_childrenList.length > 0) {
 				// Add the placeholder content already with the correct html structure per item, expected by the library
 				for (const item of _childrenList) {
-					if (!item.classList.contains(Enum.CssClass.SplideSlide)) {
+					if (!OSFramework.OSUI.Helper.Dom.Styles.ContainsClass(item as HTMLElement, Enum.CssClass.SplideSlide)) {
 						// Never create or move platform-owned nodes here: reparenting an <img>
 						// (e.g. wrapping it in a <div>) invalidates React's fiber bookkeeping and crashes
 						// the next reconcile with NotFoundError on removeChild. Only mutate classes;
 						// ARIA roles on <img> slides are stripped non-destructively in _setListRoles.
-						item.classList.add(Enum.CssClass.SplideSlide);
+						OSFramework.OSUI.Helper.Dom.Styles.AddClass(item as HTMLElement, Enum.CssClass.SplideSlide);
 					}
 				}
 			}


### PR DESCRIPTION
### What was happening

On O11 and  ODC, a Carousel with bare `<img>` slides crashed with `NotFoundError: Failed to execute 'removeChild' on 'Node'` (`OS-CLRT-60500`) when a `ParameterOnChange` action re-executed an aggregate feeding the carousel (and an IF around it).

Regressed in **v2.29.0** by commit `c30702391` (PR #1138, ROU-12567): `_prepareCarouselItems()` started reparenting bare `<img>` slides into a newly created wrapper `<div>`:

```ts
if (item.tagName === 'IMG') {
    const wrapper = document.createElement(...Div);
    item.replaceWith(wrapper);   // moves a platform-owned node
    wrapper.appendChild(item);
    wrapper.classList.add(Enum.CssClass.SplideSlide);
}
```

The `<img>` is a **platform-owned** node. On O11 and  ODC, the runtime is React; moving it invalidates React's fiber record of the node's parent, so the next reconcile (triggered by the aggregate refresh) calls `parent.removeChild(img)` against a parent that no longer contains it → throw. Every provider `redraw()` re-ran this and re-wrapped the fresh nodes, making it self-sustaining.

### What was done

Stop reparenting and keep the ARIA roles valid without moving any DOM — 3 changes in `Splide.ts`:

1. **`_prepareCarouselItems()`** — restored the pre-regression class-add loop: every item (incl. `<img>`) just gets the `splide__slide` class; no node is created or moved. Kept the `Array.from` snapshot.
2. **`_applyListRoles()`** — skip list semantics when the list has bare `<img>` slides: a `role="list"` whose children aren't list items is invalid ARIA, and an image can't take `role="listitem"` without losing its image semantics. Also drops a `role="list"` left from a previous pass when content changes across platform refreshes. The images stay exposed to screen readers via their alt text.
3. **`_setListRoles()`** — strip the role Splide assigns to a bare `<img>` slide: `role="presentation"` is valid on an image but removes it from the accessibility tree, so stripping it keeps the image announced via its alt text. Also strip `role="tabpanel"` from slides that **are** native list elements (`ul`/`ol`/`li`), via a `tagName` check.

PR #1138's other improvements (WCAG pagination target size, list/listitem roles for non-img slides, root `role="presentation"`) are preserved untouched.

### Test Steps

1. Open the sample page 
2. Go to the "Test Carousel OnParameterChanged" section.
3. Toggle the `Test_Carousel_OnParameterChanged` switch a few times (re-runs `OnParametersChanged`).
4. Before fix: `NotFoundError … removeChild` in the console. After fix: no error; carousel keeps rendering.

### Screenshots

N.A.

### Checklist

-   [x] tested locally
-   [x] documented the code
-   [x] clean all warnings and errors of eslint
-   [ ] requires changes in OutSystems (if so, provide a module with changes)
-   [ ] requires new sample page in OutSystems (if so, provide a module with changes)
