### PR TITLE
ROU-12927: Fix content and Tooltip pattern attributes per Figma

### DIFF
--- a/src/scss/01-foundations/_icon-library-odc.scss
+++ b/src/scss/01-foundations/_icon-library-odc.scss
@@ -308,7 +308,6 @@ body.iconLibrary-phosphor {
 .chat-message-wrapper .chat-message-status {
 	display: inline-flex;
 	gap: variables.$token-scale-100;
-	padding: none;
 }
 
 .chat-message-status {

--- a/src/scss/04-patterns/02-content/_chat-message.scss
+++ b/src/scss/04-patterns/02-content/_chat-message.scss
@@ -8,11 +8,13 @@
 ///
 .chat {
 	// ─── Component CSS API ─────────────────────────────────────────────
-	--osui-chat-message-background:      #{variables.$token-bg-neutral-subtle-default};
-	--osui-chat-message-border-radius:   #{variables.$token-border-radius-200};
-	--osui-chat-message-sent-background: var(--color-primary);
-	--osui-chat-message-sent-color:      var(--color-text-inverse);
-	--osui-chat-message-status-color:    #{variables.$token-text-subtlest};
+	--osui-chat-message-background:         #{variables.$token-bg-neutral-subtle-default};
+	--osui-chat-message-border-radius:      #{variables.$token-border-radius-200};
+	--osui-chat-message-sent-background:    var(--color-primary);
+	--osui-chat-message-sent-color:         var(--color-text-inverse);
+	--osui-chat-message-status-color:       #{variables.$token-text-subtlest};
+	// TODO: needs a line-height token — the font-line-height scale has no 18px step (Figma ChatMessage status).
+	--osui-chat-message-status-line-height: 18px;
 	// ───────────────────────────────────────────────────────────────────
 
 	display: flex;
@@ -58,6 +60,7 @@
 			color: var(--osui-chat-message-status-color);
 			display: block;
 			font-size: variables.$token-font-size-275;
+			line-height: var(--osui-chat-message-status-line-height);
 			margin-top: variables.$token-space-100;
 
 			&.hidden {

--- a/src/scss/04-patterns/02-content/_chat-message.scss
+++ b/src/scss/04-patterns/02-content/_chat-message.scss
@@ -62,6 +62,7 @@
 			font-size: variables.$token-font-size-275;
 			line-height: var(--osui-chat-message-status-line-height);
 			margin-top: variables.$token-space-100;
+			width: 100%;
 
 			&.hidden {
 				display: none;

--- a/src/scss/04-patterns/02-content/_list-item-content.scss
+++ b/src/scss/04-patterns/02-content/_list-item-content.scss
@@ -10,6 +10,8 @@
 	// ─── Component CSS API ─────────────────────────────────────────────
 	--osui-list-item-content-title-color: var(--color-text);
 	--osui-list-item-content-text-color: #{variables.$token-text-subtlest};
+	// TODO: needs a line-height token — the font-line-height scale has no 21px step (Figma ListItemContent text).
+	--osui-list-item-content-text-line-height: 21px;
 	--osui-list-item-content-icon-size: #{variables.$token-scale-500};
 	--osui-list-item-content-icon-color: #{variables.$token-icon-subtlest};
 	// ───────────────────────────────────────────────────────────────────
@@ -57,6 +59,7 @@
 	&-text {
 		color: var(--osui-list-item-content-text-color);
 		font-size: variables.$token-font-size-350;
+		line-height: var(--osui-list-item-content-text-line-height);
 	}
 }
 

--- a/src/scss/04-patterns/02-content/_section.scss
+++ b/src/scss/04-patterns/02-content/_section.scss
@@ -9,9 +9,12 @@
 ///
 .section {
 	// ─── Component CSS API ─────────────────────────────────────────────
-	--osui-section-title-color:        var(--color-text);
-	--osui-section-title-border-color: var(--color-border);
-	--osui-section-content-color:      var(--color-text-subtlest);
+	--osui-section-title-color:         var(--color-text);
+	--osui-section-title-border-color:  var(--color-border);
+	--osui-section-content-color:       var(--color-text-subtlest);
+	// TODO: needs line-height tokens — the font-line-height scale has no 25px / 21px steps (Figma Section).
+	--osui-section-title-line-height:   25px;
+	--osui-section-content-line-height: 21px;
 	// ───────────────────────────────────────────────────────────────────
 
 	&-title {
@@ -19,7 +22,8 @@
 		border-bottom: variables.$token-border-size-025 solid var(--osui-section-title-border-color);
 		color: var(--osui-section-title-color);
 		font-size: variables.$token-font-size-500;
-		font-weight: variables.$token-font-weight-medium;
+		font-weight: variables.$token-font-weight-semi-bold;
+		line-height: var(--osui-section-title-line-height);
 		padding: variables.$token-scale-0 variables.$token-scale-0 variables.$token-space-200 variables.$token-scale-0;
 		position: relative;
 		text-transform: none;
@@ -28,6 +32,7 @@
 
 	&-content {
 		color: var(--osui-section-content-color);
+		line-height: var(--osui-section-content-line-height);
 		padding: variables.$token-space-200 variables.$token-scale-0 variables.$token-scale-0;
 	}
 

--- a/src/scss/04-patterns/02-content/_tag.scss
+++ b/src/scss/04-patterns/02-content/_tag.scss
@@ -32,6 +32,7 @@ $osui-tag-lightest-text-colors: (
 	--osui-tag-primary-color: var(--color-primary);
 	--osui-tag-on-light-color: var(--color-text);
 	--osui-tag-soft-border-radius: #{variables.$token-border-radius-100};
+	--osui-tag-medium-soft-border-radius: #{variables.$token-border-radius-200};
 	// ───────────────────────────────────────────────────────────────────
 
 	align-items: center;
@@ -44,7 +45,7 @@ $osui-tag-lightest-text-colors: (
 	line-height: variables.$token-font-line-height-full;
 	min-height: variables.$token-scale-500;
 	min-width: unset;
-	padding: variables.$token-space-0 variables.$token-space-300;
+	padding: variables.$token-space-0 variables.$token-space-200;
 	word-break: normal;
 
 	// Figma Tag spec: Soft shape uses the 4px radius token (border/border-radius/100),
@@ -63,7 +64,13 @@ $osui-tag-lightest-text-colors: (
 		&-medium {
 			font-size: variables.$token-font-size-350;
 			min-height: variables.$token-scale-700;
-			padding: variables.$token-space-0 variables.$token-space-300;
+			padding: variables.$token-space-0 variables.$token-space-250;
+
+			// Figma Tag spec: the Medium size steps the Soft shape up to the 8px
+			// radius token (border/border-radius/200), unlike the 4px default.
+			&.border-radius-soft {
+				border-radius: var(--osui-tag-medium-soft-border-radius);
+			}
 		}
 	}
 

--- a/src/scss/04-patterns/02-content/_user-avatar.scss
+++ b/src/scss/04-patterns/02-content/_user-avatar.scss
@@ -139,11 +139,12 @@ $osui-avatar-lightest-text-colors: (
 		color: variables.$token-text-warning;
 	}
 
-	// Per Figma, the light primary avatar keeps the plain white background the
-	// background-primary-lightest utility already provides (bg/neutral/subtlest)
-	// — only the text follows the brand primary color.
+	// The background-primary-lightest utility is still surface-white (pending
+	// theme-layer review), so the Figma subtle background is set locally.
+	// Matches the Tag pattern's primary treatment.
 	&.background-primary-lightest {
-		color: var(--osui-avatar-primary-color);
+		background-color: variables.$token-bg-primary-subtle-default;
+		color: variables.$token-text-primary;
 	}
 
 	&.background-secondary-lightest {

--- a/src/scss/04-patterns/03-interaction/tooltip/_tooltip.scss
+++ b/src/scss/04-patterns/03-interaction/tooltip/_tooltip.scss
@@ -11,7 +11,7 @@
 	--osui-tooltip-background: #{variables.$token-bg-neutral-boldest-default};
 	--osui-tooltip-color: var(--color-text-inverse);
 	--osui-tooltip-border-radius: #{variables.$token-border-radius-200};
-	--osui-tooltip-padding: #{variables.$token-space-200} #{variables.$token-space-400};
+	--osui-tooltip-padding: #{variables.$token-space-0} #{variables.$token-space-100};
 	--osui-tooltip-font-size: #{variables.$token-font-size-350};
 	--osui-tooltip-shadow: #{variables.$token-elevation-3};
 	--osui-tooltip-min-height: #{variables.$token-scale-900};

--- a/src/scss/04-patterns/03-interaction/tooltip/_tooltip.scss
+++ b/src/scss/04-patterns/03-interaction/tooltip/_tooltip.scss
@@ -10,7 +10,7 @@
 	// ─── Component CSS API ─────────────────────────────────────────────
 	--osui-tooltip-background: #{variables.$token-bg-neutral-boldest-default};
 	--osui-tooltip-color: var(--color-text-inverse);
-	--osui-tooltip-border-radius: #{variables.$token-border-radius-100};
+	--osui-tooltip-border-radius: #{variables.$token-border-radius-200};
 	--osui-tooltip-padding: #{variables.$token-space-200} #{variables.$token-space-400};
 	--osui-tooltip-font-size: #{variables.$token-font-size-350};
 	--osui-tooltip-shadow: #{variables.$token-elevation-3};
@@ -103,7 +103,10 @@
 		}
 	}
 
+	// The balloon wrapper (.osui-balloon) already owns --osui-tooltip-padding, so
+	// the inner content element must not add any of its own or it doubles up.
 	&__balloon-wrapper__balloon {
+		padding: variables.$token-space-0;
 		text-wrap: wrap;
 	}
 }


### PR DESCRIPTION
This PR is for correcting a set of attribute values on the content patterns and the Tooltip so they match the Figma specification.

### What was happening
* ChatMessage status, ListItemContent text, Section title and Section content had no explicit line-height, so they inherited the surrounding line-height instead of the Figma values (18px / 21px / 25px / 21px).
* Section title was rendering with the medium (500) font-weight instead of semi-bold (600).
* Tag had `0 12px` padding on both the Default and the Medium size, instead of `0 8px` and `0 10px`.
* Tag Medium size was using the same 4px Soft radius as the smaller sizes, instead of 8px.
* Tooltip was using the 4px radius token instead of 8px.
* The Tooltip inner content element added its own padding on top of the padding already applied to the balloon wrapper, doubling it.
* UserAvatar with a light primary background kept the plain white background coming from the `background-primary-lightest` utility, so it did not match the equivalent Tag variant.

### What was done
* Added explicit line-heights for the ChatMessage status, ListItemContent text, Section title and Section content. The `font-line-height` token scale has no 18px / 21px / 25px step, so each value is exposed as a component CSS API custom property (`--osui-*-line-height`) with a literal default and a TODO flagging the token gap.
* Section title now reads the semi-bold font-weight token.
* Tag Default size padding now uses `space/200` (`0 8px`) and the Medium size `space/250` (`0 10px`).
* Tag Medium size steps the Soft shape up to the `border/border-radius/200` token (8px) via a new `--osui-tag-medium-soft-border-radius` knob.
* Tooltip border-radius now reads the `border/border-radius/200` token (8px).
* `osui-tooltip__balloon-wrapper__balloon` padding is reset to zero, leaving `--osui-tooltip-padding` on the balloon wrapper as the single source of the tooltip's internal spacing.
* UserAvatar with `background-primary-lightest` now reads the same `bg/primary/subtle/default` background and `text/primary` colour as the Tag pattern, so the primary and transparent variants render identically across both.

### Test Steps
1. Run `npm run dev --target=odc` (and again with `--target=o11`) and open the sample page.
2. Inspect a Chat Message with a status and confirm the status line-height is 18px.
3. Inspect a List Item Content and confirm the secondary text line-height is 21px.
4. Inspect a Section and confirm the title is semi-bold with a 25px line-height and the content has a 21px line-height.
5. Inspect a Tag in the Default size and confirm the padding is `0 8px`; switch to the Medium size and confirm `0 10px` plus an 8px border-radius on the Soft shape.
6. Hover a Tooltip and confirm the balloon has an 8px border-radius and a single `8px 16px` padding ring (no doubled inset around the text).
7. Place a Tag and a User Avatar side by side using the primary and transparent backgrounds, with IsLight both on and off, and confirm the background and text colours match.

### Screenshots
(prefer animated gif)

### Checklist
* [ ] tested locally
* [ ] documented the code
* [ ] clean all warnings and errors of eslint
* [ ] requires changes in OutSystems (if so, provide a module with changes)
* [ ] requires new sample page in OutSystems (if so, provide a module with changes)
