### PR TITLE
ROU-12945: Fix padding on tabs empty placeholders

### DIFF
--- a/src/scripts/OSFramework/OSUI/Pattern/Tabs/scss/_tabs.scss
+++ b/src/scripts/OSFramework/OSUI/Pattern/Tabs/scss/_tabs.scss
@@ -251,10 +251,6 @@
 				-servicestudio-display: block !important;
 				-servicestudio-margin-bottom: var(--space-m);
 
-				div:empty {
-					-servicestudio-padding: var(--space-m);
-				}
-
 				.uieditor-if-branch-widget:has(> div:empty) {
 					-servicestudio-height: 0;
 				}

--- a/src/scss/08-servicestudio-preview/_placeholder-empty-o11.scss
+++ b/src/scss/08-servicestudio-preview/_placeholder-empty-o11.scss
@@ -13,7 +13,7 @@
 			display: contents;
 		}
 	}
-	&-item {
+	&__content-item {
 		.ph:empty,
 		.placeholder-empty:empty {
 			-servicestudio-padding: var(--space-m);

--- a/src/scss/08-servicestudio-preview/_placeholder-empty-o11.scss
+++ b/src/scss/08-servicestudio-preview/_placeholder-empty-o11.scss
@@ -13,4 +13,10 @@
 			display: contents;
 		}
 	}
+	&-item {
+		.ph:empty,
+		.placeholder-empty:empty {
+			-servicestudio-padding: var(--space-m);
+		}
+	}
 }

--- a/src/scss/08-servicestudio-preview/_placeholder-empty-odc.scss
+++ b/src/scss/08-servicestudio-preview/_placeholder-empty-odc.scss
@@ -9,5 +9,10 @@
 		& > .placeholder-empty > .list.list-group {
 			display: contents;
 		}
+		&-item {
+			.placeholder-empty:empty {
+				-servicestudio-padding: var(--space-m);
+			}
+		}
 	}
 }

--- a/src/scss/08-servicestudio-preview/_placeholder-empty-odc.scss
+++ b/src/scss/08-servicestudio-preview/_placeholder-empty-odc.scss
@@ -9,10 +9,11 @@
 		& > .placeholder-empty > .list.list-group {
 			display: contents;
 		}
-		&-item {
-			.placeholder-empty:empty {
-				-servicestudio-padding: var(--space-m);
-			}
+	}
+
+	&__content-item {
+		.placeholder-empty:empty {
+			-servicestudio-padding: var(--space-m);
 		}
 	}
 }

--- a/src/scss/08-servicestudio-preview/_servicestudiopreview.scss
+++ b/src/scss/08-servicestudio-preview/_servicestudiopreview.scss
@@ -120,6 +120,16 @@ html[data-uieditorversion^='1'] {
 		}
 	}
 
+	.chat-message-status {
+		.uieditor-if-branch-widget {
+			-servicestudio-display: inline-flex;
+
+			&:empty {
+				-servicestudio-display: none;
+			}
+		}
+	}
+
 	.phone {
 		.table:not(.table-responsive) {
 			display: block;


### PR DESCRIPTION
This PR is for fixing Service Studio preview padding that was incorrectly applied to pattern empty elements inside tab content items.

### What was happening
* A broad `div:empty` rule inside `.osui-tabs__content-item` applied `-servicestudio-padding: var(--space-m)` to every empty div within tab content
* This inflated UI elements that rely on empty divs for rendering, including Button Loading spinners, Range Slider handles, and Splide pagination/spinner elements
* The padding rule was scoped in the Tabs pattern SCSS instead of the platform-specific Service Studio placeholder preview files

### What was done
* Removed the broad `div:empty` padding rule from `_tabs.scss`
* Moved the Service Studio padding rule to `_placeholder-empty-o11.scss` and `_placeholder-empty-odc.scss`, targeting only `.ph:empty` and `.placeholder-empty:empty` placeholders
* Fixed selector specificity so padding applies to `.osui-tabs__content-item` only (not `.osui-tabs-item` or header items)

### Test Steps
1. Open Service Studio and place a Tabs pattern with tab content preview enabled
2. Add a Button Loading pattern inside a tab content item and set IsLoading to True — verify the spinner remains 16px and is not oversized
3. Add a Range Slider inside a tab content item — verify handles render at the correct size
4. Add a Carousel with pagination inside a tab content item — verify navigation dots render at the correct size
5. Verify empty tab content placeholders (`.ph` / `.placeholder-empty`) still have enlarged drop area padding in Service Studio preview
6. Build for both O11 and ODC targets and confirm no SCSS compilation errors

### Screenshots
(prefer animated gif)

### Checklist
* [ ] tested locally
* [ ] documented the code
* [ ] clean all warnings and errors of eslint
* [ ] requires changes in OutSystems (if so, provide a module with changes)
* [ ] requires new sample page in OutSystems (if so, provide a module with changes)
