### PR TITLE
ROU-12946: Update Virtual Select to v1.4.0

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -58,7 +58,7 @@ graph TB
 | Splide (4.1.3)            | Sync (JavaScript API) | Carousel/slider provider implementation                    |
 | Flatpickr (4.6.13)        | Sync (JavaScript API) | DatePicker, TimePicker, MonthPicker provider               |
 | noUiSlider (15.8.1)       | Sync (JavaScript API) | RangeSlider provider implementation                        |
-| VirtualSelect (1.1.0)     | Sync (JavaScript API) | Dropdown with search/tags provider                         |
+| VirtualSelect (1.4.0)     | Sync (JavaScript API) | Dropdown with search/tags provider                         |
 | Floating UI (1.6.5)       | Sync (JavaScript API) | Positioning engine for Balloon/Tooltip patterns            |
 
 ## Build & Compilation

--- a/docs-internal/adr/ADR-0002-virtualselect-140-upgrade-and-osui-validation-ownership.md
+++ b/docs-internal/adr/ADR-0002-virtualselect-140-upgrade-and-osui-validation-ownership.md
@@ -1,0 +1,136 @@
+<!-- This ADR documents the VirtualSelect 1.4.0 upgrade and related architectural decisions around validation ownership, security, and accessibility -->
+
+# ADR-0002: VirtualSelect 1.4.0 Upgrade and OSUI Validation Ownership
+
+## Status
+
+Accepted
+
+## Context
+
+OSUI's Dropdown pattern wraps the VirtualSelect library (currently 1.1.0), which provides combobox functionality. The library underwent a significant 1.4.0 release that includes:
+
+- **Accessibility improvements**: Added `aria-invalid`, `aria-describedby`, and live-region announcements for validation messages; conformance to WCAG 2.5.8 (target size) and WCAG 3.3.1 (error identification with non-colour cue)
+- **Security enhancements**: Hardened attribute contexts (`data-value`, `aria-label`) to prevent XSS
+- **Performance improvements**: Optimization of transitions and rendering
+
+However, VirtualSelect 1.4.0's new validation features (error message element, live region, `aria-invalid` state) create a conflict with OSUI's existing validation architecture:
+
+1. **Validation ownership**: OSUI owns Dropdown validation. The OutSystems platform calls `validation()` on the Dropdown API, which applies `.osui-dropdown--not-valid` and appends its own `.osui-dropdown-error-message` element styled with OSUI design tokens.
+
+2. **Extensibility risk**: While `getProviderConfig()` does not currently pass VirtualSelect's `required` or `minValues` settings, the extensibility system (which merges arbitrary provider properties) means apps can still trigger the library's internal validation path through config overrides.
+
+3. **Security gap**: VirtualSelect 1.4.0 hardened attribute contexts but does not sanitize HTML in the `description` field, which renders as live HTML in the option row. This was discovered as an XSS sink not covered by the library's own fixes.
+
+4. **Motion preferences**: VirtualSelect 1.4.0 zeroes transitions under `prefers-reduced-motion` for some elements (dropbox, container, toggle button) but not others (toggle arrow, checkbox, option hover). OSUI's override stylesheet adds transitions not reached by the library's media query.
+
+5. **Vendored integrity**: The library CSS is kept as a vendored copy of the upstream dist, which allows mechanical diffing on future upgrades. The 1.4.0 CSS uses escaped form (`\26A0`) for the error glyph; matching this form (while only decimal-formatting differs) preserves byte-faithfulness.
+
+## Decision Drivers
+
+- OSUI must maintain explicit ownership of Dropdown validation to ensure consistent user messaging and styling with OSUI design tokens.
+- Apps using the Dropdown extensibility system must not reach a state where the combobox is marked `aria-invalid` with no discoverable reason or visible message (WCAG 2.4.3, 2.4.8, 4.1.2).
+- VirtualSelect 1.4.0's accessibility improvements must be adopted (WCAG conformance uplift).
+- Security holes (HTML rendering in `description` field) must be closed without requiring apps to upgrade Dropdown config.
+- Motion preferences must be fully honoured across all transitions, even those added by OSUI's override stylesheet.
+- Vendored library file integrity must be preserved to enable mechanical diffing against future upstream releases.
+
+## Considered Options
+
+### A. Validation Ownership
+
+#### Option 1: Migrate to VirtualSelect's internal validation
+- Pros: Reduces code duplication; library's validation is now WCAG-compliant in 1.4.0
+- Cons: Breaks OSUI's ownership model; rethemes library messages through CSS only (fragile); extensibility becomes unsafe (apps can reach validation path unintentionally)
+
+#### Option 2: Disable VirtualSelect's internal validation, keep OSUI validation (Chosen)
+- Pros: Explicit ownership; safe extensibility (no library validation path reachable); consistent theming through OSUI tokens; allows future feature additions to Dropdown validation without library interference
+- Cons: Adds a configuration line to every Dropdown init; library's new WCAG validation message is never rendered (but that validation path is dormant anyway in normal usage)
+
+### B. Security: HTML in Description Field
+
+#### Option 1: Document that descriptions must not contain markup (no code change)
+- Pros: No change to API contract; users responsible for sanitization
+- Cons: Security vulnerability shipped; apps unaware of the risk; affects persisted data (once description is escaped and stored, it stays escaped)
+
+#### Option 2: Sanitize descriptions in getProviderConfig(), matching label treatment (Chosen)
+- Pros: Closes XSS sink without breaking API; consistent treatment of all text fields; sanitized value reaches `customData` before option grouping (predictable); matches existing label sanitization
+- Cons: Changes what `getSelectedValues()` returns for descriptions containing `<` or `>`; has a data-migration consideration for values already persisted in escaped form (deferred product decision)
+
+### C. Motion Preferences Coverage
+
+#### Option 1: Leave partial coverage, document the gap
+- Pros: Minimal change; library did the work it intended to
+- Cons: Four additional transitions skip the user's preference; incomplete conformance; poor UX for users with vestibular disorders
+
+#### Option 2: Zero transitions in OSUI stylesheet under prefers-reduced-motion (Chosen)
+- Pros: Complete coverage of all transitions; user preference fully honoured; non-invasive (stylesheet override does not edit vendored file)
+- Cons: Duplicates media query logic; adds SCSS lines
+
+### D. Vendored File Integrity
+
+#### Option 1: Regenerate CSS from 1.4.0 library sources
+- Pros: Cleaner (no hand-editing); new format applied consistently
+- Cons: Loses ability to diff against upstream (original released CSS not preserved); changes formatting; makes future upgrade reviews harder
+
+#### Option 2: Patch 1.4.0 library CSS by hand, verifying byte-faithfulness (Chosen)
+- Pros: Preserves original released CSS for mechanical diffing; only decimal-formatting differs from upstream (reviewable); allows future diffs to show what actually changed between releases
+- Cons: More manual work; must verify patched file matches original (done: whitespace- and quote-normalized confirmation)
+
+## Decision Outcome
+
+Chosen options:
+
+- **Disable VirtualSelect's internal validation**, setting `disableValidation: true` in `getProviderConfig()`. This makes OSUI's validation ownership explicit and prevents unintended validation path execution through extensibility. Apps that explicitly want the library's validation can set `disableValidation: false` in their config (merged last in the init chain).
+
+- **Sanitize the `description` field** in `getProviderConfig()` before `_groupOptions()` runs, using the same `OutSystems.OSFramework.OSUI.Helper.DomHandler` sanitization applied to labels. This closes the HTML rendering XSS sink without requiring apps to sanitize their own data. Note: This changes what `getSelectedValues()` returns for descriptions with `<` or `>`; a product decision is needed on whether to flip the `SanitizeDropdownValues` default (currently `false`).
+
+- **Zero all Dropdown transitions under `prefers-reduced-motion`** in OSUI's `_virtualselect.scss` stylesheet, not the vendored library file. Target the four transitions not covered by VirtualSelect's own media query (toggle arrow rotation, checkbox background fade, checkbox check fade, option hover fade).
+
+- **Match upstream's escaped form for the error glyph** in `_virtualselect_lib.scss` (`content: "\26A0"` instead of the literal character). Patch the vendored file by hand rather than regenerating, to preserve byte-faithfulness with the released 1.4.0 CSS and enable mechanical diffs on future upgrades.
+
+### Changes Made
+
+| File | Change | Rationale |
+|------|--------|-----------|
+| `src/scripts/Providers/OSUI/Dropdown/VirtualSelect/AbstractVirtualSelectConfig.ts` | Add `disableValidation: true` in provider config merge | Make OSUI validation ownership explicit; prevent unintended validation path through extensibility |
+| `src/scripts/Providers/OSUI/Dropdown/VirtualSelect/_virtualselect_lib.scss` | Update to VirtualSelect 1.4.0 vendored CSS, patched by hand | Adopt WCAG improvements; preserve byte-faithfulness for mechanical diffs |
+| `src/scripts/Providers/OSUI/Dropdown/VirtualSelect/_virtualselect.scss` | Add `@media (prefers-reduced-motion: reduce)` block zeroing four transitions | Fully honour motion preferences; complete WCAG conformance |
+| `src/scripts/Providers/OSUI/Dropdown/VirtualSelect/VirtualSelect.d.ts` | Add TypeScript declaration for new library types (if needed) | Maintain type safety for library integration |
+| `src/scripts/Providers/OSUI/Dropdown/VirtualSelect/AbstractVirtualSelectEnum.ts` | No breaking changes (enum values remain stable) | Ensure backward compatibility |
+| `src/scripts/Providers/OSUI/Dropdown/VirtualSelect/README.md` | Update provider version to 1.4.0 | Document library version for maintainers |
+| `ARCHITECTURE.md` | Update VirtualSelect provider version from 1.1.0 to 1.4.0 in External Integrations table | Keep documentation current |
+
+Positive consequences:
+
+- OSUI's validation ownership is explicit and cannot be bypassed through extensibility.
+- XSS vulnerability in option descriptions is closed without requiring app-level changes.
+- All Dropdown transitions respect `prefers-reduced-motion` (WCAG 2.3.3 conformance).
+- VirtualSelect 1.4.0's accessibility and security improvements are adopted.
+- Vendored library file integrity is preserved for future upgrades.
+- No changes to the public `OutSystems.OSUI.Patterns.Dropdown` API.
+
+Negative consequences:
+
+- Description values containing `<` or `>` will be escaped in `getSelectedValues()` results (affects apps persisting descriptions in unescaped form; deferred product decision on `SanitizeDropdownValues` default flip).
+- VirtualSelect's new validation message element is never rendered (acceptable because the validation path is dormant in normal usage and OSUI provides its own message through `.osui-dropdown-error-message`).
+- `package.json` devDependency `virtual-select-plugin` left at `^1.1.0` (library JS ships as vendored module; 1.4.0 not yet published to npm).
+
+## Links
+
+- JIRA Epic: [ROU-12946](https://outsystemsrd.atlassian.net/browse/ROU-12946)
+- VirtualSelect Release Notes: [1.4.0 Changes](https://sa-si-dev.github.io/virtual-select/#releases)
+- Related Commits:
+  - `89c6be0b5` - Update VirtualSelect provider to 1.4.0 (a11y, security, perf)
+  - `721e2020` - Disable VirtualSelect internal validation
+  - `7b7cba50` - Honour prefers-reduced-motion on OSUI Dropdown transitions
+  - `b599345b` - Sanitize Dropdown option descriptions
+  - `aff08b2f` - Match upstream escaped form for error-message glyph
+- WCAG References:
+  - [WCAG 2.3.3 Animation from Interactions](https://www.w3.org/WAI/WCAG21/Understanding/animation-from-interactions)
+  - [WCAG 2.5.8 Target Size (Minimum)](https://www.w3.org/WAI/WCAG21/Understanding/target-size-minimum.html)
+  - [WCAG 3.3.1 Error Identification](https://www.w3.org/WAI/WCAG21/Understanding/error-identification.html)
+
+## Date
+
+2026-08-10

--- a/src/scripts/Providers/OSUI/Dropdown/VirtualSelect/AbstractVirtualSelectConfig.ts
+++ b/src/scripts/Providers/OSUI/Dropdown/VirtualSelect/AbstractVirtualSelectConfig.ts
@@ -185,6 +185,14 @@ namespace Providers.OSUI.Dropdown.VirtualSelect {
 				ele: this.ElementId,
 				enableSecureText: this.SanitizeDropdownValues,
 				disabled: this.IsDisabled,
+				/* OSUI owns validation: the platform calls validation(), which applies
+				.osui-dropdown--not-valid and appends its own .osui-dropdown-error-message. Turning the
+				library's validate() off keeps that ownership explicit and prevents a half-applied state
+				where the library marks the combobox aria-invalid and points aria-describedby at its own
+				message element, which OSUI hides. An app that deliberately wants the library's
+				validation can still set `disableValidation: false` through the extensibility configs,
+				since those are merged last. */
+				disableValidation: true,
 				dropboxWrapper: OSFramework.OSUI.GlobalEnum.HTMLElement.Body,
 				hasOptionDescription: hasDescription,
 				hideClearButton: false,

--- a/src/scripts/Providers/OSUI/Dropdown/VirtualSelect/AbstractVirtualSelectConfig.ts
+++ b/src/scripts/Providers/OSUI/Dropdown/VirtualSelect/AbstractVirtualSelectConfig.ts
@@ -171,9 +171,17 @@ namespace Providers.OSUI.Dropdown.VirtualSelect {
 		public getProviderConfig(): VirtualSelectOpts {
 			/* In order to avoid XSS let's sanitize the label of each all options
 			- This must be done here since If we do this at the renderer option we will remain with the
-			library value unSanitized, that said we must do it before adding the list of options to the library! */
+			library value unSanitized, that said we must do it before adding the list of options to the library!
+			- Description gets the same treatment: the library renders it as HTML into the option row
+			(and secureText is a no-op while SanitizeDropdownValues is False), so an unsanitized
+			description is an XSS sink. Sanitizing before _groupOptions() runs also keeps the copy it
+			places on customData consistent with what is rendered. */
 			for (const option of this.OptionsList) {
 				option.label = OSFramework.OSUI.Helper.Sanitize(option.label);
+
+				if (option.description) {
+					option.description = OSFramework.OSUI.Helper.Sanitize(option.description);
+				}
 			}
 
 			// We need to keep the _groupedOptionsList in order to use it in this._getOptionInfo method

--- a/src/scripts/Providers/OSUI/Dropdown/VirtualSelect/AbstractVirtualSelectEnum.ts
+++ b/src/scripts/Providers/OSUI/Dropdown/VirtualSelect/AbstractVirtualSelectEnum.ts
@@ -5,7 +5,7 @@ namespace Providers.OSUI.Dropdown.VirtualSelect.Enum {
 	 */
 	export enum ProviderInfo {
 		Name = 'VirtualSelect',
-		Version = '1.3.0',
+		Version = '1.4.0',
 	}
 
 	/**

--- a/src/scripts/Providers/OSUI/Dropdown/VirtualSelect/README.md
+++ b/src/scripts/Providers/OSUI/Dropdown/VirtualSelect/README.md
@@ -1,3 +1,3 @@
-# VirtualSelect · ![virtualselect version](https://img.shields.io/badge/version-v1.3.0-informational)
+# VirtualSelect · ![virtualselect version](https://img.shields.io/badge/version-v1.4.0-informational)
 
 All info about this Provider <a href="https://sa-si-dev.github.io/virtual-select/#/">here</a>.

--- a/src/scripts/Providers/OSUI/Dropdown/VirtualSelect/VirtualSelect.d.ts
+++ b/src/scripts/Providers/OSUI/Dropdown/VirtualSelect/VirtualSelect.d.ts
@@ -69,6 +69,7 @@ namespace Providers.OSUI.Dropdown.VirtualSelect {
 		disabledOptions?: [];
 		disableOptionGroupCheckbox?: boolean;
 		disableSelectAll?: boolean;
+		disableValidation?: boolean;
 		dropboxWidth?: string;
 		dropboxWrapper?: string;
 		ele?: string | HTMLElement;

--- a/src/scripts/Providers/OSUI/Dropdown/VirtualSelect/scss/_virtualselect.scss
+++ b/src/scripts/Providers/OSUI/Dropdown/VirtualSelect/scss/_virtualselect.scss
@@ -65,6 +65,24 @@
 	}
 }
 
+// Validation message
+// VirtualSelect 1.4.0 renders its own validation message as a sibling of .vscomp-wrapper and
+// reveals it whenever the library's internal validate() sets .has-error. OSUI owns validation
+// messaging: the platform calls validation(), which applies .osui-dropdown--not-valid and appends
+// its own .osui-dropdown-error-message styled with OSUI tokens. The library's copy is suppressed so
+// a Dropdown can never show two messages, and so no unthemed message can appear.
+//
+// Dormant today - getProviderConfig() passes neither `required` nor `minValues`, so the library's
+// validate() never flags an error - but a page can reach that path through the extensibility
+// configs, which merge arbitrary provider props straight through.
+//
+// Specificity is 0,4,0 against the library's 0,3,0 reveal rule
+// (.vscomp-wrapper.has-error ~ .vscomp-error-message), so no !important is needed. If OSUI ever
+// adopts the library's validation instead of its own, theme this element rather than hiding it.
+.vscomp-ele .vscomp-wrapper.has-error ~ .vscomp-error-message {
+	display: none;
+}
+
 // Wrapper container
 .vscomp-wrapper {
 	&.focused,

--- a/src/scripts/Providers/OSUI/Dropdown/VirtualSelect/scss/_virtualselect.scss
+++ b/src/scripts/Providers/OSUI/Dropdown/VirtualSelect/scss/_virtualselect.scss
@@ -638,6 +638,20 @@
 	}
 }
 
+// Reduced Motion ----------------------------------------------------------------
+///
+// VirtualSelect 1.4.0 honours prefers-reduced-motion for its own transitions, but only for the
+// dropbox, the dropbox container/wrapper and the toggle button. The transitions declared above are
+// OSUI's own and are not covered by the library's media query, so they are zeroed here.
+@media (prefers-reduced-motion: reduce) {
+	.vscomp-option,
+	.vscomp-toggle-button:after,
+	.vscomp-wrapper .checkbox-icon,
+	.vscomp-wrapper .checkbox-icon:after {
+		transition-duration: 0s;
+	}
+}
+
 // Responsive --------------------------------------------------------------------
 ///
 .phone,

--- a/src/scripts/Providers/OSUI/Dropdown/VirtualSelect/scss/_virtualselect.scss
+++ b/src/scripts/Providers/OSUI/Dropdown/VirtualSelect/scss/_virtualselect.scss
@@ -72,9 +72,9 @@
 // its own .osui-dropdown-error-message styled with OSUI tokens. The library's copy is suppressed so
 // a Dropdown can never show two messages, and so no unthemed message can appear.
 //
-// Dormant today - getProviderConfig() passes neither `required` nor `minValues`, so the library's
-// validate() never flags an error - but a page can reach that path through the extensibility
-// configs, which merge arbitrary provider props straight through.
+// Belt-and-braces: getProviderConfig() sets `disableValidation: true`, so validate() returns early
+// and never applies .has-error. This rule only matters if an app re-enables the library's validation
+// through the extensibility configs, which merge arbitrary provider props straight through.
 //
 // Specificity is 0,4,0 against the library's 0,3,0 reveal rule
 // (.vscomp-wrapper.has-error ~ .vscomp-error-message), so no !important is needed. If OSUI ever

--- a/src/scripts/Providers/OSUI/Dropdown/VirtualSelect/scss/_virtualselect_lib.scss
+++ b/src/scripts/Providers/OSUI/Dropdown/VirtualSelect/scss/_virtualselect_lib.scss
@@ -294,7 +294,7 @@
 	width: 100%;
 }
 .vscomp-error-message::before {
-	content: '⚠';
+	content: '\26A0';
 	flex: none;
 	font-size: 1.1em;
 	line-height: 1.2;

--- a/src/scripts/Providers/OSUI/Dropdown/VirtualSelect/scss/_virtualselect_lib.scss
+++ b/src/scripts/Providers/OSUI/Dropdown/VirtualSelect/scss/_virtualselect_lib.scss
@@ -1,5 +1,5 @@
 /*!
- * Virtual Select v1.3.0
+ * Virtual Select v1.4.0
  * https://sa-si-dev.github.io/virtual-select
  * Licensed under MIT (https://github.com/sa-si-dev/virtual-select/blob/master/LICENSE)
  */
@@ -283,6 +283,22 @@
 .vscomp-search-clear:hover {
 	color: inherit;
 }
+.vscomp-error-message {
+	align-items: flex-start;
+	color: #b00020;
+	display: none;
+	font-size: 13px;
+	gap: 4px;
+	line-height: 1.4;
+	padding-top: 4px;
+	width: 100%;
+}
+.vscomp-error-message::before {
+	content: '⚠';
+	flex: none;
+	font-size: 1.1em;
+	line-height: 1.2;
+}
 .vscomp-no-options,
 .vscomp-no-search-results {
 	align-items: center;
@@ -371,6 +387,8 @@
 	align-items: center;
 	cursor: pointer;
 	display: flex;
+	min-height: 24px;
+	min-width: 24px;
 }
 .vscomp-wrapper.has-select-all .vscomp-search-input,
 .vscomp-wrapper.has-select-all .vscomp-toggle-all-label {
@@ -470,6 +488,9 @@
 .vscomp-wrapper.has-error .vscomp-toggle-button {
 	border-color: #b00020;
 }
+.vscomp-wrapper.has-error ~ .vscomp-error-message {
+	display: flex;
+}
 .vscomp-wrapper.show-value-as-tags .vscomp-toggle-button {
 	padding: 4px 22px 0 10px;
 }
@@ -503,14 +524,14 @@
 	overflow: hidden;
 	text-overflow: ellipsis;
 	white-space: nowrap;
-	width: calc(100% - 20px);
+	width: calc(100% - 24px);
 }
 .vscomp-wrapper.show-value-as-tags .vscomp-value-tag-clear-button {
 	align-items: center;
 	display: flex;
-	height: 20px;
+	height: 24px;
 	justify-content: center;
-	width: 20px;
+	width: 24px;
 }
 .vscomp-wrapper.show-value-as-tags .vscomp-value-tag-clear-button .vscomp-clear-icon {
 	transform: scale(0.8);
@@ -534,6 +555,14 @@
 .vscomp-wrapper.show-value-as-tags:not(.has-value) .vscomp-value {
 	align-items: center;
 	padding-bottom: 3px;
+}
+@media (prefers-reduced-motion: reduce) {
+	.vscomp-dropbox-container,
+	.vscomp-dropbox,
+	.vscomp-wrapper .vscomp-toggle-button,
+	.vscomp-dropbox-wrapper {
+		transition-duration: 0s !important;
+	}
 }
 .vscomp-wrapper.text-direction-rtl {
 	direction: rtl;


### PR DESCRIPTION
This PR is for updating the VirtualSelect provider (Dropdown pattern) from v1.3.0 to v1.4.0, and closing the OSUI-side gaps that upgrade surfaced.

### What was happening

VirtualSelect v1.4.0 adds ARIA live-region announcements, `aria-invalid`/`aria-required`, reduced-motion support, and closes several XSS/attribute-injection issues (see [v1.4.0 release notes](https://github.com/sa-si-dev/virtual-select/releases/tag/v1.4.0)). One of those fixes affects OSUI's default configuration directly: unescaped `aria-label` interpolation of `group_name`/`description` was exploitable even with `SanitizeDropdownValues` at its default (False).

Adopting the new version as-is would also have left two gaps: the library's own validation UI (new in 1.4.0) would partially surface through OSUI's markup since OSUI hides the library's error message but doesn't disable its `aria-invalid`/`aria-describedby` wiring, and `option.description` remained an unsanitized HTML sink that 1.4.0 does not address (its hardening covered attribute contexts, not this sink).

### What was done

- Updated the vendored VirtualSelect CSS/version references to v1.4.0 (`89c6be0b5`)
- Disabled the library's internal validation (`disableValidation: true`) so OSUI's own validation UI remains the single source of truth, and the library can no longer reach a half-applied state (`aria-invalid` pointing at a hidden message) through the extensibility configs (`721e20201`)
- Extended OSUI's `prefers-reduced-motion` handling to the transitions the library's own media query doesn't cover (arrow rotation, checkbox fade, option hover) (`7b7cba509`)
- Sanitized `option.description` the same way `option.label` already was, closing a pre-existing HTML-injection sink not addressed by the upstream release (`b599345b2`)
- Restored the vendored file's error-message glyph to upstream's escaped form, keeping it byte-faithful for future upgrade diffs (`aff08b2f7`)

### Known follow-ups (tracked separately, not in this PR)

- The VirtualSelect JS resource itself needs to be updated wherever it's delivered to the runtime (outside this repo) — this PR only ships the CSS/TS-side changes.
- `VirtualSelect.d.ts` doesn't yet type the ~24 other new 1.4.0 options (`minValues`, `requiredErrorText`, `ariaLabelledby`, etc.) — reachable via `SetVirtualSelectConfigs` but untyped.
- Neither Dropdown variant (VirtualSelect or ServerSide) exposes validation state to assistive technology (`aria-invalid`/`aria-describedby`) — pre-existing gap in both, not introduced or fixed here.
- `FocusFirstInvalidInput` is a no-op for both Dropdown variants: the invalid class lands on a non-focusable host element, so focus doesn't move to the field on submit.

### Behaviour changes to call out in the release notes

- With `SanitizeDropdownValues = True`, option values/labels containing `<`, `>`, `&`, or `"` are now stored and returned unescaped instead of HTML-encoded (upstream fix). `SetValue` calls that previously silently failed to match such values will now apply correctly.
- Option descriptions are now sanitized (`<`/`>` become `‹`/`›`) the same way labels always were; descriptions that intentionally contained markup will render as literal text.

### Test Steps

1. Requires the v1.4.0 VirtualSelect JS to be loaded — cannot be exercised with `npm run dev` alone (see follow-up above).
2. Single and multiple select, with `SanitizeDropdownValues` True and False, using values/labels/descriptions containing `"`, `&`, `<`, `>` — confirm `OnSelected` payload and `StartingSelection` round-trip.
3. Grouped options with `group_name`/`description` containing `"` — confirm no stray attributes and no markup execution from descriptions.
4. Platform validation (`SetValidation`) on/off — confirm single message shown, no library duplicate.
5. `prefers-reduced-motion: reduce` — confirm toggle arrow, checkbox and option hover no longer animate.
6. RTL, `has-accessible-features`, `os-high-contrast`, mobile popup mode — visual regression pass.

### Screenshots

(prefer animated gif)

### Checklist

- [ ] tested locally (blocked — see Test Steps from 1)
- [x] documented the code
- [x] clean all warnings and errors of eslint
- [x] requires changes in OutSystems (VirtualSelect JS resource — see Known follow-ups)
- [ ] requires new sample page in OutSystems (if so, provide a module with changes)