### PR TITLE
ROU-12875: Align Dropdown, DatePicker and Animated Label with Figma

### DIFF
--- a/docs/css-api-reference.md
+++ b/docs/css-api-reference.md
@@ -630,7 +630,7 @@ _File: `src/scss/04-patterns/03-interaction/dropdown/_dropdown.scss`_
 | Property | Default |
 |---|---|
 | `--osui-dropdown-disabled-background` | `var(--color-background-input-disabled)` |
-| `--osui-dropdown-disabled-border-color` | `var(--color-border)` |
+| `--osui-dropdown-disabled-border-color` | `var(--color-border-input)` |
 | `--osui-dropdown-disabled-color` | `var(--color-text-disabled)` |
 
 ### Dropdownserversideitem (`.osui-dropdown-serverside-item`)

--- a/docs/css-api-reference.md
+++ b/docs/css-api-reference.md
@@ -622,6 +622,7 @@ _File: `src/scss/04-patterns/03-interaction/dropdown/_dropdown-tags.scss`_
 | `--osui-dropdown-list-background` | `var(--color-background-surface)` |
 | `--osui-dropdown-arrow-color` | `#{$token-icon-subtlest}` |
 | `--osui-dropdown-arrow-size` | `#{$token-scale-400}` |
+| `--osui-dropdown-tag-color` | `#{$token-text-subtlest}` |
 
 ### Dropdown (`.osui-dropdown`)
 _File: `src/scss/04-patterns/03-interaction/dropdown/_dropdown.scss`_
@@ -863,7 +864,7 @@ _File: `src/scss/04-patterns/05-numbers/_badge.scss`_
 | Property | Default |
 |---|---|
 | `--osui-badge-color` | `var(--color-text-inverse)` |
-| `--osui-badge-primary-color` | `var(--color-primary)` |
+| `--osui-badge-primary-color` | `#{$token-text-primary}` |
 | `--osui-badge-on-light-color` | `var(--color-text)` |
 
 ### Icon Badge (`.icon-badge`)
@@ -871,7 +872,8 @@ _File: `src/scss/04-patterns/05-numbers/_icon-badge.scss`_
 
 | Property | Default |
 |---|---|
-| `--osui-icon-badge-ring-color` | `var(--color-background-surface)` |
+| `--osui-icon-badge-ring-color` | `#{$token-border-subtlest}` |
+| `--osui-icon-badge-shadow` | `0 0 0 1px var(--osui-icon-badge-ring-color)` |
 
 ### Rating (`.rating`)
 _File: `src/scss/04-patterns/05-numbers/rating/_rating.scss`_
@@ -986,7 +988,7 @@ _File: `src/scss/01-foundations/_root.scss`_
 | `--osui-motion-duration-400` | `400ms` |
 | `--osui-bg-surface-hover` | `#{$token-primitives-neutral-100}` |
 | `--osui-bg-surface-active` | `color-mix( in srgb, #{$token-semantics-primary-base} 8%, transparent )` |
-| `--osui-border-subtle` | `#{$token-primitives-neutral-300}` |
+| `--osui-border-subtle` | `#{$token-border-subtle}` |
 | `--osui-opacity-disabled` | `0.45` |
 | `--osui-elevation-25` | `0 1px 2px rgba(0, 0, 0, 0.08)` |
 | `--osui-elevation-50` | `0 1px 2px rgba(0, 0, 0, 0.2)` |
@@ -997,4 +999,4 @@ _File: `src/scss/01-foundations/_root.scss`_
 
 ---
 
-<sub>458 properties across 79 components, generated from `src/scss`.</sub>
+<sub>460 properties across 79 components, generated from `src/scss`.</sub>

--- a/src/scss/01-foundations/_icon-library-odc.scss
+++ b/src/scss/01-foundations/_icon-library-odc.scss
@@ -321,6 +321,7 @@ body.iconLibrary-phosphor {
 
 .vscomp-search-clear:after,
 .vscomp-ele .vscomp-clear-icon:after {
+	color: $token-icon-subtlest;
 	content: var(--osui-icon-clear);
 	font-size: 13px;
 }
@@ -357,10 +358,11 @@ body.iconLibrary-phosphor {
 		-servicestudio-height: 40px;
 		-servicestudio-line-height: 40px;
 		-servicestudio-min-width: 180px;
-		-servicestudio-padding: 0 $token-scale-600;
+		-servicestudio-padding: 0 $token-space-400;
 		-servicestudio-position: relative;
 		-servicestudio-vertical-align: middle;
 		-servicestudio-width: 100%;
+		-servicestudio-align-items: center;
 
 		&__arrow-icon {
 			-servicestudio-position: relative;
@@ -391,10 +393,11 @@ body.iconLibrary-phosphor {
 		-servicestudio-display: flex;
 		-servicestudio-height: 40px;
 		-servicestudio-min-width: 180px;
-		-servicestudio-padding: 0 $token-scale-600;
+		-servicestudio-padding: 0 $token-space-400;
 		-servicestudio-position: relative;
 		-servicestudio-vertical-align: middle;
 		-servicestudio-width: 100%;
+		-servicestudio-align-items: center;
 
 		&-as-tag {
 			-servicestudio-align-items: center;
@@ -408,8 +411,6 @@ body.iconLibrary-phosphor {
 			-servicestudio-height: 30px;
 			-servicestudio-padding: 8px;
 			-servicestudio-position: relative;
-			-servicestudio-top: 50%;
-			-servicestudio-transform: translateY(-50%);
 			-servicestudio-width: 70px;
 
 			&__clear-icon {

--- a/src/scss/01-foundations/_icon-library-odc.scss
+++ b/src/scss/01-foundations/_icon-library-odc.scss
@@ -351,8 +351,9 @@ body.iconLibrary-phosphor {
 	// Service Studio Preview
 	&-ss-preview {
 		-servicestudio-background-color: $token-primitives-base-white;
-		-servicestudio-border-radius: $token-border-radius-100;
+		-servicestudio-border-radius: $token-border-radius-200;
 		-servicestudio-border: $token-border-size-025 solid $token-primitives-neutral-500;
+		-servicestudio-color: $token-text-subtlest;
 		-servicestudio-display: inline-flex;
 		-servicestudio-justify-content: space-between;
 		-servicestudio-height: 40px;
@@ -387,9 +388,9 @@ body.iconLibrary-phosphor {
 	&-ss-preview {
 		-servicestudio-justify-content: space-between;
 		-servicestudio-background-color: $token-primitives-base-white;
-		-servicestudio-border-radius: $token-border-radius-100;
+		-servicestudio-border-radius: $token-border-radius-200;
 		-servicestudio-border: $token-border-size-025 solid $token-primitives-neutral-500;
-		-servicestudio-color: $token-primitives-neutral-300;
+		-servicestudio-color: $token-text-subtlest;
 		-servicestudio-display: flex;
 		-servicestudio-height: 40px;
 		-servicestudio-min-width: 180px;

--- a/src/scss/01-foundations/_root.scss
+++ b/src/scss/01-foundations/_root.scss
@@ -130,7 +130,7 @@
 		#{$token-semantics-primary-base} 8%,
 		transparent
 	); // future: --token-bg-surface-active
-	--osui-border-subtle: #{$token-primitives-neutral-300}; // future: --token-border-subtle (intended neutral-300)
+	--osui-border-subtle: #{$token-border-subtle}; // resolves to neutral-300 once outsystems-design-tokens ships the border.subtle fix (PR #99)
 	--osui-opacity-disabled: 0.45; // future: --token-opacity-disabled
 	--osui-elevation-25: 0 1px 2px rgba(0, 0, 0, 0.08); // future: --token-elevation-25
 	--osui-elevation-50: 0 1px 2px rgba(0, 0, 0, 0.2); // future: --token-elevation-50

--- a/src/scss/04-patterns/03-interaction/animated-label/_animated-label.scss
+++ b/src/scss/04-patterns/03-interaction/animated-label/_animated-label.scss
@@ -309,10 +309,6 @@
 ///
 .tablet,
 .phone {
-	.animated-label-text {
-		top: var(--osui-scale-350);
-	}
-
 	.form-control {
 		&[data-textarea] {
 			& + span.validation-message {

--- a/src/scss/04-patterns/03-interaction/date-picker/provider/_flatpickr.scss
+++ b/src/scss/04-patterns/03-interaction/date-picker/provider/_flatpickr.scss
@@ -249,7 +249,7 @@
 
 // Flatpickr - WeekDay Element
 span.flatpickr-weekday {
-	color: var(--color-text-subtlest);
+	color: var(--color-text-subtle);
 	font-size: $token-font-size-350;
 	font-weight: $token-font-weight-regular;
 	user-select: none;
@@ -288,9 +288,9 @@ span.flatpickr-weekday {
 
 		&:hover,
 		&:focus {
-			background: var(--color-border-subtle);
-			border-color: var(--osui-border-subtle);
-			color: $token-semantics-primary-base;
+			background: $token-bg-neutral-subtle-default;
+			border-color: var(--color-border);
+			color: var(--color-text);
 		}
 
 		&.inRange {
@@ -700,7 +700,7 @@ span.flatpickr-weekday {
 
 	// ─── Today button ───────────────────────────────────────────────────
 	.flatpickr-today-button {
-		border-top: $token-border-size-025 solid var(--osui-border-subtle);
+		border-top: $token-border-size-025 solid var(--color-border);
 		padding: $token-scale-200 $token-scale-400;
 
 		a,

--- a/src/scss/04-patterns/03-interaction/dropdown/_dropdown-tags.scss
+++ b/src/scss/04-patterns/03-interaction/dropdown/_dropdown-tags.scss
@@ -15,6 +15,7 @@
 	--osui-dropdown-list-background:     var(--color-background-surface);
 	--osui-dropdown-arrow-color:        #{$token-icon-subtlest};
 	--osui-dropdown-arrow-size:         #{$token-scale-400};
+	--osui-dropdown-tag-color:          #{$token-text-subtlest};
 	// ───────────────────────────────────────────────────────────────────
 
 	// If not valid

--- a/src/scss/04-patterns/03-interaction/dropdown/_dropdown.scss
+++ b/src/scss/04-patterns/03-interaction/dropdown/_dropdown.scss
@@ -7,39 +7,41 @@
 @import 'provider/virtualselect';
 
 // Common dropdown styles
-.osui-dropdown {
+.osui-dropdown,
+.osui-dropdown-search,
+.osui-dropdown-tags {
 	// ─── Component CSS API ─────────────────────────────────────────────
 	--osui-dropdown-disabled-background:   var(--color-background-input-disabled);
 	--osui-dropdown-disabled-border-color: var(--color-border-input);
 	--osui-dropdown-disabled-color:        var(--color-text-disabled);
 	// ───────────────────────────────────────────────────────────────────
 
-	&-search,
-	&-tags {
-		/// Disable states for dropdowns
-		&.vscomp-ele[disabled] {
-			// Override of library cursor on disable states
-			cursor: initial;
 
-			.vscomp {
-				&-toggle-button {
-					background-color: var(--osui-dropdown-disabled-background);
-					border: $token-border-size-025 solid var(--osui-dropdown-disabled-border-color);
+	/// Disable states for dropdowns
+	&.vscomp-ele[disabled] {
+		// Override of library cursor on disable states
+		cursor: initial;
+
+		.vscomp {
+			&-toggle-button {
+				background-color: var(--osui-dropdown-disabled-background);
+				border: $token-border-size-025 solid var(--osui-dropdown-disabled-border-color);
+				pointer-events: none;
+				.vscomp-value {
 					color: var(--osui-dropdown-disabled-color);
-					pointer-events: none;
-				}
-
-				&-wrapper,
-				&-wrapper:not(.has-value) .vscomp-value {
-					opacity: inherit;
 				}
 			}
-		}
 
-		// Override the font-family of provider
-		.vscomp-wrapper {
-			font-family: inherit;
+			&-wrapper,
+			&-wrapper:not(.has-value) .vscomp-value {
+				opacity: inherit;
+			}
 		}
+	}
+
+	// Override the font-family of provider
+	.vscomp-wrapper {
+		font-family: inherit;
 	}
 
 	/// Dropdown Option Item image

--- a/src/scss/04-patterns/03-interaction/dropdown/_dropdown.scss
+++ b/src/scss/04-patterns/03-interaction/dropdown/_dropdown.scss
@@ -10,7 +10,7 @@
 .osui-dropdown {
 	// ─── Component CSS API ─────────────────────────────────────────────
 	--osui-dropdown-disabled-background:   var(--color-background-input-disabled);
-	--osui-dropdown-disabled-border-color: var(--color-border);
+	--osui-dropdown-disabled-border-color: var(--color-border-input);
 	--osui-dropdown-disabled-color:        var(--color-text-disabled);
 	// ───────────────────────────────────────────────────────────────────
 

--- a/src/scss/04-patterns/03-interaction/dropdown/provider/_virtualselect.scss
+++ b/src/scss/04-patterns/03-interaction/dropdown/provider/_virtualselect.scss
@@ -148,12 +148,12 @@
 			background-color: $token-bg-neutral-subtlest-hover;
 			border: none;
 			border-radius: var(--border-radius-rounded);
-			color: var(--color-text);
+			color: $token-text-subtlest;
 			display: inline-flex;
 			font-size: $token-font-size-300;
 			font-weight: $token-font-weight-medium;
 			height: $token-scale-600;
-			padding: 0 $token-scale-200;
+			padding: 0 $token-space-200 0 $token-space-300;
 			position: relative;
 
 			.vscomp-value-tag-content {
@@ -163,18 +163,14 @@
 			.vscomp-value-tag-clear-button {
 				background-color: transparent;
 				border-radius: 0;
+				color: $token-icon-subtlest;
 				height: auto;
 				margin-left: $token-scale-100;
-				opacity: 0.5;
 				position: relative;
 				right: auto;
 				top: auto;
 				transform: none;
 				width: auto;
-
-				&:hover {
-					opacity: 1;
-				}
 
 				.vscomp-clear-icon {
 					height: $token-scale-300;
@@ -185,7 +181,16 @@
 
 					&:before,
 					&:after {
-						color: var(--color-text);
+						color: $token-icon-subtlest;
+					}
+				}
+
+				&:hover {
+					.vscomp-clear-icon {
+						&:before,
+						&:after {
+							color: $token-icon-default;
+						}
 					}
 				}
 			}
@@ -509,14 +514,14 @@
 	transition: background-color $token-transition-time-100 $token-transition-curve-base;
 
 	&.focused {
-		background-color: var(--color-border-subtle);
+		background-color: $token-bg-neutral-subtlest-hover;
 	}
 
 	&.selected {
 		background-color: transparent;
 
 		&.focused {
-			background-color: transparent;
+			background-color: $token-bg-neutral-subtlest-hover;
 		}
 
 		// Right-side checkmark — requires --osui-icon-check + --osui-icon-font-family (icon library)

--- a/src/scss/04-patterns/03-interaction/dropdown/provider/_virtualselect.scss
+++ b/src/scss/04-patterns/03-interaction/dropdown/provider/_virtualselect.scss
@@ -40,7 +40,7 @@
 	&-ele .vscomp-clear-icon:after,
 	&-search-clear:after {
 		align-items: center;
-		color: #91999e;
+		color: $token-icon-subtlest;
 		display: flex;
 		height: 100%;
 		justify-content: center;
@@ -57,7 +57,6 @@
 			&::after,
 			&::before {
 				background-color: transparent;
-				color: $token-primitives-neutral-700;
 			}
 		}
 	}
@@ -226,7 +225,7 @@
 	// RTL Text
 	&.text-direction-rtl {
 		.vscomp-search-container {
-			padding: $token-scale-0 $token-scale-400 $token-scale-0 $token-scale-200;
+			padding: $token-space-0 $token-space-400;
 		}
 
 		&.multiple {
@@ -286,8 +285,6 @@
 		}
 
 		.checkbox-icon {
-			margin-left: $token-scale-200;
-
 			&.checked {
 				&:after {
 					@include IsRTL_CheckBoxCheckIconTransform;
@@ -310,7 +307,7 @@
 		border-radius: $token-border-radius-100;
 		border: $token-border-size-025 solid var(--color-border-input);
 		height: $token-scale-400;
-		margin-right: $token-scale-200;
+		margin-right: 0px;
 		overflow: visible;
 		transition: background-color $token-transition-time-300 $token-transition-curve-expressive;
 		width: $token-scale-400;
@@ -463,6 +460,12 @@
 			background-color: var(--color-border);
 		}
 	}
+
+	// Move "Toggle all" checkbox to the end of the search container
+	.vscomp-toggle-all-button {
+		order: 1;
+		margin-left: $token-space-200;
+	}
 }
 
 // Options container input search
@@ -470,8 +473,7 @@
 	font-size: $token-font-size-350;
 
 	&::placeholder {
-		color: var(--color-text);
-		opacity: 0.5;
+		color: var(--color-text-subtlest);
 	}
 }
 

--- a/src/scss/04-patterns/03-interaction/dropdown/provider/_virtualselect.scss
+++ b/src/scss/04-patterns/03-interaction/dropdown/provider/_virtualselect.scss
@@ -91,6 +91,7 @@
 			}
 		}
 		.vscomp-value {
+			color: var(--color-text);
 			margin-right: $token-scale-600;
 			margin-left: $token-scale-0;
 		}

--- a/src/scss/04-patterns/03-interaction/dropdown/provider/_virtualselect.scss
+++ b/src/scss/04-patterns/03-interaction/dropdown/provider/_virtualselect.scss
@@ -148,7 +148,7 @@
 			background-color: $token-bg-neutral-subtlest-hover;
 			border: none;
 			border-radius: var(--border-radius-rounded);
-			color: $token-text-subtlest;
+			color: var(--color-text-subtlest);
 			display: inline-flex;
 			font-size: $token-font-size-300;
 			font-weight: $token-font-weight-medium;

--- a/src/scss/04-patterns/03-interaction/dropdown/provider/_virtualselect.scss
+++ b/src/scss/04-patterns/03-interaction/dropdown/provider/_virtualselect.scss
@@ -379,11 +379,16 @@
 
 	&:hover {
 		border-color: var(--osui-dropdown-hover-border-color, var(--color-border-input-hover));
+
+		.vscomp-value {
+			color: var(--color-text);
+		}
 	}
 }
 
 // Container with the selected value(s)
 .vscomp-value {
+	color: var(--color-text-subtlest);
 	font-size: $token-font-size-350;
 }
 

--- a/src/scss/04-patterns/03-interaction/dropdown/provider/_virtualselect.scss
+++ b/src/scss/04-patterns/03-interaction/dropdown/provider/_virtualselect.scss
@@ -151,7 +151,7 @@
 			display: inline-flex;
 			font-size: $token-font-size-300;
 			font-weight: $token-font-weight-medium;
-			height: $token-scale-600;
+			height: $token-scale-700;
 			padding: 0 $token-space-200 0 $token-space-300;
 			position: relative;
 

--- a/stories/CssApiReference.mdx
+++ b/stories/CssApiReference.mdx
@@ -627,6 +627,7 @@ _File: `src/scss/04-patterns/03-interaction/dropdown/_dropdown-tags.scss`_
 | `--osui-dropdown-list-background` | `var(--color-background-surface)` |
 | `--osui-dropdown-arrow-color` | `#{$token-icon-subtlest}` |
 | `--osui-dropdown-arrow-size` | `#{$token-scale-400}` |
+| `--osui-dropdown-tag-color` | `#{$token-text-subtlest}` |
 
 ### Dropdown (`.osui-dropdown`)
 _File: `src/scss/04-patterns/03-interaction/dropdown/_dropdown.scss`_
@@ -868,7 +869,7 @@ _File: `src/scss/04-patterns/05-numbers/_badge.scss`_
 | Property | Default |
 |---|---|
 | `--osui-badge-color` | `var(--color-text-inverse)` |
-| `--osui-badge-primary-color` | `var(--color-primary)` |
+| `--osui-badge-primary-color` | `#{$token-text-primary}` |
 | `--osui-badge-on-light-color` | `var(--color-text)` |
 
 ### Icon Badge (`.icon-badge`)
@@ -876,7 +877,8 @@ _File: `src/scss/04-patterns/05-numbers/_icon-badge.scss`_
 
 | Property | Default |
 |---|---|
-| `--osui-icon-badge-ring-color` | `var(--color-background-surface)` |
+| `--osui-icon-badge-ring-color` | `#{$token-border-subtlest}` |
+| `--osui-icon-badge-shadow` | `0 0 0 1px var(--osui-icon-badge-ring-color)` |
 
 ### Rating (`.rating`)
 _File: `src/scss/04-patterns/05-numbers/rating/_rating.scss`_
@@ -991,7 +993,7 @@ _File: `src/scss/01-foundations/_root.scss`_
 | `--osui-motion-duration-400` | `400ms` |
 | `--osui-bg-surface-hover` | `#{$token-primitives-neutral-100}` |
 | `--osui-bg-surface-active` | `color-mix( in srgb, #{$token-semantics-primary-base} 8%, transparent )` |
-| `--osui-border-subtle` | `#{$token-primitives-neutral-300}` |
+| `--osui-border-subtle` | `#{$token-border-subtle}` |
 | `--osui-opacity-disabled` | `0.45` |
 | `--osui-elevation-25` | `0 1px 2px rgba(0, 0, 0, 0.08)` |
 | `--osui-elevation-50` | `0 1px 2px rgba(0, 0, 0, 0.2)` |
@@ -1002,4 +1004,4 @@ _File: `src/scss/01-foundations/_root.scss`_
 
 ---
 
-<sub>458 properties across 79 components, generated from `src/scss`.</sub>
+<sub>460 properties across 79 components, generated from `src/scss`.</sub>

--- a/stories/CssApiReference.mdx
+++ b/stories/CssApiReference.mdx
@@ -635,7 +635,7 @@ _File: `src/scss/04-patterns/03-interaction/dropdown/_dropdown.scss`_
 | Property | Default |
 |---|---|
 | `--osui-dropdown-disabled-background` | `var(--color-background-input-disabled)` |
-| `--osui-dropdown-disabled-border-color` | `var(--color-border)` |
+| `--osui-dropdown-disabled-border-color` | `var(--color-border-input)` |
 | `--osui-dropdown-disabled-color` | `var(--color-text-disabled)` |
 
 ### Dropdownserversideitem (`.osui-dropdown-serverside-item`)

--- a/stories/Dropdown.stories.ts
+++ b/stories/Dropdown.stories.ts
@@ -33,7 +33,9 @@ type Story = StoryObj<DropdownArgs>;
 
 function renderDropdown(args: DropdownArgs): HTMLElement {
 	const id = uid('dropdown');
-	const template = `<div ${osuiRoot(id)} class="osui-dropdown" style="max-width:280px;"></div>`;
+	// Platform markup parity: the widget root carries the mode class (osui-dropdown-search / osui-dropdown-tags)
+	const modeClass = args.allowMultipleSelection ? 'osui-dropdown-tags' : 'osui-dropdown-search';
+	const template = `<div ${osuiRoot(id)} class="osui-dropdown ${modeClass}" style="max-width:280px;"></div>`;
 	return renderPattern(template, (_root, register) => {
 		const P = Patterns();
 		const mode = args.allowMultipleSelection ? 'tags' : 'search';


### PR DESCRIPTION
This PR is for aligning the Dropdown (search/tags), DatePicker calendar, and Animated Label visuals with the Figma spec, and for routing remaining hardcoded values through design tokens.

### What was happening
* Dropdown tag text and clear icons used `--color-text` with opacity-based hover states, diverging from the Figma spec (subtlest icon/text colors with a darkened hover state)
* Dropdown tags had symmetric padding and a smaller height than Figma; the "toggle all" checkbox sat at the start of the search bar
* The clear icon color was a hardcoded hex (`#91999e`) and the search placeholder used `--color-text` at 50% opacity
* The dropdown selected-value text always used the default text color, with no distinction between placeholder, hover, and filled states
* Focused options in the VirtualSelect list used `--color-border-subtle` as background, and focused+selected options had no visual feedback
* The disabled Dropdown border used `--color-border` instead of matching the disabled input border, and the disabled-state rules were nested under the search/tags mode classes only, tinting the whole toggle button instead of just the value text
* The DatePicker weekday header used the subtlest text color (too low contrast), and hovered/focused day cells showed primary-tinted text on a border-colored background; the "Today" button separator used `--osui-border-subtle`
* The Service Studio dropdown preview had wrong border radius, padding, text color, and vertical alignment, and the tag preview was double-offset vertically
* The Animated Label floating text had a hardcoded top offset on tablet/phone, misaligning it against the default position
* `--osui-border-subtle` pointed directly at `$token-primitives-neutral-300` as a workaround while the `border.subtle` token was wrong upstream (neutral.100); the fix is now upstream in outsystems-design-tokens PR 99
* The generated CSS API reference was stale (missing the Badge/IconBadge updates from ROU-12877)

### What was done
* Added `--osui-dropdown-tag-color` CSS API property defaulting to `$token-text-subtlest`
* Tag clear button and search clear icon now use `$token-icon-subtlest`, darkening to `$token-icon-default` on hover (replaces the opacity-based states)
* Tag height bumped to `$token-scale-700`, horizontal padding adjusted to space tokens (`0 $token-space-200 0 $token-space-300`), and the "toggle all" checkbox moved to the end of the search bar
* Search placeholder now uses `--color-text-subtlest`; clear icon hex replaced with `$token-icon-subtlest`
* Selected-value text now defaults to `--color-text-subtlest` (placeholder state), switches to `--color-text` on hover, and stays `--color-text` whenever the dropdown has a value
* Focused options (including selected ones) now use `$token-bg-neutral-subtlest-hover`
* Disabled Dropdown border now uses `--color-border-input` to match disabled inputs; disabled-state styles consolidated at the widget root classes (`osui-dropdown` / `osui-dropdown-search` / `osui-dropdown-tags`), with the disabled text color scoped to the value element
* DatePicker weekday header now uses `--color-text-subtle`; hovered/focused day cells use `$token-bg-neutral-subtle-default` background with `--color-border` and `--color-text`; "Today" button separator uses `--color-border`
* Fixed Service Studio dropdown preview border radius (`$token-border-radius-200`), padding (`$token-space-400`), text color (`$token-text-subtlest`), and vertical centering
* Storybook Dropdown story now mirrors the platform mode class (`osui-dropdown-search` / `osui-dropdown-tags`) on the widget root
* Removed the tablet/phone top offset on `.animated-label-text`
* `--osui-border-subtle` now aliases `$token-border-subtle` (resolves to the intended neutral-300 once the upstream token fix ships and the dependency is bumped)
* Regenerated the CSS API reference docs

### Test Steps
1. Run `npm run dev -- --target ODC` and open the Storybook/dev page with a Dropdown in tags mode
2. Verify tag text and clear icons render in the subtlest color and darken on hover, and tags have the updated height/padding
3. With no selection, verify the placeholder text is subtlest and darkens on hover; select a value and verify the text stays in the default text color even without hover
4. Open the dropdown list and verify focused and focused+selected options show the neutral hover background, and the "toggle all" checkbox sits at the end of the search bar
5. Set the Dropdown to disabled (both search and tags modes) and verify the border matches a disabled input and only the value text is tinted with the disabled color
6. Open a DatePicker and verify the weekday header contrast and the neutral hover state on day cells
7. Check a Dropdown preview in Service Studio for correct radius, padding, and centering
8. On a tablet/phone viewport, verify the Animated Label floating text position

### Screenshots
(prefer animated gif)

### Checklist
* [ ] tested locally
* [ ] documented the code
* [ ] clean all warnings and errors of eslint
* [ ] requires changes in OutSystems (if so, provide a module with changes)
* [ ] requires new sample page in OutSystems (if so, provide a module with changes)
