### PR TITLE
ROU-12939: Carousel - Fixed issue and improve A11Y

### DIFF
--- a/src/scripts/Providers/OSUI/Carousel/Splide/Enum.ts
+++ b/src/scripts/Providers/OSUI/Carousel/Splide/Enum.ts
@@ -55,6 +55,6 @@ namespace Providers.OSUI.Carousel.Splide.Enum {
 	 * Splide provider console warnings
 	 */
 	export enum WarningMessages {
-		BareImageSlidesNeedHost = 'Bare <img> slides were found without a host wrapper. ARIA role "listitem" cannot be applied to <img> (ARIA in HTML / axe). Wrap each image in a container so list semantics can be applied.',
+		BareImageSlidesNeedHost = 'Bare <img> slides were found without a host wrapper. ARIA role "listitem" cannot be applied to <img> (ARIA in HTML). Wrap each image in a container so list semantics can be applied.',
 	}
 }

--- a/src/scripts/Providers/OSUI/Carousel/Splide/Enum.ts
+++ b/src/scripts/Providers/OSUI/Carousel/Splide/Enum.ts
@@ -8,6 +8,8 @@ namespace Providers.OSUI.Carousel.Splide.Enum {
 		SplideTrack = 'splide__track',
 		SplideList = 'splide__list',
 		SplideSlide = 'splide__slide',
+		SplideSlideActive = 'is-active',
+		SplideSlideClone = 'splide__slide--clone',
 	}
 
 	/**
@@ -47,5 +49,12 @@ namespace Providers.OSUI.Carousel.Splide.Enum {
 	export enum TypeOptions {
 		Loop = 'loop',
 		Slide = 'slide',
+	}
+
+	/**
+	 * Splide provider console warnings
+	 */
+	export enum WarningMessages {
+		BareImageSlidesNeedHost = 'Bare <img> slides were found without a host wrapper. ARIA role "listitem" cannot be applied to <img> (ARIA in HTML / axe). Wrap each image in a container so list semantics can be applied.',
 	}
 }

--- a/src/scripts/Providers/OSUI/Carousel/Splide/Splide.ts
+++ b/src/scripts/Providers/OSUI/Carousel/Splide/Splide.ts
@@ -40,12 +40,12 @@ namespace Providers.OSUI.Carousel.Splide {
 		}
 
 		// Announce the active slide via the hidden aria-live status element
-		private _announceActiveSlide(activeIndex?: number): void {
+		private _announceActiveSlide(): void {
 			if (this._a11yStatusElem === undefined) {
 				return;
 			}
 
-			const activeSlide = this._resolveActiveSlideElem(activeIndex);
+			const activeSlide = this._resolveActiveSlideElem();
 			if (activeSlide === undefined) {
 				return;
 			}
@@ -153,9 +153,15 @@ namespace Providers.OSUI.Carousel.Splide {
 			);
 		}
 
-		// Resolve slide by Splide index — safe inside Moved handlers that run before .is-active updates
+		// Resolve slide by Splide index — safe inside Moved handlers that run before .is-active updates.
 		private _getSlideElemByIndex(index: number): HTMLElement {
-			return this.provider?.Components?.Slides?.getAt(index)?.slide;
+			const slides = this.provider?.Components?.Slides;
+			if (slides === undefined) {
+				return undefined;
+			}
+
+			const original = slides.get(true)?.find((slide) => slide.index === index);
+			return original?.slide ?? slides.getAt(index)?.slide;
 		}
 
 		// Method to init the provider
@@ -250,9 +256,9 @@ namespace Providers.OSUI.Carousel.Splide {
 			}, 500);
 		}
 
-		// Prefer event/provider index; fall back to .is-active when index is unavailable (e.g. pre-mount)
+		// Resolve via provider.index (or explicit index); fall back to .is-active when unavailable
 		private _resolveActiveSlideElem(activeIndex?: number): HTMLElement {
-			const index = activeIndex ?? this.provider?.index;
+			const index = activeIndex ?? this.provider.index;
 
 			if (index !== undefined && index !== null && this.provider?.Components?.Slides) {
 				const slideByIndex = this._getSlideElemByIndex(index);
@@ -357,19 +363,21 @@ namespace Providers.OSUI.Carousel.Splide {
 				if (index !== this._currentIndex) {
 					this.triggerPlatformEventCallback(this._platformEventOnSlideMoved, index);
 					this._currentIndex = index;
-					// Only sync selection state on move — full setA11YProperties runs on mount/refresh
-					this._syncActiveSlideAriaCurrent(index);
 
-					// Skip the first move (page load) and suppress announcements while autoplay is playing
-					if (this.provider.Components.Autoplay.isPaused()) {
-						this._announceActiveSlide(index);
-					}
+					OSFramework.OSUI.Helper.AsyncInvocation(() => {
+						this._syncActiveSlideAriaCurrent();
+
+						// Suppress announcements while autoplay is playing
+						if (this.provider.Components.Autoplay.isPaused()) {
+							this._announceActiveSlide();
+						}
+					});
 				}
 			});
 		}
 
 		// Set aria-current on the active non-clone slide and clear it from every other slide
-		private _syncActiveSlideAriaCurrent(activeIndex?: number): void {
+		private _syncActiveSlideAriaCurrent(): void {
 			this.selfElement
 				.querySelectorAll(OSFramework.OSUI.Constants.Dot + Enum.CssClass.SplideSlide)
 				.forEach((slide) =>
@@ -379,7 +387,7 @@ namespace Providers.OSUI.Carousel.Splide {
 					)
 				);
 
-			const activeSlide = this._resolveActiveSlideElem(activeIndex);
+			const activeSlide = this._resolveActiveSlideElem();
 			if (activeSlide) {
 				OSFramework.OSUI.Helper.Dom.Attribute.Set(
 					activeSlide,
@@ -442,6 +450,11 @@ namespace Providers.OSUI.Carousel.Splide {
 		protected setA11YProperties(): void {
 			this._setA11yStatusElem();
 			this._setListRoles();
+
+			// Splide emits mounted/ready after our sync and clearsaria-current via Slide.updateActivity when isNavigation is false — re-apply after.
+			OSFramework.OSUI.Helper.AsyncInvocation(() => {
+				this._syncActiveSlideAriaCurrent();
+			});
 		}
 
 		/**

--- a/src/scripts/Providers/OSUI/Carousel/Splide/Splide.ts
+++ b/src/scripts/Providers/OSUI/Carousel/Splide/Splide.ts
@@ -8,6 +8,8 @@ namespace Providers.OSUI.Carousel.Splide {
 		extends OSFramework.OSUI.Patterns.Carousel.AbstractCarousel<Splide, Splide.SplideConfig>
 		implements OSFramework.OSUI.Patterns.Carousel.ICarousel
 	{
+		// Store the hidden aria-live status element used to announce the active slide
+		private _a11yStatusElem: HTMLElement;
 		// Store if the render callback should be prevented
 		private _blockOnRender = false;
 		// Store the List widget element
@@ -24,6 +26,8 @@ namespace Providers.OSUI.Carousel.Splide {
 		private _eventOnResize: OSFramework.OSUI.GlobalCallbacks.Generic;
 		// Store if a List widget is used inside the CarouselItems placeholder
 		private _hasList: boolean;
+		// Ensure the bare-image host-wrapper warning is logged only once per instance
+		private _hasWarnedBareImageSlides = false;
 		// Store the pending list-roles poll timeout id, so it can be cancelled on re-entry
 		private _listRolesPollId: number | undefined;
 		// Store the onSlideMoved event
@@ -35,12 +39,34 @@ namespace Providers.OSUI.Carousel.Splide {
 			super(uniqueId, new SplideConfig(configs));
 		}
 
+		// Announce the active slide via the hidden aria-live status element
+		private _announceActiveSlide(activeIndex?: number): void {
+			if (this._a11yStatusElem === undefined) {
+				return;
+			}
+
+			const activeSlide = this._resolveActiveSlideElem(activeIndex);
+			if (activeSlide === undefined) {
+				return;
+			}
+
+			const ariaLabel = OSFramework.OSUI.Helper.Dom.Attribute.Get(
+				activeSlide,
+				OSFramework.OSUI.Constants.A11YAttributes.Aria.Label
+			);
+
+			if (ariaLabel) {
+				this._a11yStatusElem.textContent = ariaLabel;
+			}
+		}
+
 		// Method to apply role="list" and role="listitem" to the list element and its direct children.
 		// Skips native list elements (ul/ol) and elements whose direct children are native list
 		// elements (li/ul/ol), since those already carry implicit list semantics. Also skips lists
-		// with bare <img> slides: images can't take role="listitem" without replacing their image
-		// semantics, wrapping them is off-limits, and a role="list" whose children
-		// aren't list items is invalid — the images stay exposed to screen readers via alt text.
+		// with bare <img> slides: ARIA in HTML (and axe) disallow role="listitem" on <img>, and
+		// wrapping/reparenting those nodes is off-limits (ROU-12937). Callers should wrap each
+		// image in a platform-owned host (Container/Block); when that host is missing we warn once
+		// and fall back to image semantics + aria-current / live status for selection feedback.
 		private _applyListRoles(listEl: HTMLElement): void {
 			const _isNativeList = listEl.tagName === 'UL' || listEl.tagName === 'OL';
 			const _hasNativeListChildren =
@@ -48,6 +74,10 @@ namespace Providers.OSUI.Carousel.Splide {
 			// Direct-child <img> slides only — a wrapped image (div > img) must still get list roles,
 			// so the selector is scoped with ':scope >' instead of matching any descendant.
 			const _hasImageSlides = OSFramework.OSUI.Helper.Dom.TagSelector(listEl, ':scope > img') !== undefined;
+
+			if (_hasImageSlides) {
+				this._warnBareImageSlidesNeedHost();
+			}
 
 			if (_isNativeList || _hasNativeListChildren || _hasImageSlides) {
 				// Content can change across platform refreshes (e.g. List widget data) — drop a list
@@ -64,21 +94,15 @@ namespace Providers.OSUI.Carousel.Splide {
 						OSFramework.OSUI.Constants.A11YAttributes.Role.AttrName
 					);
 				}
-				return;
+			} else {
+				OSFramework.OSUI.Helper.A11Y.RoleList(listEl);
+				OSFramework.OSUI.Helper.Dom.TagSelectorAll(listEl, ':scope > *')?.forEach((slide) =>
+					OSFramework.OSUI.Helper.A11Y.RoleListitem(slide as HTMLElement)
+				);
 			}
 
-			OSFramework.OSUI.Helper.Dom.Attribute.Set(
-				listEl,
-				OSFramework.OSUI.Constants.A11YAttributes.Role.AttrName,
-				OSFramework.OSUI.Constants.A11YAttributes.Role.List
-			);
-			OSFramework.OSUI.Helper.Dom.TagSelectorAll(listEl, ':scope > *')?.forEach((slide) => {
-				OSFramework.OSUI.Helper.Dom.Attribute.Set(
-					slide,
-					OSFramework.OSUI.Constants.A11YAttributes.Role.AttrName,
-					OSFramework.OSUI.Constants.A11YAttributes.Role.Listitem
-				);
-			});
+			// List-widget polls can re-apply roles asynchronously; keep aria-current in sync
+			this._syncActiveSlideAriaCurrent();
 		}
 
 		// Method to wait for the OutSystems List widget to finish loading before applying roles
@@ -114,6 +138,26 @@ namespace Providers.OSUI.Carousel.Splide {
 			}
 		}
 
+		// Resolve the true active (non-clone) slide element from the DOM (post-Splide update)
+		private _getActiveSlideElem(): HTMLElement {
+			return OSFramework.OSUI.Helper.Dom.TagSelector(
+				this.selfElement,
+				OSFramework.OSUI.Constants.Dot +
+					Enum.CssClass.SplideSlide +
+					OSFramework.OSUI.Constants.Dot +
+					Enum.CssClass.SplideSlideActive +
+					':not(' +
+					OSFramework.OSUI.Constants.Dot +
+					Enum.CssClass.SplideSlideClone +
+					')'
+			);
+		}
+
+		// Resolve slide by Splide index — safe inside Moved handlers that run before .is-active updates
+		private _getSlideElemByIndex(index: number): HTMLElement {
+			return this.provider?.Components?.Slides?.getAt(index)?.slide;
+		}
+
 		// Method to init the provider
 		private _initProvider(): void {
 			// Init provider
@@ -135,15 +179,15 @@ namespace Providers.OSUI.Carousel.Splide {
 			// Set initial carousel width
 			this._setCarouselWidth();
 
-			// Init the provider — pass a custom extension so list roles are re-applied on every
-			// mount cycle, including after provider.refresh() which wipes provider.on() listeners.
+			// Init the provider — pass a custom extension so a11y is re-applied on every mount
+			// cycle, including after provider.refresh() which wipes provider.on() listeners.
 			// The extension's mount() runs after all built-in components (including A11y) have
 			// already mounted, so Splide's ARIA roles are already set and can be overridden directly.
 			this.provider.mount({
 				OSUIListRoles: () => {
 					return {
 						mount: () => {
-							this._setListRoles();
+							this.setA11YProperties();
 						},
 					};
 				},
@@ -172,7 +216,7 @@ namespace Providers.OSUI.Carousel.Splide {
 						// Never create or move platform-owned nodes here: reparenting an <img>
 						// (e.g. wrapping it in a <div>) invalidates React's fiber bookkeeping and crashes
 						// the next reconcile with NotFoundError on removeChild. Only mutate classes;
-						// ARIA roles on <img> slides are stripped non-destructively in _setListRoles.
+						// invalid ARIA roles on <img> slides are stripped in setA11YProperties.
 						OSFramework.OSUI.Helper.Dom.Styles.AddClass(item as HTMLElement, Enum.CssClass.SplideSlide);
 					}
 				}
@@ -200,10 +244,40 @@ namespace Providers.OSUI.Carousel.Splide {
 				} else {
 					// refresh() reapplies Splide's default ARIA (e.g. presentation) without firing
 					// mounted — e.g. when DevTools toggles and triggers resize. Full redraw remounts and
-					// mounted reapplies list roles; after refresh-only we must restore them here.
-					this._setListRoles();
+					// mounted reapplies a11y; after refresh-only we must restore them here.
+					this.setA11YProperties();
 				}
 			}, 500);
+		}
+
+		// Prefer event/provider index; fall back to .is-active when index is unavailable (e.g. pre-mount)
+		private _resolveActiveSlideElem(activeIndex?: number): HTMLElement {
+			const index = activeIndex ?? this.provider?.index;
+
+			if (index !== undefined && index !== null && this.provider?.Components?.Slides) {
+				const slideByIndex = this._getSlideElemByIndex(index);
+				if (slideByIndex) {
+					return slideByIndex;
+				}
+			}
+
+			return this._getActiveSlideElem();
+		}
+
+		// Ensure a persistent, visually-hidden aria-live status element exists for slide announcements
+		private _setA11yStatusElem(): void {
+			if (this._a11yStatusElem === undefined) {
+				this._a11yStatusElem = document.createElement(OSFramework.OSUI.GlobalEnum.HTMLElement.Div);
+				OSFramework.OSUI.Helper.Dom.Styles.AddClass(
+					this._a11yStatusElem,
+					OSFramework.OSUI.Constants.AccessibilityHideElementClass
+				);
+				this.selfElement.appendChild(this._a11yStatusElem);
+			}
+
+			OSFramework.OSUI.Helper.A11Y.RoleStatus(this._a11yStatusElem);
+			OSFramework.OSUI.Helper.A11Y.AriaLivePolite(this._a11yStatusElem);
+			OSFramework.OSUI.Helper.A11Y.AriaAtomicTrue(this._a11yStatusElem);
 		}
 
 		// Ensure that the splide track maintains the correct width
@@ -225,9 +299,10 @@ namespace Providers.OSUI.Carousel.Splide {
 				.querySelectorAll(OSFramework.OSUI.Constants.Dot + Enum.CssClass.SplideSlide)
 				.forEach((slide) => {
 					const _slideEl = slide as HTMLElement;
-					// A bare <img> slide keeps no assigned role (ROU-12937): role="presentation" is valid
-					// on an image, but it removes the image from the accessibility tree, hiding it from
-					// screen readers. Stripping the role keeps the image announced via its alt text.
+					// Bare <img> slides must not carry an explicit role: ARIA in HTML disallows
+					// listitem/group/tabpanel on <img> (axe: "ARIA role listitem is not allowed"),
+					// and role="presentation" would remove the image from the a11y tree. Stripping
+					// the role keeps the image announced via its accessible name (aria-label/alt).
 					if (_slideEl.tagName === 'IMG') {
 						OSFramework.OSUI.Helper.Dom.Attribute.Remove(
 							_slideEl,
@@ -262,6 +337,9 @@ namespace Providers.OSUI.Carousel.Splide {
 					this._applyListRoles(splideList);
 				}
 			}
+
+			// Keep aria-current aligned after every list-role re-application point (mount, refresh, redraw)
+			this._syncActiveSlideAriaCurrent();
 		}
 
 		// Method to set the OnInitializeEvent
@@ -273,12 +351,42 @@ namespace Providers.OSUI.Carousel.Splide {
 
 		// Method to set the OnSlideMoved event
 		private _setOnSlideMovedEvent(): void {
+			// Registered before mount, so this runs before Splide updates .is-active — always use
+			// the event index (via Slides.getAt) instead of querying .is-active in the DOM.
 			this.provider.on(Enum.SpliderEvents.Moved, (index) => {
 				if (index !== this._currentIndex) {
 					this.triggerPlatformEventCallback(this._platformEventOnSlideMoved, index);
 					this._currentIndex = index;
+					// Only sync selection state on move — full setA11YProperties runs on mount/refresh
+					this._syncActiveSlideAriaCurrent(index);
+
+					// Skip the first move (page load) and suppress announcements while autoplay is playing
+					if (this.provider.Components.Autoplay.isPaused()) {
+						this._announceActiveSlide(index);
+					}
 				}
 			});
+		}
+
+		// Set aria-current on the active non-clone slide and clear it from every other slide
+		private _syncActiveSlideAriaCurrent(activeIndex?: number): void {
+			this.selfElement
+				.querySelectorAll(OSFramework.OSUI.Constants.Dot + Enum.CssClass.SplideSlide)
+				.forEach((slide) =>
+					OSFramework.OSUI.Helper.Dom.Attribute.Remove(
+						slide as HTMLElement,
+						OSFramework.OSUI.Constants.A11YAttributes.Aria.Current.prop
+					)
+				);
+
+			const activeSlide = this._resolveActiveSlideElem(activeIndex);
+			if (activeSlide) {
+				OSFramework.OSUI.Helper.Dom.Attribute.Set(
+					activeSlide,
+					OSFramework.OSUI.Constants.A11YAttributes.Aria.Current.prop,
+					OSFramework.OSUI.Constants.A11YAttributes.States.True
+				);
+			}
 		}
 
 		// Method to toggle class when pagination is present
@@ -300,6 +408,16 @@ namespace Providers.OSUI.Carousel.Splide {
 			}
 		}
 
+		// Warn once when bare <img> slides lack a platform-owned host for listitem semantics
+		private _warnBareImageSlidesNeedHost(): void {
+			if (this._hasWarnedBareImageSlides) {
+				return;
+			}
+
+			this._hasWarnedBareImageSlides = true;
+			console.warn(`Carousel (${this.widgetId}): ${Enum.WarningMessages.BareImageSlidesNeedHost}`);
+		}
+
 		/**
 		 * Method that encapsulates all methods needed to create a new Carousel
 		 *
@@ -315,13 +433,15 @@ namespace Providers.OSUI.Carousel.Splide {
 		}
 
 		/**
-		 * This method has no implementation on this pattern context!
+		 * Apply all Carousel ARIA attributes (status live region, list roles, aria-current).
+		 * Invoked after Splide mount/refresh and whenever slide state changes.
 		 *
 		 * @protected
 		 * @memberof Providers.OSUI.Carousel.Splide.OSUISplide
 		 */
 		protected setA11YProperties(): void {
-			console.warn(OSFramework.OSUI.GlobalEnum.WarningMessages.MethodNotImplemented);
+			this._setA11yStatusElem();
+			this._setListRoles();
 		}
 
 		/**
@@ -485,6 +605,11 @@ namespace Providers.OSUI.Carousel.Splide {
 				this._listRolesPollId = undefined;
 			}
 
+			if (this._a11yStatusElem) {
+				this._a11yStatusElem.remove();
+				this._a11yStatusElem = undefined;
+			}
+
 			// Check if provider is ready
 			if (this.isBuilt) {
 				this.provider.destroy();
@@ -612,9 +737,9 @@ namespace Providers.OSUI.Carousel.Splide {
 					this.redraw();
 				}
 			} else if (this._hasList && this._carouselListWidgetElem) {
-				// Even when redraw is blocked (e.g. during a changeProperty call), re-apply list roles
-				// in case the List widget refreshed its content and replaced DOM nodes that had the roles.
-				this._applyListRolesWhenReady(this._carouselListWidgetElem);
+				// Even when redraw is blocked (e.g. during a changeProperty call), re-apply a11y
+				// in case the List widget refreshed its content and replaced DOM nodes that had roles.
+				this.setA11YProperties();
 			}
 		}
 	}


### PR DESCRIPTION
This pull request introduces significant accessibility (a11y) improvements to the Splide Carousel provider, focusing on correct ARIA roles, live region announcements, and better handling of bare image slides. The changes ensure that carousels are more accessible to screen readers and compliant with ARIA in HTML standards, especially when slides are simple images not wrapped in containers.

**Accessibility improvements and ARIA handling:**

* Added a visually-hidden `aria-live` status element to announce the active slide to assistive technologies, and implemented logic to update its content as the active slide changes. (`Splide.ts` [[1]](diffhunk://#diff-5f0aee42814ed2a03b05b7128bb8ffc0accd80087d95047ba4a72e70dc7fae9cR11-R12) [[2]](diffhunk://#diff-5f0aee42814ed2a03b05b7128bb8ffc0accd80087d95047ba4a72e70dc7fae9cR42-R69) [[3]](diffhunk://#diff-5f0aee42814ed2a03b05b7128bb8ffc0accd80087d95047ba4a72e70dc7fae9cL228-R305) [[4]](diffhunk://#diff-5f0aee42814ed2a03b05b7128bb8ffc0accd80087d95047ba4a72e70dc7fae9cR354-R391)
* Refactored the logic for applying ARIA roles: now applies `role="list"` and `role="listitem"` only when appropriate, strips roles from bare `<img>` slides, and synchronizes `aria-current` on the active slide. (`Splide.ts` [[1]](diffhunk://#diff-5f0aee42814ed2a03b05b7128bb8ffc0accd80087d95047ba4a72e70dc7fae9cR78-R81) [[2]](diffhunk://#diff-5f0aee42814ed2a03b05b7128bb8ffc0accd80087d95047ba4a72e70dc7fae9cL67-R105) [[3]](diffhunk://#diff-5f0aee42814ed2a03b05b7128bb8ffc0accd80087d95047ba4a72e70dc7fae9cL228-R305) [[4]](diffhunk://#diff-5f0aee42814ed2a03b05b7128bb8ffc0accd80087d95047ba4a72e70dc7fae9cR354-R391)
* Introduced a warning (logged only once per instance) when bare `<img>` slides are used without a container, as this prevents proper list semantics for accessibility. (`Splide.ts` [[1]](diffhunk://#diff-5f0aee42814ed2a03b05b7128bb8ffc0accd80087d95047ba4a72e70dc7fae9cR29-R30) [[2]](diffhunk://#diff-5f0aee42814ed2a03b05b7128bb8ffc0accd80087d95047ba4a72e70dc7fae9cR78-R81) [[3]](diffhunk://#diff-5f0aee42814ed2a03b05b7128bb8ffc0accd80087d95047ba4a72e70dc7fae9cR411-R420); `Enum.ts` [[4]](diffhunk://#diff-39148504cb6cf1722e9570d740708e3cf1003623857dce8e8e9d7d0a9eca13e0R53-R59)

**Code structure and maintainability:**

* Centralized all a11y-related setup into a new `setA11YProperties` method, which is now called after every mount, refresh, or relevant DOM update, ensuring consistent accessibility state. (`Splide.ts` [[1]](diffhunk://#diff-5f0aee42814ed2a03b05b7128bb8ffc0accd80087d95047ba4a72e70dc7fae9cL138-R190) [[2]](diffhunk://#diff-5f0aee42814ed2a03b05b7128bb8ffc0accd80087d95047ba4a72e70dc7fae9cL203-R282) [[3]](diffhunk://#diff-5f0aee42814ed2a03b05b7128bb8ffc0accd80087d95047ba4a72e70dc7fae9cL318-R444) [[4]](diffhunk://#diff-5f0aee42814ed2a03b05b7128bb8ffc0accd80087d95047ba4a72e70dc7fae9cL615-R742)
* Added new enum values for Splide slide state classes and warning messages to improve code clarity and maintainability. (`Enum.ts` [[1]](diffhunk://#diff-39148504cb6cf1722e9570d740708e3cf1003623857dce8e8e9d7d0a9eca13e0R11-R12) [[2]](diffhunk://#diff-39148504cb6cf1722e9570d740708e3cf1003623857dce8e8e9d7d0a9eca13e0R53-R59)

These changes make the Splide Carousel provider more robust and accessible, particularly for users relying on screen readers or keyboard navigation.