### PR TITLE
ROU-12877: Align number patterns with figma

### DIFF
--- a/src/scss/04-patterns/05-numbers/rating/_rating.scss
+++ b/src/scss/04-patterns/05-numbers/rating/_rating.scss
@@ -11,7 +11,7 @@
 	// ───────────────────────────────────────────────────────────────────
 
 	// Internal colour vars — overrideable per-instance
-	--token-rating-filled-color: #{$token-icon-primary};
+	--token-rating-filled-color: var(--color-primary};
 	--token-rating-empty-color: #{$token-bg-neutral-base-default};
 
 	--rating-size: #{$token-scale-400}; // 16px default

--- a/src/scss/04-patterns/05-numbers/rating/_rating.scss
+++ b/src/scss/04-patterns/05-numbers/rating/_rating.scss
@@ -11,12 +11,8 @@
 	// ───────────────────────────────────────────────────────────────────
 
 	// Internal colour vars — overrideable per-instance
-	--token-rating-filled-color: #{$token-semantics-warning-base};
-	--token-rating-empty-color: color-mix(
-		in srgb,
-		var(--token-rating-filled-color) 38%,
-		#{$token-primitives-base-white}
-	);
+	--token-rating-filled-color: #{$token-icon-primary};
+	--token-rating-empty-color: #{$token-bg-neutral-base-default};
 
 	--rating-size: #{$token-scale-400}; // 16px default
 


### PR DESCRIPTION
This PR is for aligning rating pattern with the Figma design.

### What was happening

- The primary color was not being settled. 

### What was done
- fix rating icons color;

### Test Steps

1. Open the screen of each pattern. Confirm the pattern matches Figma.

### Checklist

-   [x] tested locally
-   [ ] documented the code
-   [ ] clean all warnings and errors of eslint
-   [ ] requires changes in OutSystems (if so, provide a module with changes)
-   [ ] requires new sample page in OutSystems (if so, provide a module with changes)
