### PR TITLE
ROU-12799: Input with type search started to have an icon with v2.28.0 and icon modernization

### DIFF
--- a/src/scss/01-foundations/_icon-library-odc.scss
+++ b/src/scss/01-foundations/_icon-library-odc.scss
@@ -120,6 +120,38 @@ body.iconLibrary-phosphor {
 	font-family: var(--osui-icon-font-family);
 }
 
+// Search – search icon
+.osui-search .input-search {
+	position: relative;
+
+	&::after {
+		color: var(--color-neutral-6);
+		content: var(--osui-icon-search);
+		font-family: var(--osui-icon-font-family);
+		left: var(--space-base);
+		pointer-events: none;
+		position: absolute;
+		top: 50%;
+		transform: translateY(-50%);
+	}
+
+	.form-control[data-input]{
+		padding-left: var(--space-xl);
+	}
+}
+
+.is-rtl .osui-search .input-search {
+	&::after {
+		left: auto;
+		right: var(--space-base);
+	}
+
+	.form-control[data-input]{
+		padding-left: var(--space-base);
+		padding-right: var(--space-xl);
+	}
+}
+
 // Submenu – header arrow
 .osui-submenu {
 	&__header__icon {


### PR DESCRIPTION
This PR is for rollback the changed made and remove the magnifying icon just on input with type search.

### What was done

- rollback input-search icon when inside osui-search;

### Test Steps

1. Go to sample
2. Check if the input doesn't have any icon
3. Inspect the DOM and check the input is of type search and has the a wrapper with the class "input-search";
4. Check input-search component has icon


### Checklist

-   [x] tested locally
-   [ ] documented the code
-   [ ] clean all warnings and errors of eslint
-   [ ] requires changes in OutSystems (if so, provide a module with changes)
-   [ ] requires new sample page in OutSystems (if so, provide a module with changes)
