### PR TITLE
ROU-12926: Fix release workflow to create PR instead of direct merge

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -25,6 +25,7 @@ jobs:
         permissions:
             id-token: write
             contents: write
+            pull-requests: write
         #uses: OutSystems/ui-components.github-reusable-workflows/.github/workflows/release.yaml@7ffd7f90f6e5016bd92d0e050d2516084b99c2f6 #v0.2.5
         uses: ./.github/workflows/template-release.yaml
         with:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -11,10 +11,6 @@ on:
                 description: 'Update pre-release into latest.'
                 type: boolean
                 default: true
-            delete-rc-branch:
-                description: 'Delete rc* branch at the end of process.'
-                type: boolean
-                default: true
 
 permissions:
     contents: read
@@ -31,7 +27,6 @@ jobs:
         with:
             new-version: ${{ inputs.new-version }}
             update-prerelease-into-latest: ${{ inputs.update-prerelease-into-latest }}
-            delete-rc-branch: ${{ inputs.delete-rc-branch }}
         secrets:
             OSUI_AZURE_CLIENT_ID: ${{ secrets.OSUI_AZURE_CLIENT_ID }}
             OSUI_AZURE_TENANT_ID: ${{ secrets.OSUI_AZURE_TENANT_ID }}

--- a/.github/workflows/template-release.yaml
+++ b/.github/workflows/template-release.yaml
@@ -83,6 +83,7 @@ jobs:
         permissions:
             id-token: write
             contents: read
+            pull-requests: write
 
         if: ${{ inputs.new-version }}
         steps:
@@ -104,16 +105,59 @@ jobs:
               with:
                   key-name: o11odc-github-gitpersonal-token-prd
 
-            - name: 🔄 Merge rc${{ inputs.new-version }} into main
+            - name: 🔄 Create release PR and auto-merge rc${{ inputs.new-version }} into main
               env:
                   GH_TOKEN: ${{ steps.get-github-token.outputs.az-keyvault-value }}
               run: |
-                  gh api \
-                    --method POST \
-                    "repos/${{ github.repository }}/merges" \
-                    -f base=main \
-                    -f head=rc${{ inputs.new-version }} \
-                    -f commit_message="Merged rc${{ inputs.new-version }} into main. [skip ci]"
+                  SOURCE_BRANCH="rc${{ inputs.new-version }}"
+                  PR_TITLE="Merge ${SOURCE_BRANCH} into main [skip ci]"
+
+                  COMPARE_STATUS=$(gh api \
+                    "repos/${{ github.repository }}/compare/main...${SOURCE_BRANCH}" \
+                    --jq -r '.status')
+
+                  if [ "${COMPARE_STATUS}" = "identical" ] || [ "${COMPARE_STATUS}" = "behind" ]; then
+                    echo "${SOURCE_BRANCH} is already merged into main."
+                    exit 0
+                  fi
+
+                  if ! gh pr view "${SOURCE_BRANCH}" --json number --jq .number >/dev/null 2>&1; then
+                    gh pr create \
+                      --base main \
+                      --head "${SOURCE_BRANCH}" \
+                      --title "${PR_TITLE}" \
+                      --body "$(cat <<EOF
+                  This PR merges ${SOURCE_BRANCH} into main.
+
+                  This PR was automatically created by the Release workflow.
+                  Auto-merge is enabled after required checks pass.
+                  EOF
+                  )"
+                  fi
+
+                  PR_NUMBER=$(gh pr view "${SOURCE_BRANCH}" --json number --jq .number)
+                  PR_STATE=$(gh pr view "${SOURCE_BRANCH}" --json state --jq -r '.state')
+
+                  if [ "${PR_STATE}" = "MERGED" ]; then
+                    echo "Pull request #${PR_NUMBER} is already merged."
+                    exit 0
+                  fi
+
+                  echo "Release PR: https://github.com/${{ github.repository }}/pull/${PR_NUMBER}"
+                  gh pr merge "${PR_NUMBER}" --auto --merge
+
+                  for attempt in $(seq 1 60); do
+                    STATE=$(gh pr view "${PR_NUMBER}" --json state --jq -r '.state')
+                    if [ "${STATE}" = "MERGED" ]; then
+                      echo "Pull request #${PR_NUMBER} merged."
+                      exit 0
+                    fi
+                    echo "Waiting for required checks and auto-merge (${attempt}/60)..."
+                    sleep 30
+                  done
+
+                  echo "::error::Timed out waiting for pull request #${PR_NUMBER} to auto-merge."
+                  exit 1
 
     set-pre-release-as-lts:
         name: Set pre-release as LTS

--- a/.github/workflows/template-release.yaml
+++ b/.github/workflows/template-release.yaml
@@ -82,6 +82,9 @@ jobs:
 
         if: ${{ inputs.new-version }}
         steps:
+            - name: 📥 Checkout repository
+              uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
             - name: 🔐 Azure login
               #uses: OutSystems/rd.github-reusable-workflows/.github/actions/az-login@9d497d1c5bc6e355aa8f4663539e6b75c212f6b4 #v2.0.7
               uses: ./.github/actions/az-login
@@ -143,6 +146,9 @@ jobs:
             contents: read
 
         steps:
+            - name: 📥 Checkout repository
+              uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
             - name: 🔐 Azure login
               #uses: OutSystems/rd.github-reusable-workflows/.github/actions/az-login@9d497d1c5bc6e355aa8f4663539e6b75c212f6b4 #v2.0.7
               uses: ./.github/actions/az-login

--- a/.github/workflows/template-release.yaml
+++ b/.github/workflows/template-release.yaml
@@ -105,59 +105,47 @@ jobs:
               with:
                   key-name: o11odc-github-gitpersonal-token-prd
 
-            - name: 🔄 Create release PR and auto-merge rc${{ inputs.new-version }} into main
+            - name: 🔄 Create release PR for rc${{ inputs.new-version }} into main
               env:
                   GH_TOKEN: ${{ steps.get-github-token.outputs.az-keyvault-value }}
               run: |
                   SOURCE_BRANCH="rc${{ inputs.new-version }}"
-                  PR_TITLE="Merge ${SOURCE_BRANCH} into main [skip ci]"
+                  BASE_BRANCH="main"
+                  PR_TITLE="Merge ${SOURCE_BRANCH} into ${BASE_BRANCH} [skip ci]"
 
                   COMPARE_STATUS=$(gh api \
-                    "repos/${{ github.repository }}/compare/main...${SOURCE_BRANCH}" \
-                    --jq -r '.status')
+                    "repos/${{ github.repository }}/compare/${BASE_BRANCH}...${SOURCE_BRANCH}" \
+                    --template '{{.status}}')
 
                   if [ "${COMPARE_STATUS}" = "identical" ] || [ "${COMPARE_STATUS}" = "behind" ]; then
-                    echo "${SOURCE_BRANCH} is already merged into main."
+                    echo "${SOURCE_BRANCH} is already merged into ${BASE_BRANCH}."
                     exit 0
                   fi
 
-                  if ! gh pr view "${SOURCE_BRANCH}" --json number --jq .number >/dev/null 2>&1; then
-                    gh pr create \
-                      --base main \
+                  PR_NUMBER=$(gh pr list \
+                    --head "${SOURCE_BRANCH}" \
+                    --base "${BASE_BRANCH}" \
+                    --state open \
+                    --limit 1 \
+                    --json number \
+                    --jq '.[0].number // empty')
+
+                  if [ -z "${PR_NUMBER}" ]; then
+                    PR_NUMBER=$(gh pr create \
+                      --base "${BASE_BRANCH}" \
                       --head "${SOURCE_BRANCH}" \
                       --title "${PR_TITLE}" \
                       --body "$(cat <<EOF
-                  This PR merges ${SOURCE_BRANCH} into main.
+                  This PR merges ${SOURCE_BRANCH} into ${BASE_BRANCH}.
 
                   This PR was automatically created by the Release workflow.
-                  Auto-merge is enabled after required checks pass.
                   EOF
-                  )"
-                  fi
-
-                  PR_NUMBER=$(gh pr view "${SOURCE_BRANCH}" --json number --jq .number)
-                  PR_STATE=$(gh pr view "${SOURCE_BRANCH}" --json state --jq -r '.state')
-
-                  if [ "${PR_STATE}" = "MERGED" ]; then
-                    echo "Pull request #${PR_NUMBER} is already merged."
-                    exit 0
+                  )" \
+                      --json number \
+                      --jq .number)
                   fi
 
                   echo "Release PR: https://github.com/${{ github.repository }}/pull/${PR_NUMBER}"
-                  gh pr merge "${PR_NUMBER}" --auto --merge
-
-                  for attempt in $(seq 1 60); do
-                    STATE=$(gh pr view "${PR_NUMBER}" --json state --jq -r '.state')
-                    if [ "${STATE}" = "MERGED" ]; then
-                      echo "Pull request #${PR_NUMBER} merged."
-                      exit 0
-                    fi
-                    echo "Waiting for required checks and auto-merge (${attempt}/60)..."
-                    sleep 30
-                  done
-
-                  echo "::error::Timed out waiting for pull request #${PR_NUMBER} to auto-merge."
-                  exit 1
 
     set-pre-release-as-lts:
         name: Set pre-release as LTS

--- a/.github/workflows/template-release.yaml
+++ b/.github/workflows/template-release.yaml
@@ -105,12 +105,15 @@ jobs:
                   key-name: o11odc-github-gitpersonal-token-prd
 
             - name: 🔄 Merge rc${{ inputs.new-version }} into main
-              uses: everlytic/branch-merge@c4a244dc23143f824ae6c022a10732566cb8e973 #v1.1.5
-              with:
-                  github_token: ${{ steps.get-github-token.outputs.az-keyvault-value }}
-                  source_ref: rc${{ inputs.new-version }}
-                  target_branch: 'main'
-                  commit_message_template: 'Merged rc${{ inputs.new-version }} into main. [skip ci]'
+              env:
+                  GH_TOKEN: ${{ steps.get-github-token.outputs.az-keyvault-value }}
+              run: |
+                  gh api \
+                    --method POST \
+                    "repos/${{ github.repository }}/merges" \
+                    -f base=main \
+                    -f head=rc${{ inputs.new-version }} \
+                    -f commit_message="Merged rc${{ inputs.new-version }} into main. [skip ci]"
 
     set-pre-release-as-lts:
         name: Set pre-release as LTS

--- a/.github/workflows/template-release.yaml
+++ b/.github/workflows/template-release.yaml
@@ -166,4 +166,3 @@ jobs:
                   prerelease: false
                   token: ${{ steps.get-github-token.outputs.az-keyvault-value }}
                   make_latest: true
-                  token: ${{ steps.get-github-token.outputs.az-keyvault-value }}

--- a/.github/workflows/template-release.yaml
+++ b/.github/workflows/template-release.yaml
@@ -19,7 +19,6 @@
 #         with:
 #             new-version: ${{ inputs.new-version }}
 #             update-prerelease-into-latest: true
-#             delete-rc-branch: true
 #
 # ======================================================================
 #
@@ -34,10 +33,6 @@ on:
                 required: true
             update-prerelease-into-latest:
                 description: 'Update pre-release into latest.'
-                type: boolean
-                default: true
-            delete-rc-branch:
-                description: 'Delete rc* branch at the end of process.'
                 type: boolean
                 default: true
         secrets:
@@ -66,7 +61,7 @@ jobs:
                   ref: rc${{ inputs.new-version }}
 
             - name: 📦 Setup Node
-              uses: actions/setup-node@2028fbc5c25fe9cf00d9f06a71cc4710d4507903 # v6.0.0
+              uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
               with:
                   node-version: 24
 
@@ -87,9 +82,6 @@ jobs:
 
         if: ${{ inputs.new-version }}
         steps:
-            - name: 📥 Checkout repository
-              uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-
             - name: 🔐 Azure login
               #uses: OutSystems/rd.github-reusable-workflows/.github/actions/az-login@9d497d1c5bc6e355aa8f4663539e6b75c212f6b4 #v2.0.7
               uses: ./.github/actions/az-login
@@ -135,12 +127,7 @@ jobs:
                       --base "${BASE_BRANCH}" \
                       --head "${SOURCE_BRANCH}" \
                       --title "${PR_TITLE}" \
-                      --body "$(cat <<EOF
-                  This PR merges ${SOURCE_BRANCH} into ${BASE_BRANCH}.
-
-                  This PR was automatically created by the Release workflow.
-                  EOF
-                  )" \
+                      --body "$(printf 'This PR merges %s into %s.\n\nThis PR was automatically created by the Release workflow.\n' "${SOURCE_BRANCH}" "${BASE_BRANCH}")" \
                       --json number \
                       --jq .number)
                   fi
@@ -156,9 +143,6 @@ jobs:
             contents: read
 
         steps:
-            - name: 📥 Checkout repository
-              uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-
             - name: 🔐 Azure login
               #uses: OutSystems/rd.github-reusable-workflows/.github/actions/az-login@9d497d1c5bc6e355aa8f4663539e6b75c212f6b4 #v2.0.7
               uses: ./.github/actions/az-login
@@ -182,22 +166,4 @@ jobs:
                   prerelease: false
                   token: ${{ steps.get-github-token.outputs.az-keyvault-value }}
                   make_latest: true
-
-    delete-rc-branch:
-        name: Delete rc branch
-        needs: merge-rc-into-main
-        runs-on: ubuntu-latest
-        permissions:
-            contents: write
-
-        if: ${{ inputs.delete-rc-branch == true }}
-        steps:
-            - name: 📥 Checkout branch dev
-              uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-              with:
-                  ref: dev
-
-            - name: 🗑️ Delete branch rc${{ inputs.new-version }}
-              shell: bash
-              run: |
-                  git push origin -d rc${{ inputs.new-version }}
+                  token: ${{ steps.get-github-token.outputs.az-keyvault-value }}

--- a/.github/workflows/template-release.yaml
+++ b/.github/workflows/template-release.yaml
@@ -82,6 +82,9 @@ jobs:
 
         if: ${{ inputs.new-version }}
         steps:
+            - name: 📥 Checkout repository
+              uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
             - name: 🔐 Azure login
               #uses: OutSystems/rd.github-reusable-workflows/.github/actions/az-login@9d497d1c5bc6e355aa8f4663539e6b75c212f6b4 #v2.0.7
               uses: ./.github/actions/az-login
@@ -143,6 +146,9 @@ jobs:
             contents: read
 
         steps:
+            - name: 📥 Checkout into main
+              uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
             - name: 🔐 Azure login
               #uses: OutSystems/rd.github-reusable-workflows/.github/actions/az-login@9d497d1c5bc6e355aa8f4663539e6b75c212f6b4 #v2.0.7
               uses: ./.github/actions/az-login


### PR DESCRIPTION
This PR is for fixing the release workflow so it creates a pull request from the rc branch into main instead of merging directly, and removes obsolete Everlytic and rc-branch deletion steps.

### What was happening
* The release workflow merged the rc branch into main directly via the GitHub API, bypassing PR review and branch protection rules.
* The workflow included Everlytic email steps and an automatic rc branch deletion job that are no longer needed.
* A duplicate `token` key in the release action step caused workflow validation to fail.

### What was done
* Replaced the direct merge API call with logic that creates (or reuses) a PR from `rc*` into `main`, skipping when already merged.
* Removed the `delete-rc-branch` input and the corresponding delete job.
* Removed Everlytic-related steps from the release workflow.
* Added `pull-requests: write` permission where required.
* Fixed the duplicate `token` definition in the `softprops/action-gh-release` step.
* Updated `actions/setup-node` to v7.0.0.

### Test Steps
1. Trigger the Release workflow manually via workflow_dispatch with a test version.
2. Confirm the workflow validates without YAML errors.
3. Verify a PR is created from `rc<version>` into `main` when branches differ.
4. Verify no PR is created when the rc branch is already merged into main.
5. Confirm the pre-release tag is updated to latest when `update-prerelease-into-latest` is true.

### Screenshots
(prefer animated gif)

### Checklist
* [ ] tested locally
* [ ] documented the code
* [ ] clean all warnings and errors of eslint
* [ ] requires changes in OutSystems (if so, provide a module with changes)
* [ ] requires new sample page in OutSystems (if so, provide a module with changes)
