### PR TITLE
ROU-12926: Updated release workflow to remove everlytic

### DIFF
--- a/.github/workflows/template-release.yaml
+++ b/.github/workflows/template-release.yaml
@@ -105,12 +105,15 @@ jobs:
                   key-name: o11odc-github-gitpersonal-token-prd
 
             - name: 🔄 Merge rc${{ inputs.new-version }} into main
-              uses: everlytic/branch-merge@c4a244dc23143f824ae6c022a10732566cb8e973 #v1.1.5
-              with:
-                  github_token: ${{ steps.get-github-token.outputs.az-keyvault-value }}
-                  source_ref: rc${{ inputs.new-version }}
-                  target_branch: 'main'
-                  commit_message_template: 'Merged rc${{ inputs.new-version }} into main. [skip ci]'
+              env:
+                  GH_TOKEN: ${{ steps.get-github-token.outputs.az-keyvault-value }}
+              run: |
+                  gh api \
+                    --method POST \
+                    "repos/${{ github.repository }}/merges" \
+                    -f base=main \
+                    -f head=rc${{ inputs.new-version }} \
+                    -f commit_message="Merged rc${{ inputs.new-version }} into main. [skip ci]"
 
     set-pre-release-as-lts:
         name: Set pre-release as LTS


### PR DESCRIPTION
This PR is to remove everlytic from the release workflow


### What was happening

- 
<img width="2380" height="900" alt="image" src="https://github.com/user-attachments/assets/2dfa419b-13ec-44fb-89c1-0949f9a9bd22" />


### What was done

- Changed the workflow to directly use the GitHub cli 

### Test Steps

1. Run release workflow
2. Validate workflow result

### Checklist

-   [ ] tested locally
-   [ ] documented the code
-   [ ] clean all warnings and errors of eslint
-   [ ] requires changes in OutSystems (if so, provide a module with changes)
-   [ ] requires new sample page in OutSystems (if so, provide a module with changes)
