### PR TITLE
ROU-12956: Fix Animated Label autofill and disabled appearance

### DIFF
--- a/src/scss/04-patterns/03-interaction/animated-label/_animated-label.scss
+++ b/src/scss/04-patterns/03-interaction/animated-label/_animated-label.scss
@@ -189,6 +189,12 @@
 		}
 	}
 
+	// Autofill — bottom half transparent so field/autocomplete color shows through the label
+	&:has(.form-control:-webkit-autofill).active .animated-label-text {
+		background-color: transparent;
+		background-image: linear-gradient(to top, transparent 50%, var(--color-background-body) 50%);
+	}
+
 	&:has(.not-valid) {
 		border-color: var(--osui-animated-label-error-color);
 		margin-bottom: variables.$token-scale-900;

--- a/src/scss/04-patterns/03-interaction/animated-label/_animated-label.scss
+++ b/src/scss/04-patterns/03-interaction/animated-label/_animated-label.scss
@@ -1,4 +1,4 @@
-@use "../../../tokens/variables";
+@use '../../../tokens/variables';
 
 /* Patterns - Interaction - Animated Label */
 ////
@@ -13,7 +13,8 @@
 	--osui-animated-label-hover-border-color: var(--color-border-input-hover);
 	--osui-animated-label-focus-border-color: var(--color-border-primary);
 	--osui-animated-label-focus-ring-color: #{variables.$token-border-focus-default};
-	--osui-animated-label-focus-shadow: 0 0 0 #{variables.$token-border-size-050} var(--osui-animated-label-focus-ring-color);
+	--osui-animated-label-focus-shadow: 0 0 0 #{variables.$token-border-size-050}
+		var(--osui-animated-label-focus-ring-color);
 	--osui-animated-label-error-color: #{variables.$token-text-danger};
 	--osui-animated-label-disabled-background: var(--color-background-input-disabled);
 	--osui-animated-label-disabled-color: var(--color-text-disabled);
@@ -26,6 +27,7 @@
 			font-size: variables.$token-font-size-300;
 			top: 0;
 			transform: translateY(-50%);
+			z-index: 1;
 
 			label {
 				color: var(--osui-animated-label-color);
@@ -177,6 +179,14 @@
 				color: var(--osui-animated-label-disabled-color);
 			}
 		}
+
+		&.active .animated-label-text {
+			background-image: -webkit-linear-gradient(
+				bottom,
+				var(--osui-animated-label-disabled-background) 50%,
+				var(--osui-input-background, var(--color-background-input)) 50%
+			);
+		}
 	}
 
 	&:has(.not-valid) {
@@ -200,10 +210,15 @@
 
 	// Nested to raise specificity above global .form-control focus rules
 	.animated-label-input {
+		border-radius: inherit;
 		position: relative;
 
 		span.input-text {
 			display: block;
+		}
+
+		span {
+			border-radius: inherit;
 		}
 
 		&:not(:has(textarea)) {
@@ -218,7 +233,7 @@
 			&[data-input] {
 				background-color: transparent;
 				border: none;
-				border-radius: 0;
+				border-radius: inherit;
 				height: 100%;
 				padding: 0 variables.$token-scale-400;
 				width: 100%;
@@ -233,7 +248,7 @@
 			&[data-textarea] {
 				background-color: transparent;
 				border: none;
-				border-radius: 0;
+				border-radius: inherit;
 				margin: 0;
 				padding: variables.$token-scale-400 variables.$token-scale-400 0;
 				width: 100%;

--- a/src/scss/04-patterns/03-interaction/animated-label/_animated-label.scss
+++ b/src/scss/04-patterns/03-interaction/animated-label/_animated-label.scss
@@ -27,7 +27,7 @@
 			font-size: variables.$token-font-size-300;
 			top: 0;
 			transform: translateY(-50%);
-			z-index: 1;
+			z-index: var(--layer-local-tier-1);
 
 			label {
 				color: var(--osui-animated-label-color);
@@ -93,7 +93,6 @@
 				background-color: transparent;
 				border: variables.$token-border-size-0;
 				border-bottom: variables.$token-border-size-025 solid var(--osui-animated-label-border-color);
-				border-radius: variables.$token-border-radius-0;
 				padding: variables.$token-scale-0;
 				transition: all variables.$token-transition-time-100 variables.$token-transition-curve-expressive;
 
@@ -181,8 +180,8 @@
 		}
 
 		&.active .animated-label-text {
-			background-image: -webkit-linear-gradient(
-				bottom,
+			background-image: linear-gradient(
+				to top,
 				var(--osui-animated-label-disabled-background) 50%,
 				var(--osui-input-background, var(--color-background-input)) 50%
 			);
@@ -216,15 +215,15 @@
 
 	// Nested to raise specificity above global .form-control focus rules
 	.animated-label-input {
-		border-radius: inherit;
 		position: relative;
+
+		&,
+		* {
+			border-radius: inherit;
+		}
 
 		span.input-text {
 			display: block;
-		}
-
-		span {
-			border-radius: inherit;
 		}
 
 		&:not(:has(textarea)) {
@@ -239,7 +238,6 @@
 			&[data-input] {
 				background-color: transparent;
 				border: none;
-				border-radius: inherit;
 				height: 100%;
 				padding: 0 variables.$token-scale-400;
 				width: 100%;
@@ -254,7 +252,6 @@
 			&[data-textarea] {
 				background-color: transparent;
 				border: none;
-				border-radius: inherit;
 				margin: 0;
 				padding: variables.$token-scale-400 variables.$token-scale-400 0;
 				width: 100%;


### PR DESCRIPTION
This PR is for improving the outlined Animated Label appearance 

### What was happening
* Chrome autofill painted a native background on the input that did not align with the outlined field styling
* The floated label kept a solid background that overlapped the autofill fill, creating a visible mismatch at the border notch
* The label and autofill layers stacked incorrectly in some states
* The label had a visible mismatch when the input was disabled

### What was done
* Raised floated label z-index so it renders above the input autofill layer
* Added an autofill-specific label gradient with a transparent bottom half so autocomplete color shows through
* Added a disabled active label gradient for the border notch
* Inherited border-radius on the inner input wrapper and controls for consistent rounded corners

### Test Steps
1. Open sample application
3. Verify the label floats correctly and sits above the autofill field
4. Verify the label bottom is transparent and shows the field/autofill colour
5. Verify a disabled outlined Animated Label with autofill still looks correct
6. Verify non-autofill active and disabled states are unchanged


### Checklist
* [ ] tested locally
* [ ] documented the code
* [ ] clean all warnings and errors of eslint
* [ ] requires changes in OutSystems (if so, provide a module with changes)
* [ ] requires new sample page in OutSystems (if so, provide a module with changes)
