### PR TITLE
ROU-12945: Fix padding on tabs empty placeholders

### DIFF
--- a/src/scss/04-patterns/04-navigation/tabs/_tabs.scss
+++ b/src/scss/04-patterns/04-navigation/tabs/_tabs.scss
@@ -1,4 +1,4 @@
-@use "../../../tokens/variables";
+@use '../../../tokens/variables';
 
 /* Patterns - Navigation - Tabs */
 ////
@@ -12,7 +12,8 @@
 	--osui-tabs-header-gap: #{variables.$token-space-800}; // horizontal only; Justified stretches instead
 	--osui-tabs-header-item-color: var(--color-text-subtlest);
 	--osui-tabs-header-item-font-size: #{variables.$token-font-size-350};
-	--osui-tabs-header-item-border-radius: #{variables.$token-border-radius-100} #{variables.$token-border-radius-100} 0 0;
+	--osui-tabs-header-item-border-radius: #{variables.$token-border-radius-100} #{variables.$token-border-radius-100} 0
+		0;
 	// Figma says 21px; the scale's nearest step is 20px.
 	--osui-tabs-header-item-line-height: #{variables.$token-font-line-height-500};
 	--osui-tabs-header-item-color-active: #{variables.$token-text-select};
@@ -285,10 +286,6 @@
 			& {
 				-servicestudio-display: block !important;
 				-servicestudio-margin-bottom: variables.$token-scale-600;
-
-				div:empty {
-					-servicestudio-padding: variables.$token-scale-600;
-				}
 
 				.uieditor-if-branch-widget:has(> div:empty) {
 					-servicestudio-height: 0;

--- a/src/scss/08-servicestudio-preview/_placeholder-empty-o11.scss
+++ b/src/scss/08-servicestudio-preview/_placeholder-empty-o11.scss
@@ -1,4 +1,4 @@
-@use '../../../tokens/variables';
+@use '../tokens/variables';
 
 .ph:empty,
 .placeholder-empty:empty {

--- a/src/scss/08-servicestudio-preview/_placeholder-empty-o11.scss
+++ b/src/scss/08-servicestudio-preview/_placeholder-empty-o11.scss
@@ -1,3 +1,5 @@
+@use '../../../tokens/variables';
+
 .ph:empty,
 .placeholder-empty:empty {
 	display: none;
@@ -11,6 +13,12 @@
 		& > .ph > .list.list-group,
 		& > .placeholder-empty > .list.list-group {
 			display: contents;
+		}
+	}
+	&__content-item {
+		.ph:empty,
+		.placeholder-empty:empty {
+			-servicestudio-padding: variables.$token-scale-600;
 		}
 	}
 }

--- a/src/scss/08-servicestudio-preview/_placeholder-empty-odc.scss
+++ b/src/scss/08-servicestudio-preview/_placeholder-empty-odc.scss
@@ -1,4 +1,4 @@
-@use '../../../tokens/variables';
+@use '../tokens/variables';
 
 .placeholder-empty:empty {
 	display: none;
@@ -14,7 +14,7 @@
 	}
 	&__content-item {
 		.placeholder-empty:empty {
-			-servicestudio-padding: var(--space-m);
+			-servicestudio-padding: variables.$token-scale-600;
 		}
 	}
 }

--- a/src/scss/08-servicestudio-preview/_placeholder-empty-odc.scss
+++ b/src/scss/08-servicestudio-preview/_placeholder-empty-odc.scss
@@ -1,3 +1,5 @@
+@use '../../../tokens/variables';
+
 .placeholder-empty:empty {
 	display: none;
 }
@@ -8,6 +10,11 @@
 		& > .placeholder-empty > .OSBlockWidget,
 		& > .placeholder-empty > .list.list-group {
 			display: contents;
+		}
+	}
+	&__content-item {
+		.placeholder-empty:empty {
+			-servicestudio-padding: var(--space-m);
 		}
 	}
 }

--- a/src/scss/08-servicestudio-preview/_servicestudiopreview.scss
+++ b/src/scss/08-servicestudio-preview/_servicestudiopreview.scss
@@ -1,4 +1,4 @@
-@use "../tokens/variables";
+@use '../tokens/variables';
 
 ////
 /// @group ServiceStudio_Preview
@@ -113,6 +113,16 @@ html[data-uieditorversion^='1'] {
 	}
 
 	.icon-states {
+		.uieditor-if-branch-widget {
+			-servicestudio-display: inline-flex;
+
+			&:empty {
+				-servicestudio-display: none;
+			}
+		}
+	}
+
+	.chat-message-status {
 		.uieditor-if-branch-widget {
 			-servicestudio-display: inline-flex;
 


### PR DESCRIPTION
This PR is for fixing Service Studio preview padding that was incorrectly applied to pattern empty elements inside tab content items.

### What was happening
* A broad `div:empty` rule inside `.osui-tabs__content-item` applied `-servicestudio-padding: variables.$token-scale-600` to every empty div within tab content
* This inflated UI elements that rely on empty divs for rendering, including Button Loading spinners, Range Slider handles, and Splide pagination/spinner elements
* The padding rule was scoped in the Tabs pattern SCSS instead of the platform-specific Service Studio placeholder preview files

### What was done
* Removed the broad `div:empty` padding rule from `_tabs.scss`
* Moved the Service Studio padding rule to `_placeholder-empty-o11.scss` and `_placeholder-empty-odc.scss`, targeting only `.ph:empty` and `.placeholder-empty:empty` placeholders
* Fixed selector specificity so padding applies to `.osui-tabs__content-item` only (not `.osui-tabs-item` or header items)

### Test Steps
1. Open Service Studio and place a Tabs pattern with tab content preview enabled
2. Add a Button Loading pattern inside a tab content item and set IsLoading to True — verify the spinner remains 16px and is not oversized
3. Add a Range Slider inside a tab content item — verify handles render at the correct size
4. Add a Carousel with pagination inside a tab content item — verify navigation dots render at the correct size
5. Verify empty tab content placeholders (`.ph` / `.placeholder-empty`) still have enlarged drop area padding in Service Studio preview
6. Build for both O11 and ODC targets and confirm no SCSS compilation errors

### Screenshots
(prefer animated gif)

### Checklist
* [ ] tested locally
* [ ] documented the code
* [ ] clean all warnings and errors of eslint
* [ ] requires changes in OutSystems (if so, provide a module with changes)
* [ ] requires new sample page in OutSystems (if so, provide a module with changes)
