### PR TITLE
ROU-13000: Align Button Group widget with Figma

### DIFF
--- a/.cursor/mcp.json
+++ b/.cursor/mcp.json
@@ -1,0 +1,7 @@
+{
+  "mcpServers": {
+    "Figma": {
+      "url": "https://mcp.figma.com/mcp"
+    }
+  }
+}

--- a/src/scss/03-widgets/_button-group.scss
+++ b/src/scss/03-widgets/_button-group.scss
@@ -118,44 +118,6 @@
 	}
 }
 
-/* Button Group when used inside Header Content Placeholder */
-///
-.layout-native {
-	.header-top-content {
-		.button-group {
-			--osui-button-group-container-background: transparent;
-			--osui-button-group-container-padding: #{variables.$token-scale-0};
-			--osui-button-group-container-gap: #{variables.$token-scale-0};
-			--osui-button-group-container-border-radius: #{variables.$token-border-radius-0};
-		}
-
-		.button-group-item {
-			--osui-button-group-background: var(--background-color-header, var(--color-background-header));
-			--osui-button-group-border-color: transparent;
-			--osui-button-group-border-radius: #{variables.$token-border-radius-0};
-			--osui-button-group-border-width: #{variables.$token-border-size-0};
-			--osui-button-group-color: var(--color-text-subtlest);
-			--osui-button-group-selected-background: var(--background-color-header, var(--color-background-header));
-			--osui-button-group-selected-border-color: transparent;
-
-			border-bottom: variables.$token-border-size-050 solid transparent;
-
-			&.button-group-selected-item {
-				border-bottom-color: variables.$token-semantics-primary-base;
-				color: var(--color-text);
-			}
-
-			&[disabled] {
-				color: var(--color-text-disabled);
-
-				&.button-group-selected-item {
-					border-bottom-color: var(--color-text-disabled);
-				}
-			}
-		}
-	}
-}
-
 // Accessinility -----------------------------------------------------------------
 ///
 .has-accessible-features {

--- a/src/scss/03-widgets/_button-group.scss
+++ b/src/scss/03-widgets/_button-group.scss
@@ -4,66 +4,90 @@
 ////
 /// @group Widgets-Button_Group
 /// Widgets - Button Group
+/// v3.0.0 — pill items on a neutral subtle track (Figma node 20015249:20).
 
 ///
 .button-group {
-	background-color: transparent;
-	border-radius: 0;
-	padding: variables.$token-scale-200 variables.$token-scale-0;
+	// ─── Component CSS API (container) ─────────────────────────────────
+	--osui-button-group-container-background: #{variables.$token-bg-neutral-subtle-default};
+	--osui-button-group-container-padding: #{variables.$token-scale-100};
+	--osui-button-group-container-gap: #{variables.$token-scale-200};
+	--osui-button-group-container-border-radius: #{variables.$token-border-radius-200};
+	// ───────────────────────────────────────────────────────────────────
+
+	background-color: var(--osui-button-group-container-background);
+	border-radius: var(--osui-button-group-container-border-radius);
+	display: inline-block;
+	padding: var(--osui-button-group-container-padding);
+
+	// Platform baseline sets display:flex on this wrapper; gap belongs here.
+	> div {
+		display: flex;
+		gap: var(--osui-button-group-container-gap);
+	}
 
 	&-item {
-		// ─── Component CSS API ─────────────────────────────────────────────
-		--osui-button-group-background: var(--color-background-surface);
-		--osui-button-group-border-color: var(--color-border);
+		// ─── Component CSS API (item) ──────────────────────────────────────
+		--osui-button-group-background: transparent;
+		--osui-button-group-border-color: transparent;
+		--osui-button-group-border-width: #{variables.$token-border-size-025};
 		--osui-button-group-color: var(--color-text-subtle);
+		--osui-button-group-border-radius: #{variables.$token-border-radius-200};
+		--osui-button-group-font-size: #{variables.$token-font-size-300};
+		--osui-button-group-height: #{variables.$token-scale-800};
+		--osui-button-group-min-width: #{variables.$token-scale-1200};
+		--osui-button-group-padding-inline: #{variables.$token-scale-200};
+		--osui-button-group-selected-background: #{variables.$token-bg-neutral-subtlest-default};
+		--osui-button-group-selected-border-color: #{variables.$token-border-default};
+		--osui-button-group-selected-color: var(--color-text-subtle);
+		// Hover — Figma bg/neutral/subtlest/press; same for selected and unselected
+		--osui-button-group-hover-background: #{variables.$token-bg-neutral-subtlest-press};
+		--osui-button-group-disabled-color: #{variables.$token-text-disabled};
 		--osui-button-group-disabled-overlay: #{variables.$token-state-disabled};
-		// Matches the default .btn height so a button group sits flush with
-		// buttons placed alongside it, while still growing with larger font
-		// sizes and accessibility settings
-		--osui-button-group-min-height: #{variables.$token-scale-1000};
 		// ───────────────────────────────────────────────────────────────────
 
+		align-items: center;
 		background-color: var(--osui-button-group-background);
-		border: variables.$token-border-size-025 solid var(--osui-button-group-border-color);
-		border-radius: 0;
+		border: var(--osui-button-group-border-width) solid var(--osui-button-group-border-color);
+		border-radius: var(--osui-button-group-border-radius);
 		color: var(--osui-button-group-color);
 		cursor: pointer;
-		font-size: variables.$token-font-size-400;
+		display: inline-flex;
+		flex: 1;
+		font-size: var(--osui-button-group-font-size);
 		font-weight: variables.$token-font-weight-medium;
-		min-height: var(--osui-button-group-min-height);
-		padding: variables.$token-scale-0 variables.$token-scale-400;
+		height: var(--osui-button-group-height);
+		justify-content: center;
+		line-height: variables.$token-font-line-height-500;
+		min-width: var(--osui-button-group-min-width);
+		padding: variables.$token-scale-0 var(--osui-button-group-padding-inline);
 		position: relative;
+		transition:
+			background-color variables.$token-transition-time-100 variables.$token-transition-curve-base,
+			border-color variables.$token-transition-time-100 variables.$token-transition-curve-base,
+			color variables.$token-transition-time-100 variables.$token-transition-curve-base;
 		white-space: nowrap;
 
-		&:first-child {
-			border-radius: variables.$token-border-radius-200 variables.$token-border-radius-0 variables.$token-border-radius-0
-				variables.$token-border-radius-200;
+		&.button-group-selected-item {
+			background-color: var(--osui-button-group-selected-background);
+			border-color: var(--osui-button-group-selected-border-color);
+			color: var(--osui-button-group-selected-color);
 		}
 
 		&[disabled] {
 			pointer-events: none;
 
-			&:after {
+			&:not(.button-group-selected-item) {
+				color: var(--osui-button-group-disabled-color);
+			}
+
+			&.button-group-selected-item:after {
 				background-color: var(--osui-button-group-disabled-overlay);
+				border-radius: var(--osui-button-group-border-radius);
 				content: '';
-				inset: 0;
+				inset: -1px;
 				position: absolute;
 			}
-		}
-
-		&[disabled]:not(:first-child),
-		&:not(:first-child) {
-			border-left: variables.$token-border-size-0;
-		}
-
-		&:last-child {
-			border-radius: variables.$token-border-radius-0 variables.$token-border-radius-200 variables.$token-border-radius-200
-				variables.$token-border-radius-0;
-		}
-
-		&.button-group-selected-item {
-			background-color: var(--color-primary);
-			color: var(--color-text-inverse);
 		}
 	}
 
@@ -82,17 +106,14 @@
 ///
 .desktop {
 	.button-group-item {
-		// Neutral (non-selected): matches .btn-cancel:hover — background darkens
-		// one tier, border stays on the resting --color-border role
 		&:not(.button-group-selected-item):not([disabled]):hover {
-			background-color: variables.$token-bg-neutral-subtlest-hover;
-			border-color: var(--color-border);
+			background-color: var(--osui-button-group-hover-background);
+			border-color: transparent;
 		}
 
-		// Selected: darker background + border — same technique as .btn-primary:hover
-		&.button-group-selected-item:hover {
-			background-color: var(--color-primary-hover);
-			border-color: var(--color-primary-hover);
+		&.button-group-selected-item:not([disabled]):hover {
+			background-color: var(--osui-button-group-hover-background);
+			border-color: var(--osui-button-group-selected-border-color);
 		}
 	}
 }
@@ -101,18 +122,26 @@
 ///
 .layout-native {
 	.header-top-content {
-		.button-group-item {
-			background-color: var(--background-color-header, var(--color-background-header));
-			border: 0;
-			border-bottom: variables.$token-border-size-050 solid transparent;
-			color: var(--color-text-subtlest);
+		.button-group {
+			--osui-button-group-container-background: transparent;
+			--osui-button-group-container-padding: #{variables.$token-scale-0};
+			--osui-button-group-container-gap: #{variables.$token-scale-0};
+			--osui-button-group-container-border-radius: #{variables.$token-border-radius-0};
+		}
 
-			&:last-child {
-				border-radius: 0;
-			}
+		.button-group-item {
+			--osui-button-group-background: var(--background-color-header, var(--color-background-header));
+			--osui-button-group-border-color: transparent;
+			--osui-button-group-border-radius: #{variables.$token-border-radius-0};
+			--osui-button-group-border-width: #{variables.$token-border-size-0};
+			--osui-button-group-color: var(--color-text-subtlest);
+			--osui-button-group-selected-background: var(--background-color-header, var(--color-background-header));
+			--osui-button-group-selected-border-color: transparent;
+
+			border-bottom: variables.$token-border-size-050 solid transparent;
 
 			&.button-group-selected-item {
-				border-bottom: variables.$token-border-size-050 solid variables.$token-semantics-primary-base;
+				border-bottom-color: variables.$token-semantics-primary-base;
 				color: var(--color-text);
 			}
 
@@ -120,34 +149,9 @@
 				color: var(--color-text-disabled);
 
 				&.button-group-selected-item {
-					border-bottom: variables.$token-border-size-050 solid var(--color-text-disabled);
+					border-bottom-color: var(--color-text-disabled);
 				}
 			}
-		}
-	}
-}
-
-// IsRTL -------------------------------------------------------------------------
-///
-.is-rtl {
-	.button-group-item {
-		&:first-child {
-			border-radius: variables.$token-border-radius-0 variables.$token-border-radius-200 variables.$token-border-radius-200
-				variables.$token-border-radius-0;
-		}
-
-		&:not(:first-child) {
-			border-left: variables.$token-border-size-025 solid variables.$token-semantics-primary-base;
-			border-right: variables.$token-border-size-0;
-
-			&[disabled] {
-				border-left: variables.$token-border-size-025 solid var(--color-border);
-			}
-		}
-
-		&:last-child {
-			border-radius: variables.$token-border-radius-200 variables.$token-border-radius-0 variables.$token-border-radius-0
-				variables.$token-border-radius-200;
 		}
 	}
 }
@@ -158,8 +162,10 @@
 	.button-group-item {
 		&:focus {
 			box-shadow: none;
+			outline: none;
 
 			&:before {
+				border-radius: var(--osui-button-group-border-radius);
 				bottom: -1px;
 				box-shadow: 0 0 0 variables.$token-border-size-075 var(--color-focus-outer);
 				content: '';
@@ -178,14 +184,15 @@
 .os-high-contrast {
 	.button-group-item {
 		&.button-group-selected-item:before {
+			border: variables.$token-border-size-075 solid variables.$token-semantics-primary-base;
+			border-radius: var(--osui-button-group-border-radius);
+			bottom: 0;
 			content: '';
 			display: block;
-			position: absolute;
-			top: 0;
-			right: 0;
-			bottom: 0;
 			left: 0;
-			border: variables.$token-border-size-075 solid variables.$token-semantics-primary-base;
+			position: absolute;
+			right: 0;
+			top: 0;
 		}
 	}
 }

--- a/stories/CssApiReference.mdx
+++ b/stories/CssApiReference.mdx
@@ -79,11 +79,42 @@ _File: `src/scss/03-widgets/_button-group.scss`_
 
 | Property | Default |
 |---|---|
-| `--osui-button-group-background` | `var(--color-background-surface)` |
-| `--osui-button-group-border-color` | `var(--color-border)` |
+| `--osui-button-group-container-background` | `#{$token-bg-neutral-subtle-default}` |
+| `--osui-button-group-container-padding` | `#{$token-scale-100}` |
+| `--osui-button-group-container-gap` | `#{$token-scale-200}` |
+| `--osui-button-group-container-border-radius` | `#{$token-border-radius-200}` |
+| `--osui-button-group-background` | `transparent` |
+| `--osui-button-group-border-color` | `transparent` |
+| `--osui-button-group-border-width` | `#{$token-border-size-025}` |
 | `--osui-button-group-color` | `var(--color-text-subtle)` |
+| `--osui-button-group-border-radius` | `#{$token-border-radius-200}` |
+| `--osui-button-group-font-size` | `#{$token-font-size-300}` |
+| `--osui-button-group-height` | `#{$token-scale-800}` |
+| `--osui-button-group-min-width` | `#{$token-scale-1200}` |
+| `--osui-button-group-padding-inline` | `#{$token-scale-200}` |
+| `--osui-button-group-selected-background` | `#{$token-bg-neutral-subtlest-default}` |
+| `--osui-button-group-selected-border-color` | `#{$token-border-default}` |
+| `--osui-button-group-selected-color` | `var(--color-text-subtle)` |
+| `--osui-button-group-hover-background` | `#{$token-bg-neutral-subtlest-press}` |
+| `--osui-button-group-disabled-color` | `#{$token-text-disabled}` |
 | `--osui-button-group-disabled-overlay` | `#{$token-state-disabled}` |
-| `--osui-button-group-min-height` | `#{$token-scale-1000}` |
+
+### Button Group (`.layout-native`)
+_File: `src/scss/03-widgets/_button-group.scss`_
+
+| Property | Default |
+|---|---|
+| `--osui-button-group-container-background` | `transparent` |
+| `--osui-button-group-container-padding` | `#{$token-scale-0}` |
+| `--osui-button-group-container-gap` | `#{$token-scale-0}` |
+| `--osui-button-group-container-border-radius` | `#{$token-border-radius-0}` |
+| `--osui-button-group-background` | `var(--background-color-header, var(--color-background-header))` |
+| `--osui-button-group-border-color` | `transparent` |
+| `--osui-button-group-border-radius` | `#{$token-border-radius-0}` |
+| `--osui-button-group-border-width` | `#{$token-border-size-0}` |
+| `--osui-button-group-color` | `var(--color-text-subtlest)` |
+| `--osui-button-group-selected-background` | `var(--background-color-header, var(--color-background-header))` |
+| `--osui-button-group-selected-border-color` | `transparent` |
 
 ### Checkbox (`[data-checkbox]`)
 _File: `src/scss/03-widgets/_checkbox.scss`_
@@ -1079,4 +1110,4 @@ _File: `src/scss/01-foundations/_root.scss`_
 
 ---
 
-<sub>529 properties across 80 components, generated from `src/scss`.</sub>
+<sub>554 properties across 81 components, generated from `src/scss`.</sub>

--- a/stories/CssApiReference.mdx
+++ b/stories/CssApiReference.mdx
@@ -99,23 +99,6 @@ _File: `src/scss/03-widgets/_button-group.scss`_
 | `--osui-button-group-disabled-color` | `#{$token-text-disabled}` |
 | `--osui-button-group-disabled-overlay` | `#{$token-state-disabled}` |
 
-### Button Group (`.layout-native`)
-_File: `src/scss/03-widgets/_button-group.scss`_
-
-| Property | Default |
-|---|---|
-| `--osui-button-group-container-background` | `transparent` |
-| `--osui-button-group-container-padding` | `#{$token-scale-0}` |
-| `--osui-button-group-container-gap` | `#{$token-scale-0}` |
-| `--osui-button-group-container-border-radius` | `#{$token-border-radius-0}` |
-| `--osui-button-group-background` | `var(--background-color-header, var(--color-background-header))` |
-| `--osui-button-group-border-color` | `transparent` |
-| `--osui-button-group-border-radius` | `#{$token-border-radius-0}` |
-| `--osui-button-group-border-width` | `#{$token-border-size-0}` |
-| `--osui-button-group-color` | `var(--color-text-subtlest)` |
-| `--osui-button-group-selected-background` | `var(--background-color-header, var(--color-background-header))` |
-| `--osui-button-group-selected-border-color` | `transparent` |
-
 ### Checkbox (`[data-checkbox]`)
 _File: `src/scss/03-widgets/_checkbox.scss`_
 
@@ -1110,4 +1093,4 @@ _File: `src/scss/01-foundations/_root.scss`_
 
 ---
 
-<sub>554 properties across 81 components, generated from `src/scss`.</sub>
+<sub>543 properties across 80 components, generated from `src/scss`.</sub>

--- a/stories/widgets/ButtonGroup.stories.ts
+++ b/stories/widgets/ButtonGroup.stories.ts
@@ -1,5 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/html-vite';
-import { renderPattern } from '../_helpers/osui';
+import { renderPattern, renderStatic } from '../_helpers/osui';
 
 /**
  * Button Group — the OutSystems platform **widget**, transcribed to static markup
@@ -10,43 +10,35 @@ import { renderPattern } from '../_helpers/osui';
  *     > `div`                              ← the widget's own inner wrapper
  *       > `button[data-button-group-item].button-group-item[role=radio][aria-checked]`
  *
- * The selected item additionally carries `.button-group-selected-item`. The
- * `tabindex` values are the widget's roving-tabindex output, reproduced as
- * emitted (it emits `0` for the first two items and `-1` for the third — a
- * widget quirk, not a transcription slip).
- *
- * Selection is re-wired below. Transcribing the DOM removes the React component
- * but not the need to *use* the control: the widget's visible state change on
- * click is two class/attribute mutations, so the story performs exactly those
- * and nothing else — no state model, no re-render. `tabindex` is deliberately
- * left alone, so what you see at rest stays byte-identical to the capture — which
- * is also what Chromatic snapshots, since it photographs the initial render.
+ * v3.0.0 visual contract: Figma node 20015249:20 — pill items on a neutral subtle
+ * track; selected item is white with a default border, not primary-filled.
  *
  * CSS contract: src/scss/03-widgets/_button-group.scss, plus the flex layout the
  * platform base layer puts on `[data-button-group] > div`.
  */
-const meta: Meta = { title: 'Widgets/ButtonGroup' };
+const meta: Meta = {
+	title: 'Widgets/ButtonGroup',
+	tags: ['!ui-pending', 'ui-reviewed'],
+};
 export default meta;
 type Story = StoryObj;
 
-const item = (label: string, selected: boolean, tabindex: number) =>
+const item = (label: string, selected: boolean, disabled = false, tabindex = 0) =>
 	`<button data-button-group-item="" class="button-group-item${selected ? ' button-group-selected-item' : ''}"
-		aria-checked="${selected}" role="radio" tabindex="${tabindex}">${label}</button>`;
+		aria-checked="${selected}" role="radio" tabindex="${tabindex}"${disabled ? ' disabled=""' : ''}>${label}</button>`;
 
-const template = `
-	<div data-button-group="" class="button-group" role="radiogroup">
-		<div>
-			${item('Day', false, 0)}
-			${item('Week', true, 0)}
-			${item('Month', false, -1)}
-		</div>
+const group = (items: string, extraClass = '') =>
+	`<div data-button-group="" class="button-group${extraClass ? ` ${extraClass}` : ''}" role="radiogroup">
+		<div>${items}</div>
 	</div>`;
+
+const sixItems = (selectedIndex: number, disabled = false) =>
+	Array.from({ length: 6 }, (_, i) => item('Button', i === selectedIndex, disabled, i === 0 ? 0 : -1)).join('');
 
 export const Default: Story = {
 	render: () =>
-		renderPattern(template, (root) => {
+		renderPattern(group(item('Day', false) + item('Week', true) + item('Month', false)), (root) => {
 			const items = [...root.querySelectorAll<HTMLElement>('[data-button-group-item]')];
-			// The two mutations the widget makes when a different item wins selection.
 			const select = (chosen: HTMLElement): void => {
 				for (const el of items) {
 					const isChosen = el === chosen;
@@ -54,9 +46,24 @@ export const Default: Story = {
 					el.setAttribute('aria-checked', String(isChosen));
 				}
 			};
-			// `<button>` already fires click for Enter/Space, so keyboard works for free.
 			for (const el of items) {
 				el.addEventListener('click', () => select(el));
 			}
 		}),
+};
+
+export const States: Story = {
+	render: () =>
+		renderStatic(`
+			<div style="display:flex;flex-direction:column;gap:16px;">
+				${group(sixItems(0))}
+				${group(sixItems(2))}
+				${group(sixItems(5))}
+				${group(item('Only', true))}
+				${group(
+					item('Enabled', false) +
+						item('Selected disabled', true, true) +
+						item('Disabled', false, true),
+				)}
+			</div>`),
 };


### PR DESCRIPTION
This PR is for updating the Button Group platform widget to match the v3 Figma pill-style segmented control design.

### What was happening
* Button Group used the legacy connected primary-filled style instead of the v3 segmented control from Figma
* Selected items were primary-filled rather than white with a default border on a neutral subtle track
* Hover and disabled states did not match the updated design token values from outsystems-design-tokens 2.0.0

### What was done
* Restyled src/scss/03-widgets/_button-group.scss to v3: neutral subtle container track, individual pill items, white selected state with default border
* Added shared hover press background for both selected and unselected items via --osui-button-group-hover-background
* Expanded --osui-button-group-* CSS API vars for container and item theming
* Updated Storybook with Default (interactive) and States stories only
* Regenerated CSS API reference for the new button group properties

### Test Steps
1. Run npm run build:tokens && npm run dev --target=odc
2. Open Storybook, navigate to Widgets/ButtonGroup, Default story
3. Verify pill track background, white selected item with border, and click-to-select behaviour
4. Open States story and verify selected positions, single item, and disabled variants
5. Hover items and confirm press background on both selected and unselected states

### Screenshots
(prefer animated gif)

### Checklist
* [ ] tested locally
* [ ] documented the code
* [ ] clean all warnings and errors of eslint
* [ ] requires changes in OutSystems (if so, provide a module with changes)
* [ ] requires new sample page in OutSystems (if so, provide a module with changes)
