### PR TITLE
ROU-12992: add new layout styles

### DIFF
--- a/.claude/commands/port-to-deprecated.md
+++ b/.claude/commands/port-to-deprecated.md
@@ -1,0 +1,70 @@
+---
+description: Port a new-theme SCSS change into the deprecated (pre-token) theme snapshot under deprecated/
+argument-hint: "[commit-ish | file path | nothing for the working diff]"
+---
+
+# Port to the deprecated theme
+
+Backport the change described by `$ARGUMENTS` from the token-based new theme into the deprecated pre-migration CSS snapshot in `deprecated/`.
+
+`$ARGUMENTS` may be:
+- a commit-ish (`HEAD`, `6ce34d903`, `HEAD~3..HEAD`) → port that commit's SCSS changes
+- one or more paths → port the working-tree changes in those files
+- empty → port the working-tree + staged SCSS changes (`git diff HEAD -- '*.scss'`), falling back to `HEAD`'s SCSS changes if the tree is clean
+
+---
+
+## Authoritative procedure
+
+@.claude/skills/osui-deprecated-theme/SKILL.md
+
+Follow it as written. The steps below are the execution order, not a substitute for the skill.
+
+## Steps
+
+1. **Resolve the change set.**
+   - Commit-ish → `git show <ref> -- 'src/**/*.scss'`
+   - Paths → `git diff HEAD -- <paths>`
+   - Empty → `git diff HEAD -- '*.scss'`; if empty, `git show HEAD -- 'src/**/*.scss'`
+   - If the change set contains no SCSS, stop and say so — there is nothing to port. TypeScript changes have no deprecated-theme counterpart.
+
+2. **Audit the source before porting** (skill §7). For every `$token-*` the diff touches:
+   - Confirm it exists: `grep -n '^\$token-<name>' src/scss/tokens/_variables.scss`
+   - Confirm custom-property declarations use `#{...}` interpolation
+   Fix any source bug found, recompile, and report the fix. Do not port broken output.
+
+3. **Compile the changed partial in isolation** to get the exact CSS being ported:
+   ```bash
+   npx sass --load-path=. <changed-partial> | grep -B3 -A15 '<new-selector>'
+   ```
+
+4. **De-tokenise** every value using the skill's mapping tables (§3). Keep the `--osui-*` component API structure (§4). Note every approximation you are forced to make.
+
+5. **Locate insertion anchors** in both `deprecated/O11.OutSystemsUI.css` and `deprecated/ODC.OutSystemsUI.css` — the compiled new theme's immediately-preceding rule, so the block lands in the same relative position.
+
+6. **Patch both files** with a single Python script that asserts anchor uniqueness and non-duplication before writing (skill §6 step 5). Match the compiled formatting exactly (skill §5): `selector{`, no space after `:`, two-space indent, autoprefixer prefixes where the surrounding file carries them.
+
+7. **Log the port** in `deprecated/README.md` under a `## Hand-applied ports` heading (create it if absent). One entry per port:
+   ```
+   - **<date> — <ticket / commit>** — <selectors added>.
+     Mapping: <token> → <old var> (…). Approximations: <…, or "none">.
+   ```
+   This log is what survives a snapshot refresh; without it the port is silently lost.
+
+8. **Verify** (skill §8) and report:
+   - `grep -c -- '--token-' deprecated/*.css` → must be 0 for both
+   - identical selector/var counts across both files
+   - `git diff --stat deprecated/` → same insertion count per file
+   - read `git diff deprecated/` and confirm the formatting is indistinguishable from surrounding content
+   - confirm every selector the port targets actually exists in the old theme; if one doesn't, flag it as dead CSS rather than shipping it quietly
+
+## Output
+
+Report, concisely:
+- what was ported (selectors, both bundles)
+- the token → legacy-var mapping applied
+- every approximation or value with no old-theme equivalent
+- any source bug fixed on the way
+- the verification results
+
+Do not commit unless asked.

--- a/.claude/skills/osui-deprecated-theme/SKILL.md
+++ b/.claude/skills/osui-deprecated-theme/SKILL.md
@@ -1,0 +1,205 @@
+---
+name: osui-deprecated-theme
+description: Port SCSS changes from the token-based new theme into the deprecated (pre-token-migration) theme snapshot under deprecated/. Use this skill whenever a change lands in src/scss/** or src/scripts/**/scss/** and it also has to be reflected in the old theme — i.e. any time the words "old theme", "deprecated theme", "deprecated folder", "bring this to the old theme", or "backport to the pre-migration CSS" come up. Covers what the snapshot is, the token → legacy-var mapping table, the compiled-CSS formatting rules, insertion-point anchoring, and the verification checklist.
+---
+
+# Porting to the deprecated (old) theme
+
+## 1. What `deprecated/` actually is
+
+```
+deprecated/O11.OutSystemsUI.css    ~774 KB
+deprecated/ODC.OutSystemsUI.css    ~781 KB
+deprecated/README.md
+```
+
+Two **compiled CSS snapshots** of the pre-token-migration codebase — not SCSS, not partials, not a build target. There is no source tree behind them in this repo; the SCSS they came from lives on `dev` at the commit recorded in `deprecated/README.md`.
+
+Storybook serves them at `/deprecated/*` (`.storybook/main.ts` `staticDirs`) and the **Theme** toolbar toggle (`.storybook/preview.ts`) swaps between `/osui/*` (new token theme) and `/deprecated/*` (old theme) so reviewers can eyeball old vs new.
+
+**Consequences that drive everything below:**
+
+- Porting a change means **hand-editing compiled CSS**. There is no `npm run build` that will do it for you.
+- Both files must be patched. They are separate platform bundles that share ~95% of their content; a rule present in one and absent in the other is a bug.
+- Hand-applied edits are **destroyed by a snapshot refresh** (rebuild `dev`, copy `dist/*.OutSystemsUI.css` over these). So every port must be logged in `deprecated/README.md` under **Hand-applied ports** — that log is the only record that survives review and the only way a future refresh can be replayed.
+
+## 2. The one hard rule: no tokens
+
+The old theme predates `outsystems-design-tokens`. Its entire vocabulary is the `:root` block near the top of each file (search `/*! Typography - Size */`). Anything you add must resolve inside that vocabulary.
+
+**Never** let a `--token-*` or `$token-*` reach these files. Invariant to check after every port:
+
+```bash
+grep -c -- '--token-' deprecated/*.css      # must stay 0 for both
+```
+
+## 3. Token → legacy-var mapping
+
+Resolve the new theme's `$token-*` to its literal value first (`src/scss/tokens/_variables.scss`, gitignored but present locally — each line ends in a hardcoded fallback), then map the literal onto the old vocabulary.
+
+### Spacing — `$token-scale-*` / `$token-space-*` → `--space-*`
+
+| literal | old var      | | literal | old var |
+|---------|--------------|-|---------|---------|
+| `0px`   | `--space-none` | | `24px` | `--space-m` |
+| `4px`   | `--space-xs`   | | `32px` | `--space-l` |
+| `8px`   | `--space-s`    | | `40px` | `--space-xl` |
+| `16px`  | `--space-base` | | `48px` | `--space-xxl` |
+
+The old ladder has **eight** steps; the token scale has thirty-odd. `6px`, `10px`, `12px`, `20px`, `28px`, `36px`, `44px`, `56px`+ have **no** old equivalent — emit the literal px value and add a `/*! no old-theme equivalent */`-style note in the README log, not in the CSS (comments in the CSS body diverge from compiled output).
+
+### Border size — `$token-border-size-*` → `--border-size-*`
+
+| token | literal | old var |
+|-------|---------|---------|
+| `$token-border-size-0`   | `0px` | `--border-size-none` |
+| `$token-border-size-025` | `1px` | `--border-size-s` |
+| `$token-border-size-050` | `2px` | `--border-size-m` |
+| `$token-border-size-075` | `3px` | `--border-size-l` |
+
+Note the ladder stops at `075`. There is **no** `$token-border-size-100` — if you see one in the source, the source is broken (see §7).
+
+### Border radius — `$token-border-radius-*` → `--border-radius-*`
+
+Old vocabulary is only `none` (0) / `soft` (4px) / `rounded` (100px) / `circle` (100%). Map `$token-border-radius-0` → `--border-radius-none`, `-100` (4px) → `--border-radius-soft`, `-full` (999px) → `--border-radius-rounded`. `8px`/`12px`/`16px` radii (`-200`/`-300`/`-400`) do **not** exist in the old theme — the pre-migration look is a 4px-radius design. Prefer `--border-radius-soft` over a hardcoded larger radius unless the change is specifically about radius.
+
+### Color
+
+| new token | old var |
+|-----------|---------|
+| `$token-semantics-primary-base` | `var(--color-primary)` |
+| `$token-semantics-danger-base` | `var(--color-error)` |
+| `$token-semantics-warning-base` | `var(--color-warning)` |
+| `$token-semantics-success-base` | `var(--color-success)` |
+| `$token-semantics-info-base` | `var(--color-info)` |
+| `$token-bg-body` / `$token-bg-surface-default` | `var(--color-neutral-0)` (white) or `var(--color-background-body)` for the page ground |
+| `$token-text-default` | `var(--color-neutral-10)` |
+| `$token-text-subtle` | `var(--color-neutral-7)` |
+| `$token-border-subtle` (`#e6eaee`) | `var(--color-neutral-4)` (`#dee2e6`) |
+| `$token-border-default` | `var(--color-neutral-5)` (`#ced4da`) |
+
+The old theme's neutral ramp is `--color-neutral-0..10`; the new token neutrals were rebased, so exact hex matches are rare. Pick the nearest ramp step and say so in the README log.
+
+**No fallback chains.** Write a single flat `var()` — the old theme's `:root` block defines
+every one of these names unconditionally, so there is nothing to fall back *to*:
+
+```css
+/* right */  border:var(--border-size-s) solid var(--color-neutral-4);
+/* wrong */  border:var(--border-size-s) solid var(--border-color-neutral-4, var(--color-neutral-4));
+/* wrong */  border:var(--border-size-s) solid var(--token-border-subtle, #e6eaee);
+```
+
+The two-step chain is a *new-theme* mechanic: `$token-*` expands to `var(--token-*, <literal>)`
+so the bundle still renders when the generated `:root` layer is absent. The old theme has no
+generated layer and no token tier — the chain buys nothing and just makes the port
+non-obvious to read.
+
+You **will** see `var(--border-color-neutral-4, var(--color-neutral-4))` chains throughout the
+existing snapshot content. Those come from the old `get-border-color()` / `get-background-color()`
+helper functions (`.claude/rules/scss.md` §4) — a per-component semantic-override layer that
+predates and is unrelated to token fallbacks. It is deprecated; **don't reproduce it in a port.**
+Leave the existing occurrences alone.
+
+### Typography / shadow
+
+`--font-size-{h1..h6,display,base,s,xs,label}`, `--font-{light,regular,semi-bold,bold}`, `--shadow-{none,xs,s,m,l,xl}`. Map `$token-elevation-1..4` onto `--shadow-s`/`--shadow-m`/`--shadow-l`/`--shadow-xl` — the elevation tokens are two-layer shadows with no old equivalent, so this is a deliberate approximation. Log it.
+
+### Layout plumbing — names differ, not just values
+
+| new theme | old theme |
+|-----------|-----------|
+| `--size-side-menu` | `--side-menu-size` |
+| `--size-header` | `--header-size` |
+| `--size-bottom-bar` | `--bottom-bar-size` |
+| `--layer-global-*`, `--layer-local-tier-*`, `--os-safe-area-*` | same names, no change |
+
+This one bites: the `--size-*` / `*-size` flip is a rename, so a copy-paste port silently produces a dead `var()`.
+
+## 4. The `--osui-*` component API layer — keep it
+
+The deprecated snapshot already contains ~40 `--osui-*` custom properties (`--osui-balloon-shape`, `--osui-dropdown-min-width`, …) — the pattern-scoped-variable convention predates the token migration. So **keep the component CSS API structure** when porting; only the *defaults* get de-tokenised:
+
+```css
+/* new theme, compiled */
+.layout.layout-side-no-header{
+  --osui-layout-main-padding:var(--token-space-1000, var(--token-scale-1000, 40px));
+}
+/* deprecated port */
+.layout.layout-side-no-header{
+  --osui-layout-main-padding:var(--space-xl);
+}
+```
+
+Do not flatten the var away — a reviewer comparing the two themes in Storybook should see the same override surface on both.
+
+## 5. Formatting — match the compiled output exactly
+
+These files were produced by dart-sass (compressed-ish `expanded` style) plus autoprefixer. Match it or the diff becomes unreadable:
+
+- Two-space indent, one declaration per line.
+- `{` sits directly against the selector, **no space**: `.foo{`
+- **No space after `:`**: `padding:var(--space-xl);`
+- `}` alone on its own line, no blank lines between rules.
+- Comma-separated selectors: nested-`&` groups collapse onto one line (`.a .b, .a .c,`), distinct top-level selectors go on their own line. Copy the shape of the neighbouring rules.
+- **Autoprefixer still applies.** Flexbox, `box-orient`, `transform`, `appearance`, gradients etc. need the `-webkit-`/`-ms-` prefixes the rest of the file carries. Logical properties (`border-inline-end`, `margin-block-start`) and custom properties pass through unprefixed — confirmed against the existing content.
+
+## 6. Procedure
+
+1. **Read the source change.** `git show <commit> -- 'src/**/*.scss'`, or `git diff`.
+2. **Compile the new-theme SCSS in isolation** to see exactly what CSS the change produces, including selector nesting and ordering:
+   ```bash
+   npx sass --load-path=. src/scss/02-layout/_layout.scss | grep -B2 -A10 '<your-selector>'
+   ```
+   This is the shape you are porting — never hand-derive it from the SCSS.
+3. **De-tokenise** each value using §3.
+4. **Find the insertion anchor** — the compiled new theme's immediately-preceding rule, located in the deprecated file so the ported block lands in the same relative position:
+   ```bash
+   grep -n 'layout.layout-side.aside-overlay .main' deprecated/*.css
+   ```
+   Anchor on a **unique, multi-line, exact** string (selector + body). Assert `count == 1` before replacing.
+5. **Patch both files** with one script, asserting anchor uniqueness and that the new selector is not already present:
+   ```python
+   for p in ('deprecated/O11.OutSystemsUI.css', 'deprecated/ODC.OutSystemsUI.css'):
+       s = open(p, encoding='utf-8').read()
+       assert '<new-selector>' not in s, p
+       assert s.count(ANCHOR) == 1, p
+       open(p, 'w', encoding='utf-8').write(s.replace(ANCHOR, ANCHOR + BLOCK))
+   ```
+   Prefer this over `sed` — these are 780 KB single-purpose files and a mis-anchored global substitution is hard to spot.
+6. **Log it** in `deprecated/README.md` under **Hand-applied ports**: date, source commit/ticket, selectors added, and every approximation you had to make.
+7. **Verify** (§8).
+
+## 7. Check the source before porting it
+
+Porting is the first time anyone reads the new SCSS closely, so it catches source bugs. Two that this repo's shape makes easy to ship:
+
+- **Un-interpolated `$token-*` inside a custom property.** SCSS does not evaluate a variable in a custom-property *value* — it emits the text verbatim. `--osui-x: variables.$token-space-1000;` compiles to the literal string `variables.$token-space-1000` and silently produces invalid CSS. It must be `--osui-x: #{variables.$token-space-1000};` (`.claude/rules/scss.md` §2/§3).
+- **A non-existent token, hidden by that same non-evaluation.** Because the value is never evaluated, a typo'd token name raises **no** compile error. Confirm every token you touch exists: `grep -n '^\$token-border-size' src/scss/tokens/_variables.scss`.
+
+Fix the source first, recompile, then port the corrected output. Tell the user what you fixed.
+
+## 8. Verification checklist
+
+```bash
+grep -c -- '--token-' deprecated/*.css                 # 0, both files
+grep -c '<new-selector>' deprecated/*.css              # identical count, both files
+grep -o -- '--osui-<component>-[a-z-]*' deprecated/*.css | sort | uniq -c   # same vars, same counts
+git diff --stat deprecated/                            # identical insertion count per file
+git diff deprecated/O11.OutSystemsUI.css               # read it; formatting must be indistinguishable
+```
+
+Then, for anything visual: `npm run storybook`, flip the **Theme** toolbar to *Deprecated theme*, and confirm the ported rule takes effect. Also grep that every selector the ported block targets actually exists in the old theme — the old markup contract may differ:
+
+```bash
+grep -n 'app-menu-content\|app-login-info\|main-content' deprecated/ODC.OutSystemsUI.css | head
+```
+
+A ported rule targeting a class the old theme never emits is dead CSS; say so rather than shipping it silently.
+
+## 9. What not to do
+
+- Don't hand-edit `src/scss/O11.OutSystemsUI.scss` / `ODC.OutSystemsUI.scss` (regenerated every build) — unrelated files, easy to confuse by name with the `deprecated/` ones.
+- Don't rebuild the snapshot to apply a port. A refresh from `dev` wipes every prior hand-applied port.
+- Don't reformat, minify, or run Prettier over `deprecated/*.css`. They are byte-comparable artefacts; a reformat destroys that.
+- Don't write **any** `var()` fallback chain — not a token one (`var(--token-space-1000, var(--space-xl))`), not an old semantic-override one (`var(--border-color-neutral-4, var(--color-neutral-4))`). One flat `var(--old-name)` per value (§3).
+- Don't port to only one platform bundle.

--- a/deprecated/O11.OutSystemsUI.css
+++ b/deprecated/O11.OutSystemsUI.css
@@ -973,6 +973,9 @@ body,
 .layout.layout-side-no-header .app-menu-content{
   border-inline-end:var(--osui-layout-aside-lines);
 }
+.layout.layout-side-no-header .app-menu-links{
+  gap:var(--space-s);
+}
 .layout.layout-side-no-header .app-login-info{
   border-block-start:var(--osui-layout-aside-lines);
 }

--- a/deprecated/O11.OutSystemsUI.css
+++ b/deprecated/O11.OutSystemsUI.css
@@ -963,6 +963,22 @@ body,
 .layout.layout-side.aside-overlay .main{
   margin-left:0;
 }
+.layout.layout-side-no-header{
+  --osui-layout-main-padding:var(--space-xl);
+  --osui-layout-aside-lines:var(--border-size-s) solid var(--color-neutral-4);
+}
+.layout.layout-side-no-header .main-content{
+  padding:var(--osui-layout-main-padding);
+}
+.layout.layout-side-no-header .app-menu-content{
+  border-inline-end:var(--osui-layout-aside-lines);
+}
+.layout.layout-side-no-header .app-login-info{
+  border-block-start:var(--osui-layout-aside-lines);
+}
+.layout.layout-side-no-header .menu-icon{
+  margin:var(--space-base) var(--space-m);
+}
 .layout.layout-native{
   -servicestudio-min-height:100vh !important;
 }
@@ -1025,6 +1041,10 @@ body,
 .tablet .layout-side .main,
 .phone .layout-side .main{
   margin-left:0;
+}
+.tablet .layout-side-no-header,
+.phone .layout-side-no-header{
+  --osui-layout-main-padding:0 var(--space-m) var(--space-m);
 }
 .phone .layout:not(.layout-native) [class*=ThemeGrid_Width]:not(.no-responsive){
   margin:var(--space-none) var(--space-none) var(--space-base) var(--space-none);

--- a/deprecated/ODC.OutSystemsUI.css
+++ b/deprecated/ODC.OutSystemsUI.css
@@ -1176,6 +1176,22 @@ body,
 .layout.layout-side.aside-overlay .main{
   margin-left:0;
 }
+.layout.layout-side-no-header{
+  --osui-layout-main-padding:var(--space-xl);
+  --osui-layout-aside-lines:var(--border-size-s) solid var(--color-neutral-4);
+}
+.layout.layout-side-no-header .main-content{
+  padding:var(--osui-layout-main-padding);
+}
+.layout.layout-side-no-header .app-menu-content{
+  border-inline-end:var(--osui-layout-aside-lines);
+}
+.layout.layout-side-no-header .app-login-info{
+  border-block-start:var(--osui-layout-aside-lines);
+}
+.layout.layout-side-no-header .menu-icon{
+  margin:var(--space-base) var(--space-m);
+}
 .layout.layout-native{
   -servicestudio-min-height:100vh !important;
 }
@@ -1238,6 +1254,10 @@ body,
 .tablet .layout-side .main,
 .phone .layout-side .main{
   margin-left:0;
+}
+.tablet .layout-side-no-header,
+.phone .layout-side-no-header{
+  --osui-layout-main-padding:0 var(--space-m) var(--space-m);
 }
 .phone .layout:not(.layout-native) [class*=ThemeGrid_Width]:not(.no-responsive){
   margin:var(--space-none) var(--space-none) var(--space-base) var(--space-none);

--- a/deprecated/ODC.OutSystemsUI.css
+++ b/deprecated/ODC.OutSystemsUI.css
@@ -1186,6 +1186,9 @@ body,
 .layout.layout-side-no-header .app-menu-content{
   border-inline-end:var(--osui-layout-aside-lines);
 }
+.layout.layout-side-no-header .app-menu-links{
+  gap:var(--space-s);
+}
 .layout.layout-side-no-header .app-login-info{
   border-block-start:var(--osui-layout-aside-lines);
 }

--- a/deprecated/README.md
+++ b/deprecated/README.md
@@ -21,3 +21,6 @@ Procedure: `/port-to-deprecated` (see `.claude/skills/osui-deprecated-theme/SKIL
   `$token-border-size-025` (1px) → `--border-size-s`.
   Approximations: `$token-border-subtle` (#e6eaee) → `var(--color-neutral-4)` (#dee2e6) —
   nearest step on the old neutral ramp, which was rebased by the token migration.
+- **2026-08-27 — ROU-12992 (working tree)** — added
+  `.layout.layout-side-no-header .app-menu-links{gap}` in both bundles.
+  Mapping: `$token-space-200` (8px) → `--space-s`. Approximations: none (exact match).

--- a/deprecated/README.md
+++ b/deprecated/README.md
@@ -5,3 +5,19 @@ Storybook for the "Theme" toolbar toggle).
 Snapshot provenance: built from `dev` @ d52518b15 (ROU-12946, v2.30.0, 2026-08-11)
 — the last dev state merged into the token-migration branch (ROU-12955 merge).
 Refresh by building `dev` (`npm run build`) and copying dist/*.OutSystemsUI.css here.
+
+## Hand-applied ports
+
+Changes back-ported from the new (token) theme by hand, de-tokenised onto the old
+vocabulary. **A snapshot refresh wipes these** — replay every entry after rebuilding.
+Procedure: `/port-to-deprecated` (see `.claude/skills/osui-deprecated-theme/SKILL.md`).
+
+- **2026-08-27 — ROU-12992 / 6ce34d903 "add new layout rules"** — added
+  `.layout.layout-side-no-header` (+ `.main-content`, `.app-menu-content`,
+  `.app-login-info`, `.menu-icon` children) and the `.tablet` / `.phone`
+  `--osui-layout-main-padding` override, in both bundles.
+  Mapping: `$token-space-1000` (40px) → `--space-xl`; `$token-space-600` (24px) →
+  `--space-m`; `$token-space-400` (16px) → `--space-base`;
+  `$token-border-size-025` (1px) → `--border-size-s`.
+  Approximations: `$token-border-subtle` (#e6eaee) → `var(--color-neutral-4)` (#dee2e6) —
+  nearest step on the old neutral ramp, which was rebased by the token migration.

--- a/src/scss/02-layout/_layout.scss
+++ b/src/scss/02-layout/_layout.scss
@@ -50,8 +50,8 @@ body,
 
 		&-side-no-header {
 			// ─── Component CSS API ─────────────────────────────────────────────
-			--osui-layout-main-padding: variables.$token-space-1000;
-			--osui-layout-aside-lines: variables.$token-border-size-100 solid variables.$token-border-subtle;
+			--osui-layout-main-padding: #{variables.$token-space-1000};
+			--osui-layout-aside-lines: #{variables.$token-border-size-025} solid #{variables.$token-border-subtle};
 			// ───────────────────────────────────────────────────────────────────
 
 			.main-content {
@@ -203,7 +203,7 @@ body,
 	}
 
 	.layout-side-no-header {
-		--osui-layout-main-padding: 0 variables.$token-space-600 variables.$token-space-600;
+		--osui-layout-main-padding: 0 #{variables.$token-space-600} #{variables.$token-space-600};
 	}
 }
 

--- a/src/scss/02-layout/_layout.scss
+++ b/src/scss/02-layout/_layout.scss
@@ -62,6 +62,10 @@ body,
 				border-inline-end: var(--osui-layout-aside-lines);
 			}
 
+			.app-menu-links {
+				gap: variables.$token-space-200;
+			}
+
 			.app-login-info {
 				border-block-start: var(--osui-layout-aside-lines);
 			}

--- a/src/scss/02-layout/_layout.scss
+++ b/src/scss/02-layout/_layout.scss
@@ -48,6 +48,29 @@ body,
 			}
 		}
 
+		&-side-no-header {
+			// ─── Component CSS API ─────────────────────────────────────────────
+			--osui-layout-main-padding: variables.$token-space-1000;
+			--osui-layout-aside-lines: variables.$token-border-size-100 solid variables.$token-border-subtle;
+			// ───────────────────────────────────────────────────────────────────
+
+			.main-content {
+				padding: var(--osui-layout-main-padding);
+			}
+
+			.app-menu-content {
+				border-inline-end: var(--osui-layout-aside-lines);
+			}
+
+			.app-login-info {
+				border-block-start: var(--osui-layout-aside-lines);
+			}
+
+			.menu-icon {
+				margin: variables.$token-space-400 variables.$token-space-600;
+			}
+		}
+
 		&-native {
 			// Service Studio Preview
 			& {
@@ -177,6 +200,10 @@ body,
 .phone {
 	.layout-side .main {
 		margin-left: 0;
+	}
+
+	.layout-side-no-header {
+		--osui-layout-main-padding: 0 variables.$token-space-600 variables.$token-space-600;
 	}
 }
 


### PR DESCRIPTION
This pull request introduces a new layout variant called `.layout-side-no-header` to both the new token-based theme (`src/scss/02-layout/_layout.scss`) and the deprecated pre-token theme CSS snapshots (`deprecated/O11.OutSystemsUI.css`, `deprecated/ODC.OutSystemsUI.css`). It also documents the porting process and mappings used, ensuring consistency across themes and providing guidance for future ports.

**Key changes:**

### New layout rules and implementation

* Added `.layout-side-no-header` and its child selectors (`.main-content`, `.app-menu-content`, `.app-login-info`, `.menu-icon`) to the SCSS source, using token variables for spacing, border size, and color.
* Introduced responsive overrides for `.tablet` and `.phone` variants of `.layout-side-no-header`, adjusting `--osui-layout-main-padding` accordingly.

### Port to deprecated theme

* Backported the new `.layout-side-no-header` rules to both `deprecated/O11.OutSystemsUI.css` and `deprecated/ODC.OutSystemsUI.css`, de-tokenising values to legacy variables and matching compiled formatting. [[1]](diffhunk://#diff-ca7082578d8edb2110eddd94a86d0384f71fb809f46aca21bd1ab427d89926d9R966-R981) [[2]](diffhunk://#diff-ca7082578d8edb2110eddd94a86d0384f71fb809f46aca21bd1ab427d89926d9R1045-R1048) [[3]](diffhunk://#diff-983984bedff68a9e71836b3d2774a0a81d3edecf100722a87dac525cdbb280a4R1179-R1194) [[4]](diffhunk://#diff-983984bedff68a9e71836b3d2774a0a81d3edecf100722a87dac525cdbb280a4R1258-R1261)
* Logged the port in `deprecated/README.md` under a new **Hand-applied ports** section, detailing selectors added, token-to-legacy mapping, and any approximations made (e.g., color mapping for `$token-border-subtle`).

### Process documentation

* Added `.claude/skills/osui-deprecated-theme/SKILL.md`, a comprehensive skill guide describing the porting rationale, mapping tables, formatting requirements, verification steps, and common pitfalls for maintaining the deprecated theme.
* Added a command description in `.claude/commands/port-to-deprecated.md` to standardize and automate the porting workflow.

### Checklist

-   [ ] tested locally
-   [ ] documented the code
-   [ ] clean all warnings and errors of eslint
-   [ ] requires changes in OutSystems (if so, provide a module with changes)
-   [ ] requires new sample page in OutSystems (if so, provide a module with changes)
