### PR TITLE
ROU-12950: Guard SectionIndexItem dispose when elements are missing

### DIFF
--- a/src/scripts/OSFramework/OSUI/Pattern/SectionIndexItem/SectionIndexItem.ts
+++ b/src/scripts/OSFramework/OSUI/Pattern/SectionIndexItem/SectionIndexItem.ts
@@ -79,8 +79,11 @@ namespace OSFramework.OSUI.Patterns.SectionIndexItem {
 
 		// Method to remove Pattern events
 		private _removeEvents(): void {
-			this.selfElement.removeEventListener(GlobalEnum.HTMLEvent.Click, this._eventOnClick);
-			this.selfElement.removeEventListener(GlobalEnum.HTMLEvent.keyDown, this._eventOnkeyBoardPress);
+			if (this.selfElement) {
+				this.selfElement.removeEventListener(GlobalEnum.HTMLEvent.Click, this._eventOnClick);
+				this.selfElement.removeEventListener(GlobalEnum.HTMLEvent.keyDown, this._eventOnkeyBoardPress);
+			}
+
 			Event.DOMEvents.Listeners.GlobalListenerManager.Instance.removeHandler(
 				Event.DOMEvents.Listeners.Type.ScreenOnScroll,
 				this._eventOnScreenScroll
@@ -135,6 +138,10 @@ namespace OSFramework.OSUI.Patterns.SectionIndexItem {
 
 		// Method to remove scroll margin styles on the item target
 		private _unsetTargetAttributes(): void {
+			if (!this._targetElement) {
+				return;
+			}
+
 			// Set class to target, to avoid inline property styles
 			Helper.Dom.Styles.RemoveClass(this._targetElement, Enum.CssClass.ItemTarget);
 			// Add CSS Variable with the offset value for the scroll target, to be used on the CSS

--- a/src/scripts/OSFramework/OSUI/Pattern/SectionIndexItem/SectionIndexItem.ts
+++ b/src/scripts/OSFramework/OSUI/Pattern/SectionIndexItem/SectionIndexItem.ts
@@ -138,14 +138,13 @@ namespace OSFramework.OSUI.Patterns.SectionIndexItem {
 
 		// Method to remove scroll margin styles on the item target
 		private _unsetTargetAttributes(): void {
-			if (!this._targetElement) {
-				return;
+			// Check if the target element is defined
+			if (this._targetElement) {
+				// Set class to target, to avoid inline property styles
+				Helper.Dom.Styles.RemoveClass(this._targetElement, Enum.CssClass.ItemTarget);
+				// Add CSS Variable with the offset value for the scroll target, to be used on the CSS
+				Helper.Dom.Styles.RemoveStyleAttribute(this._targetElement, Enum.CssVariable.ScrollMargin);
 			}
-
-			// Set class to target, to avoid inline property styles
-			Helper.Dom.Styles.RemoveClass(this._targetElement, Enum.CssClass.ItemTarget);
-			// Add CSS Variable with the offset value for the scroll target, to be used on the CSS
-			Helper.Dom.Styles.RemoveStyleAttribute(this._targetElement, Enum.CssVariable.ScrollMargin);
 		}
 
 		/**


### PR DESCRIPTION
This PR is for fixing SectionIndexItem dispose failures that leave stale instances registered when navigating back to a page.

### What was happening
* When leaving a page with SectionIndex (e.g. browser back), `SectionIndexItem.dispose()` could throw before reaching `super.dispose()`.
* `_removeEvents()` called `removeEventListener` on `selfElement` when it was already undefined.
* `_unsetTargetAttributes()` called DOM/CSS helpers on `_targetElement` when it was undefined, which throws in `Helper.Dom.Styles`.
* Because dispose failed, the instance stayed in `_sectionIndexItemMap`, causing `There is already a SectionIndexItem registered under id: ...` on the next visit.

### What was done
* Guard `_removeEvents()` so click/keyboard listeners are only removed when `selfElement` exists (scroll handler cleanup still runs).
* Guard `_unsetTargetAttributes()` with an early return when `_targetElement` is missing.

### Test Steps
1. Open a page with SectionIndex and SectionIndexItems.
2. Navigate to another page.
3. Use browser Back to return to the SectionIndex page.
4. Confirm no console error about duplicate SectionIndexItem registration.
5. Confirm SectionIndex navigation and scroll highlighting still work.

### Screenshots
(prefer animated gif)

### Checklist
* [ ] tested locally
* [ ] documented the code
* [ ] clean all warnings and errors of eslint
* [ ] requires changes in OutSystems (if so, provide a module with changes)
* [ ] requires new sample page in OutSystems (if so, provide a module with changes)
