### PR TITLE
ROU-12928: Fixed carousel misbehave inside accordion

### DIFF
--- a/src/scripts/OSFramework/OSUI/Pattern/AccordionItem/scss/_accordion-item.scss
+++ b/src/scripts/OSFramework/OSUI/Pattern/AccordionItem/scss/_accordion-item.scss
@@ -176,7 +176,8 @@
 
 				// This is to avoid reflowing the content when collapsed
 				& > div {
-					display: none;
+					visibility: hidden;
+					contain: layout;
 				}
 			}
 


### PR DESCRIPTION
This PR is to fix as misbehave in the carousel when used inside an accordion


### What was happening

- When a carousel was used inside a collapsed accordion, it was initialised with invalid height and width values. This happened because a CSS rule prevented the carousel container from being rendered while the accordion item was closed.

### What was done

- Changed the CSS rule to ensure the container is in the DOM during initialisation, even though it is not rendered.

### Test Steps

1. Open the sample application
2. Open the accordion
3. Validate that the carousel is correctly presented

### Checklist

-   [ ] tested locally
-   [ ] documented the code
-   [ ] clean all warnings and errors of eslint
-   [ ] requires changes in OutSystems (if so, provide a module with changes)
-   [ ] requires new sample page in OutSystems (if so, provide a module with changes)
