### PR TITLE
ROU-12799: Input with type search started to have an icon with v2.28.0 and icon modernization

### DIFF
--- a/src/scss/01-foundations/_icon-library-odc.scss
+++ b/src/scss/01-foundations/_icon-library-odc.scss
@@ -121,7 +121,7 @@ body.iconLibrary-phosphor {
 }
 
 // Search – search icon
-.osui-search .input-search {
+.osui-search .osui-search__input > span {
 	position: relative;
 
 	&::after {
@@ -140,7 +140,7 @@ body.iconLibrary-phosphor {
 	}
 }
 
-.is-rtl .osui-search .input-search {
+.is-rtl .osui-search .osui-search__input > span {
 	&::after {
 		left: auto;
 		right: var(--space-base);


### PR DESCRIPTION
This PR is for fixing icon inside input-search component

Closes #1181


### What was happening

- when input type was changed inside input-search component the magnifying icon was not appearing

### What was done

- fix icon so it appears on input-search independent of input type used;

### Test Steps

1. go to sample 
2. Check the icon exists even when input type is not search;

### Checklist

-   [x] tested locally
-   [ ] documented the code
-   [ ] clean all warnings and errors of eslint
-   [ ] requires changes in OutSystems (if so, provide a module with changes)
-   [ ] requires new sample page in OutSystems (if so, provide a module with changes)
