### PR TITLE
ROU-12945: Fixed wrong design time presentations

### DIFF
--- a/src/scss/01-foundations/_icon-library-odc.scss
+++ b/src/scss/01-foundations/_icon-library-odc.scss
@@ -207,8 +207,7 @@ body.iconLibrary-phosphor {
 }
 
 .form {
-	// Option Content = Text Only (native select), not Custom (div.dropdown-display)
-	.dropdown-container:has(> select.dropdown-display):after {
+	.dropdown-container[class*='ThemeGrid_Width']:has(select):after {
 		top: calc(50% - var(--space-m) / 2);
 	}
 }
@@ -489,6 +488,13 @@ body.iconLibrary-phosphor {
 				}
 			}
 		}
+	}
+}
+
+.form {
+	// Service Studio Preview
+	.dropdown-container:has(> select.dropdown-display):after {
+		-servicestudio-top: calc(50% - var(--space-m) / 2);
 	}
 }
 

--- a/src/scss/01-foundations/_icon-library-odc.scss
+++ b/src/scss/01-foundations/_icon-library-odc.scss
@@ -135,7 +135,7 @@ body.iconLibrary-phosphor {
 		transform: translateY(-50%);
 	}
 
-	.form-control[data-input]{
+	.form-control[data-input] {
 		padding-left: var(--space-xl);
 	}
 }
@@ -146,7 +146,7 @@ body.iconLibrary-phosphor {
 		right: var(--space-base);
 	}
 
-	.form-control[data-input]{
+	.form-control[data-input] {
 		padding-left: var(--space-base);
 		padding-right: var(--space-xl);
 	}

--- a/src/scss/01-foundations/_icon-library-odc.scss
+++ b/src/scss/01-foundations/_icon-library-odc.scss
@@ -207,7 +207,8 @@ body.iconLibrary-phosphor {
 }
 
 .form {
-	.dropdown-container[class*="ThemeGrid_Width"]:has(select):after {
+	// Option Content = Text Only (native select), not Custom (div.dropdown-display)
+	.dropdown-container:has(> select.dropdown-display):after {
 		top: calc(50% - var(--space-m) / 2);
 	}
 }

--- a/src/scss/08-servicestudio-preview/_servicestudiopreview.scss
+++ b/src/scss/08-servicestudio-preview/_servicestudiopreview.scss
@@ -121,8 +121,13 @@ html[data-uieditorversion^='1'] {
 	}
 
 	.chat-message-status {
+		&:has(.uieditor-if-widget-container) {
+			-servicestudio-display: inline-flex;
+		}
+
 		.uieditor-if-branch-widget {
 			-servicestudio-display: inline-flex;
+			-servicestudio-align-items: center;
 
 			&:empty {
 				-servicestudio-display: none;


### PR DESCRIPTION
This PR is for fixing incorrect design-time (Service Studio preview) presentation of Chat Message status and Dropdown arrow positioning on ODC.

### What was happening
* In Service Studio preview, Chat Message status layout broke when an If widget container was present inside `.chat-message-status`, causing misaligned status icons.
* The dropdown arrow positioning rule in the ODC icon library was targeting all dropdown containers with a select element, including Custom dropdowns, causing incorrect arrow placement for Text Only (native select) dropdowns.

### What was done
* Added Service Studio preview styles so `.chat-message-status` uses `inline-flex` when it contains a `.uieditor-if-widget-container`, and aligned `.uieditor-if-branch-widget` children vertically.
* Narrowed the dropdown arrow selector to only target native select dropdowns (`> select.dropdown-display`) instead of any container with a select child.

### Test Steps
1. Open a module in Service Studio with a Chat Message pattern that uses conditional logic (If widget) inside the message status area.
2. Verify the status icon and conditional content display inline and aligned in the design-time preview.
3. Add a Dropdown with Option Content set to Text Only (native select) inside a form and confirm the arrow icon is vertically centered.
4. Add a Dropdown with Option Content set to Custom and confirm the arrow positioning is not affected by this change.
5. Run `npm run build` and confirm lint passes with zero errors and warnings.

### Screenshots
(prefer animated gif)

### Checklist
* [ ] tested locally
* [ ] documented the code
* [ ] clean all warnings and errors of eslint
* [ ] requires changes in OutSystems (if so, provide a module with changes)
* [ ] requires new sample page in OutSystems (if so, provide a module with changes)
