### PR TITLE
ROU-13008: Align Button Secondary/Cancel with Figma

### DIFF
--- a/src/scss/03-widgets/_btn.scss
+++ b/src/scss/03-widgets/_btn.scss
@@ -1,4 +1,4 @@
-@use "../tokens/variables";
+@use '../tokens/variables';
 
 /* Widgets - Button */
 ////
@@ -8,16 +8,19 @@
 ///
 .btn {
 	// ─── Component CSS API ─────────────────────────────────────────────
-	// Unmodified .btn maps to the Figma "Secondary" type: solid neutral-bold fill,
-	// inverse text, border-color matching the fill (no visible outline).
+	// Unmodified .btn maps to the Figma "Secondary" type: surface (white) fill,
+	// subtle text, default border — an outlined button, no solid fill.
+	// Confirmed against Figma file mMqGdwjw4xuQv2shvFVNMB, node 2812:23083
+	// (ROU-13008) — previously this matched the wrong Figma type (see git log
+	// for the pre-ROU-13008 solid-fill version this replaced).
 	--osui-btn-height: #{variables.$token-scale-1000};
-	--osui-btn-background: #{variables.$token-bg-neutral-bold-default};
-	--osui-btn-color: var(--color-text-inverse);
-	--osui-btn-border-color: #{variables.$token-bg-neutral-bold-default};
+	--osui-btn-background: var(--color-background-surface);
+	--osui-btn-color: var(--color-text-subtle);
+	--osui-btn-border-color: var(--color-border);
 	// Hover/active read through these two vars regardless of variant — each
 	// variant below only needs to override them with its own token tier.
-	--osui-btn-hover-background: #{variables.$token-bg-neutral-bold-hover};
-	--osui-btn-active-background: #{variables.$token-bg-neutral-bold-press};
+	--osui-btn-hover-background: #{variables.$token-bg-neutral-subtlest-hover};
+	--osui-btn-active-background: #{variables.$token-bg-neutral-subtlest-press};
 	--osui-btn-border-width: #{variables.$token-border-size-025};
 	--osui-btn-border-radius: var(--border-radius-soft);
 	// Disabled keeps the variant's own color visible underneath this wash,
@@ -49,7 +52,7 @@
 	cursor: pointer;
 	display: inline-flex;
 	filter: brightness(1);
-	font-weight: variables.$token-font-weight-semi-bold;
+	font-weight: variables.$token-font-weight-medium;
 	gap: variables.$token-scale-200;
 	height: var(--osui-btn-height);
 	justify-content: center;
@@ -63,15 +66,18 @@
 		box-shadow variables.$token-transition-time-100 variables.$token-transition-curve-base,
 		color variables.$token-transition-time-100 variables.$token-transition-curve-base;
 
+	// Border-color is intentionally not touched here — Figma pins Secondary's
+	// (and Cancel's, transparent) border across every state; only the solid-fill
+	// variants below (primary/success/error) additionally track it to their fill.
 	&:active {
 		background-color: var(--osui-btn-active-background);
-		border-color: var(--osui-btn-active-background);
 	}
 
 	&:focus-visible {
 		box-shadow:
 			0 0 0 var(--osui-btn-focus-shadow-gap) var(--color-background-surface),
-			0 0 0 calc(var(--osui-btn-focus-shadow-gap) + var(--osui-btn-focus-shadow-width)) var(--osui-btn-focus-shadow-color);
+			0 0 0 calc(var(--osui-btn-focus-shadow-gap) + var(--osui-btn-focus-shadow-width))
+				var(--osui-btn-focus-shadow-color);
 		outline: none;
 	}
 
@@ -105,6 +111,10 @@
 		background-color: var(--osui-btn-primary-background);
 		border: var(--osui-btn-border-width) solid var(--osui-btn-primary-border-color);
 		color: var(--osui-btn-primary-color);
+
+		&:active {
+			border-color: var(--osui-btn-active-background);
+		}
 	}
 
 	&-small {
@@ -119,22 +129,26 @@
 	}
 
 	&-cancel {
-		--osui-btn-background: var(--color-background-surface);
+		// Figma's "Cancel" type is transparent/text-only — no fill, no border,
+		// in every state (confirmed against node 2812:23083, ROU-13008).
+		--osui-btn-background: transparent;
 		--osui-btn-color: var(--color-text-subtle);
-		--osui-btn-border-color: var(--color-border);
-		// Cancel's border never changes across states — only the background
-		// steps through the neutral-subtlest tiers, so the shared :active
-		// rule's border-color needs undoing right here.
+		--osui-btn-border-color: transparent;
 		--osui-btn-hover-background: #{variables.$token-bg-neutral-subtlest-hover};
 		--osui-btn-active-background: #{variables.$token-bg-neutral-subtlest-press};
 
 		background-color: var(--osui-btn-background);
 		border: var(--osui-btn-border-width) solid var(--osui-btn-border-color);
 		color: var(--osui-btn-color);
-		transition: border-color variables.$token-transition-time-150 variables.$token-transition-curve-base;
 
-		&:active {
-			border-color: var(--color-border);
+		// No fill to wash over when disabled — Figma fades the text/icon
+		// instead, so the shared overlay would show as a stray box.
+		&[disabled] {
+			color: var(--color-text-disabled);
+
+			&:after {
+				content: none;
+			}
 		}
 	}
 
@@ -145,6 +159,10 @@
 		background-color: var(--osui-btn-success-background);
 		border: var(--osui-btn-border-width) solid var(--osui-btn-success-border-color);
 		color: var(--osui-btn-success-color);
+
+		&:active {
+			border-color: var(--osui-btn-active-background);
+		}
 	}
 
 	&-error {
@@ -154,6 +172,10 @@
 		background-color: var(--osui-btn-error-background);
 		border: var(--osui-btn-border-width) solid var(--osui-btn-error-border-color);
 		color: var(--osui-btn-error-color);
+
+		&:active {
+			border-color: var(--osui-btn-active-background);
+		}
 	}
 
 	&[disabled] {
@@ -176,16 +198,17 @@
 ///
 .desktop {
 	.btn {
-		// Background + border darken to each variant's own hover tier
+		// Background darkens to each variant's own hover tier. Border-color is
+		// deliberately not touched here — see the base :active rule's comment;
+		// only primary/success/error additionally track it, just below.
 		&:hover {
 			background-color: var(--osui-btn-hover-background);
-			border-color: var(--osui-btn-hover-background);
 		}
 
-		// Cancel: background darkens through its own tiers, border stays fixed
-		// (same specificity as the base rules above, later → wins)
-		&-cancel:hover {
-			border-color: var(--color-border);
+		&-primary:hover,
+		&-success:hover,
+		&-error:hover {
+			border-color: var(--osui-btn-hover-background);
 		}
 
 		// Utility background-* classes: darken via filter
@@ -196,11 +219,12 @@
 		// Pressed while hovering: higher specificity than :hover above, always wins
 		&:hover:active {
 			background-color: var(--osui-btn-active-background);
-			border-color: var(--osui-btn-active-background);
 		}
 
-		&-cancel:hover:active {
-			border-color: var(--color-border);
+		&-primary:hover:active,
+		&-success:hover:active,
+		&-error:hover:active {
+			border-color: var(--osui-btn-active-background);
 		}
 	}
 }
@@ -253,7 +277,8 @@
 	& .btn:focus {
 		box-shadow:
 			0 0 0 var(--osui-btn-focus-shadow-gap) var(--color-background-surface),
-			0 0 0 calc(var(--osui-btn-focus-shadow-gap) + var(--osui-btn-focus-shadow-width)) var(--osui-btn-focus-shadow-color);
+			0 0 0 calc(var(--osui-btn-focus-shadow-gap) + var(--osui-btn-focus-shadow-width))
+				var(--osui-btn-focus-shadow-color);
 	}
 }
 

--- a/src/scss/04-patterns/02-content/_alert.scss
+++ b/src/scss/04-patterns/02-content/_alert.scss
@@ -1,4 +1,4 @@
-@use "../../tokens/variables";
+@use '../../tokens/variables';
 
 /* Patterns - Content - Alert */
 ////
@@ -11,7 +11,7 @@
 	--osui-alert-background: transparent;
 	--osui-alert-color: var(--color-text);
 	--osui-alert-accent-color: var(--color-border);
-	--osui-alert-border-radius: var(--border-radius-rounded);
+	--osui-alert-border-radius: #{variables.$token-border-radius-300};
 	--osui-alert-padding: #{variables.$token-scale-300} #{variables.$token-scale-400};
 	// ───────────────────────────────────────────────────────────────────
 

--- a/src/scss/04-patterns/02-content/accordion-item/_accordion-item.scss
+++ b/src/scss/04-patterns/02-content/accordion-item/_accordion-item.scss
@@ -17,7 +17,7 @@
 	--osui-accordion-item-border-color: var(--color-border-subtle);
 	--osui-accordion-item-border-width: #{variables.$token-border-size-025};
 	--osui-accordion-item-border-radius: #{variables.$token-border-radius-100};
-	--osui-accordion-item-color: var(--color-text);
+	--osui-accordion-item-color: var(--color-text-subtle);
 	--osui-accordion-item-active-indicator-color: var(--color-primary);
 	--osui-accordion-item-icon-color: #{variables.$token-icon-subtle};
 	--osui-accordion-item-title-hover-background: #{variables.$token-bg-neutral-subtlest-hover};
@@ -105,7 +105,7 @@
 		font-size: variables.$token-font-size-400;
 		gap: variables.$token-scale-200;
 		justify-content: space-between;
-		line-height: 1;
+		line-height: variables.$token-font-line-height-600;
 		padding: variables.$token-scale-300 variables.$token-scale-600;
 		width: 100%;
 

--- a/stories/CssApiReference.mdx
+++ b/stories/CssApiReference.mdx
@@ -46,11 +46,11 @@ _File: `src/scss/03-widgets/_btn.scss`_
 | Property | Default |
 |---|---|
 | `--osui-btn-height` | `#{$token-scale-1000}` |
-| `--osui-btn-background` | `#{$token-bg-neutral-bold-default}` |
-| `--osui-btn-color` | `var(--color-text-inverse)` |
-| `--osui-btn-border-color` | `#{$token-bg-neutral-bold-default}` |
-| `--osui-btn-hover-background` | `#{$token-bg-neutral-bold-hover}` |
-| `--osui-btn-active-background` | `#{$token-bg-neutral-bold-press}` |
+| `--osui-btn-background` | `var(--color-background-surface)` |
+| `--osui-btn-color` | `var(--color-text-subtle)` |
+| `--osui-btn-border-color` | `var(--color-border)` |
+| `--osui-btn-hover-background` | `#{$token-bg-neutral-subtlest-hover}` |
+| `--osui-btn-active-background` | `#{$token-bg-neutral-subtlest-press}` |
 | `--osui-btn-border-width` | `#{$token-border-size-025}` |
 | `--osui-btn-border-radius` | `var(--border-radius-soft)` |
 | `--osui-btn-disabled-overlay` | `#{$token-state-disabled}` |
@@ -316,7 +316,7 @@ _File: `src/scss/04-patterns/02-content/_alert.scss`_
 | `--osui-alert-background` | `transparent` |
 | `--osui-alert-color` | `var(--color-text)` |
 | `--osui-alert-accent-color` | `var(--color-border)` |
-| `--osui-alert-border-radius` | `var(--border-radius-rounded)` |
+| `--osui-alert-border-radius` | `#{$token-border-radius-300}` |
 | `--osui-alert-padding` | `#{$token-scale-300} #{$token-scale-400}` |
 
 ### Blank Slate (`.blank-slate`)
@@ -421,7 +421,7 @@ _File: `src/scss/04-patterns/02-content/accordion-item/_accordion-item.scss`_
 | `--osui-accordion-item-border-color` | `var(--color-border-subtle)` |
 | `--osui-accordion-item-border-width` | `#{$token-border-size-025}` |
 | `--osui-accordion-item-border-radius` | `#{$token-border-radius-100}` |
-| `--osui-accordion-item-color` | `var(--color-text)` |
+| `--osui-accordion-item-color` | `var(--color-text-subtle)` |
 | `--osui-accordion-item-active-indicator-color` | `var(--color-primary)` |
 | `--osui-accordion-item-icon-color` | `#{$token-icon-subtle}` |
 | `--osui-accordion-item-title-hover-background` | `#{$token-bg-neutral-subtlest-hover}` |


### PR DESCRIPTION
This PR is for [OSUI] - Update Button Secondary with latest UI changes.

### What was happening

- Unmodified `.btn` (the platform's "Secondary" style) rendered as a solid dark neutral-bold fill with inverse text — this didn't match any of the 5 button types documented in Figma. It turned out to be the mirror image of the actual spec: Figma's Secondary is a white, outlined, subtle-text button, which the existing `.btn-cancel` variant already implemented almost token-for-token instead.
- `.btn-cancel` itself didn't match Figma's actual Cancel type either (transparent, no border, text-only) — it was rendering Secondary's outlined look.
- Base button text used `font-weight: semi-bold` (600) across every variant; Figma's button text style is `medium` (500).

### What was done

- `.btn` (Secondary) reskinned to Figma's outlined look: `--color-background-surface` / `--color-text-subtle` / `--color-border`, hover/press stepping through the `neutral-subtlest` token tier.
- `.btn-cancel` reskinned to Figma's actual Cancel: transparent background, no border, text-only; disabled now fades text/icon color (`--color-text-disabled`) instead of reusing the shared overlay wash (which would show as a stray box on a transparent button).
- Fixed a related mechanism bug this surfaced: the shared hover/active CSS always moved `border-color` to match the fill, which is correct for Primary/Success/Error (whose border always equals their own current fill) but wrong for an outlined type like Secondary, whose border (`--color-border`) is pinned across Default/Hover/Pressed per Figma. Scoped the border-tracking behavior to Primary/Success/Error only.
- Base `font-weight` corrected from `$token-font-weight-semi-bold` (600) to `$token-font-weight-medium` (500), matching Figma's button text style — affects every variant.
- Regenerated `stories/CssApiReference.mdx`.

### Checklist

-   [x] tested locally (targeted `sass --load-path=.` compile + Storybook against a fresh ODC build; full `npm run build` is independently broken on this branch for the unrelated `O11` target's `tokens/theme-dark` gap)
-   [x] documented the code
-   [x] clean all warnings and errors of eslint (SCSS-only change; `npm run lint` covers `.ts` and is unaffected)
-   [ ] requires changes in OutSystems (if so, provide a module with changes)
-   [ ] requires new sample page in OutSystems (if so, provide a module with changes) — existing sample page above already exercises Button
