### PR TITLE
ROU-12957: Fixed paddings and margins for Dropdown tags

### DIFF
--- a/scripts/generate-css-api-reference.mjs
+++ b/scripts/generate-css-api-reference.mjs
@@ -172,6 +172,9 @@ for (const abs of files) {
 // ── Build shared body (TOC + category tables) ────────────────────────────────
 const sortedCats = [...categories.entries()].sort((a, b) => a[1].order - b[1].order);
 
+// Values come from our own SCSS at build time; only `|` needs escaping for the
+// markdown table. Backslashes must pass through untouched — values land inside a
+// code span (e.g. `'\f107'`), where backslash is literal, so escaping them corrupts output.
 const esc = (v) => v.replace(/\|/g, '\\|');
 let totalProps = 0;
 let totalComponents = 0;

--- a/src/scss/01-foundations/_icon-library-o11.scss
+++ b/src/scss/01-foundations/_icon-library-o11.scss
@@ -218,13 +218,6 @@
 	}
 }
 
-.vscomp-search-container {
-	&:before {
-		content: '\f002';
-		font: normal normal normal 14px/1 FontAwesome;
-	}
-}
-
 /* Patterns - Interaction - DropdownSearch */
 ////
 /// @group Patterns-DropdownSearch

--- a/src/scss/04-patterns/03-interaction/dropdown/provider/_virtualselect.scss
+++ b/src/scss/04-patterns/03-interaction/dropdown/provider/_virtualselect.scss
@@ -1,4 +1,4 @@
-@use "../../../../tokens/variables";
+@use '../../../../tokens/variables';
 
 // Set the transform values to checkBox Checked Icon
 @mixin CheckBoxCheckIconTransform {
@@ -19,7 +19,8 @@
 			// The extra `.vscomp-wrapper` is required to outrank the focus elevation reset below
 			.vscomp-wrapper .vscomp-toggle-button {
 				border-color: var(--osui-dropdown-focus-border-color, #{variables.$token-semantics-primary-base});
-				box-shadow: 0 0 0 variables.$token-border-size-050 var(--osui-dropdown-focus-ring-color, #{variables.$token-border-focus-default});
+				box-shadow: 0 0 0 variables.$token-border-size-050
+					var(--osui-dropdown-focus-ring-color, #{variables.$token-border-focus-default});
 
 				// Arrow keeps its resting colour while open — only the rotation changes
 				&:after {
@@ -88,15 +89,8 @@
 	}
 
 	&.has-value {
-		&.show-value-as-tags {
-			.vscomp-toggle-button {
-				padding-left: variables.$token-scale-200;
-			}
-		}
 		.vscomp-value {
 			color: var(--color-text);
-			margin-right: variables.$token-scale-600;
-			margin-left: variables.$token-scale-0;
 		}
 	}
 
@@ -140,10 +134,16 @@
 	}
 
 	&.show-value-as-tags {
-		.vscomp-toggle-button {
+		&.has-value .vscomp-toggle-button {
 			height: auto;
 			min-height: variables.$token-scale-1000;
-			padding: 6px variables.$token-scale-1200 2px variables.$token-scale-400; // 6px/2px: design-spec vertical rhythm for tag rows, no exact token
+			padding-block: variables.$token-scale-100;
+			padding-inline-end: variables.$token-scale-1600;
+			padding-inline-start: variables.$token-scale-200;
+		}
+
+		.vscomp-value {
+			gap: variables.$token-scale-100;
 		}
 
 		.vscomp-value-tag {
@@ -156,7 +156,10 @@
 			font-size: variables.$token-font-size-300;
 			font-weight: variables.$token-font-weight-medium;
 			height: variables.$token-scale-700;
-			padding: 0 variables.$token-scale-200 0 variables.$token-scale-300;
+			margin: 0;
+			padding-block: 0;
+			padding-inline-end: variables.$token-scale-200;
+			padding-inline-start: variables.$token-scale-300;
 			position: relative;
 
 			.vscomp-value-tag-content {
@@ -168,7 +171,8 @@
 				border-radius: 0;
 				color: variables.$token-icon-subtlest;
 				height: auto;
-				margin-left: variables.$token-scale-100;
+				left: auto;
+				margin-inline-start: variables.$token-scale-100;
 				opacity: 0.5;
 				position: relative;
 				right: auto;
@@ -198,11 +202,19 @@
 					}
 				}
 			}
+
+			&.more-value-count {
+				padding-inline-end: variables.$token-scale-200;
+			}
 		}
-		.vscomp-clear-button {
-			margin-top: 0;
-			top: 50%;
-			transform: translateY(-50%);
+
+		&.has-value {
+			.vscomp-clear-button {
+				margin-top: 0;
+				top: 50%;
+				transform: translateY(-50%);
+				right: variables.$token-scale-1000;
+			}
 		}
 	}
 
@@ -245,44 +257,21 @@
 			}
 		}
 
-		&.has-value {
-			.vscomp-value {
-				margin-left: variables.$token-scale-600;
-				margin-right: variables.$token-scale-0;
+		&.show-value-as-tags {
+			.vscomp-value-tag {
+				margin: 0;
+				padding-inline-end: variables.$token-scale-200;
+				padding-inline-start: variables.$token-scale-300;
 			}
 
-			&,
-			&.show-value-as-tags {
+			&.has-value {
 				.vscomp-clear-button {
 					left: variables.$token-scale-1000;
 				}
 			}
 		}
 
-		&.show-value-as-tags {
-			&.has-value {
-				.vscomp-toggle-button {
-					padding-right: variables.$token-scale-200;
-				}
-			}
-
-			.vscomp-value-tag {
-				padding: 6px 10px 6px 35px;
-			}
-
-			.vscomp-value-tag-clear-button {
-				left: 10px;
-				right: auto;
-			}
-
-			.vscomp-toggle-button {
-				padding: variables.$token-scale-100 variables.$token-scale-400 variables.$token-scale-0 variables.$token-scale-1200;
-			}
-		}
-
 		.vscomp-toggle-button {
-			padding: variables.$token-scale-100 variables.$token-scale-400 variables.$token-scale-100 variables.$token-scale-1000;
-
 			&:after {
 				left: variables.$token-scale-400;
 				right: auto;
@@ -296,14 +285,6 @@
 				&:after {
 					@include IsRTL_CheckBoxCheckIconTransform;
 				}
-			}
-		}
-	}
-
-	&:not(.text-direction-rtl) {
-		&.has-value {
-			.vscomp-clear-button {
-				right: variables.$token-scale-1000;
 			}
 		}
 	}
@@ -361,7 +342,8 @@
 	height: var(--vscomp-toogle-btn-height);
 	line-height: var(--vscomp-toogle-btn-height);
 	min-width: 180px;
-	padding: variables.$token-scale-100 variables.$token-scale-1000 variables.$token-scale-100 variables.$token-scale-400;
+	padding: variables.$token-scale-100 variables.$token-scale-1000 variables.$token-scale-100
+		variables.$token-scale-400;
 	position: relative;
 	transition: border-color variables.$token-transition-time-100 variables.$token-transition-curve-base;
 	vertical-align: middle;
@@ -445,6 +427,11 @@
 	border-bottom: variables.$token-border-size-025 solid var(--color-border);
 	padding: variables.$token-scale-0 variables.$token-scale-200 variables.$token-scale-0 variables.$token-scale-400;
 	position: relative;
+
+	&::before {
+		content: none;
+		display: none;
+	}
 
 	.vscomp-search-clear {
 		border-radius: 50%;
@@ -670,12 +657,9 @@
 ///
 .phone,
 .tablet {
-	.vscomp-wrapper {
-		&.show-value-as-tags {
-			.vscomp-toggle-button {
-				min-height: var(--vscomp-toogle-btn-mobile-height);
-			}
-		}
+	.vscomp-wrapper.show-value-as-tags.has-value .vscomp-toggle-button {
+		min-height: var(--vscomp-toogle-btn-mobile-height);
+		padding-block: variables.$token-scale-200;
 	}
 
 	.vscomp-toggle-button {


### PR DESCRIPTION
This PR is for correcting spacing, padding, and layout of the Dropdown Show Value as Tags mode to align with Figma specifications.

### What was happening
* Dropdown in Show Value as Tags mode had inconsistent paddings, margins, and clear-button positioning in LTR and RTL
* Tag chips used legacy physical margin/padding values instead of logical properties
* Search icon was duplicated via FontAwesome in the O11 icon library
* Mobile tag mode did not apply correct vertical padding when a value was selected

### What was done
* Reworked `.show-value-as-tags.has-value` toggle padding using logical properties and design tokens
* Added gap between tags via flex gap on `.vscomp-value`
* Reset tag margins and normalized tag clear-button positioning for RTL
* Positioned clear button consistently for LTR and RTL in tags mode
* Suppressed duplicate search icon in dropdown search container
* Removed FontAwesome search icon rule from O11 icon library
* Updated mobile padding for tags mode on phone/tablet breakpoints

### Test Steps
1. Open the sample application
2. Verify toggle padding, tag spacing (4px gap), and clear button position in LTR
3. Switch to RTL and verify tag padding and clear button mirror correctly
4. Test on mobile viewport (phone/tablet) and confirm increased vertical padding when has-value
5. Open dropdown and confirm no duplicate search magnifying icon appears

### Checklist
* [ ] tested locally
* [ ] documented the code
* [ ] clean all warnings and errors of eslint
* [ ] requires changes in OutSystems (if so, provide a module with changes)
* [ ] requires new sample page in OutSystems (if so, provide a module with changes)
