### PR TITLE
ROU-12945: Fix chat status icons layout in Service Studio preview

### DIFF
--- a/src/scss/08-servicestudio-preview/_servicestudiopreview.scss
+++ b/src/scss/08-servicestudio-preview/_servicestudiopreview.scss
@@ -1,4 +1,4 @@
-@use "../tokens/variables";
+@use '../tokens/variables';
 
 ////
 /// @group ServiceStudio_Preview
@@ -113,6 +113,16 @@ html[data-uieditorversion^='1'] {
 	}
 
 	.icon-states {
+		.uieditor-if-branch-widget {
+			-servicestudio-display: inline-flex;
+
+			&:empty {
+				-servicestudio-display: none;
+			}
+		}
+	}
+
+	.chat-message-status {
 		.uieditor-if-branch-widget {
 			-servicestudio-display: inline-flex;
 


### PR DESCRIPTION
This PR is for fixing the chat message status icons layout in Service Studio preview when an If widget is used.

### What was happening
* Inside a chat message status container, content within an If branch was displayed in a column direction instead of inline
* Service Studio injects `.uieditor-if-branch-widget` wrappers that default to block layout, causing the time icon and timestamp text to stack vertically

### What was done
* Added Service Studio preview styles for `.chat-message-status .uieditor-if-branch-widget` to use `inline-flex`, matching the existing `.icon-states` pattern
* Hidden empty If branch widgets in preview to avoid layout gaps

### Test Steps
1. Open a screen with a chat message status that uses an If condition for time/status icons
2. Verify in Service Studio preview that the time icon and timestamp appear inline (row direction) inside the If branch
3. Verify the sent/read status icon still appears correctly beside the If content
4. Confirm empty If branches are not visible in preview

### Screenshots
(prefer animated gif)

### Checklist
* [ ] tested locally
* [ ] documented the code
* [ ] clean all warnings and errors of eslint
* [ ] requires changes in OutSystems (if so, provide a module with changes)
* [ ] requires new sample page in OutSystems (if so, provide a module with changes)
