### PR TITLE
ROU-13013: Logical box-model properties (start/end, inline/block)

### DIFF
--- a/.claude/rules/scss.md
+++ b/.claude/rules/scss.md
@@ -187,7 +187,6 @@ comment saying why.
 | `border-start-start-radius` … | `border-top-left-radius` … |
 | `inset-inline-start` / `-end` | `left` / `right` |
 | `text-align: start` / `end` | `text-align: left` / `right` |
-| `var(--os-safe-area-inline-start)` | `var(--os-safe-area-left)` |
 
 Corollaries:
 
@@ -233,8 +232,9 @@ Scrollable Area are the two kept for this reason.
 `transform` (`translateX`, `scaleX`, `rotate`), `transform-origin`, `box-shadow` /
 `text-shadow` offsets, `background-position`, `linear-gradient(to right)`,
 `flex-direction: row-reverse`, `float` (the logical keywords need Chrome 118 / Safari 16.4),
-positional `top` / `bottom`, `env(safe-area-inset-*)`, everything `-servicestudio-*`, and
-the vendor baselines.
+positional `top` / `bottom`, **every declaration reading a `--os-safe-area-*` var** (the
+value is a physical `env()`, so a logical property would flip the side but not the value),
+everything `-servicestudio-*`, and the vendor baselines.
 
 ### Direction-pinned subtrees
 

--- a/.claude/rules/scss.md
+++ b/.claude/rules/scss.md
@@ -83,7 +83,7 @@ Form controls are styled via data attributes: `[data-input]`, `[data-textarea]`,
 
 `.is-active`, `.is-disabled`, `.is-open`, `.is-hidden`, `.is-selected`, `.is-focused`, `.is-inline`, `.is-rtl`, `.has-accessible-features`, `.has-event`.
 
-`.is-rtl` is used as a context selector throughout; prefer logical properties (`margin-inline-start`, `inset-inline`) in new code.
+`.is-rtl` is a context selector for the handful of genuinely physical properties only — see §15.
 
 ## 8. Pattern-scoped custom properties
 
@@ -172,3 +172,89 @@ Flag in review:
 - Imports of `_*_lib.scss` vendor baselines.
 - Hand-edits of `O11.OutSystemsUI.scss` / `ODC.OutSystemsUI.scss`.
 - Style rules on `08-servicestudio-preview/` files (read-only for runtime code).
+
+## 15. Logical box model — the default since ROU-13013
+
+`padding`, `margin`, `border` and `inset` are written **logically**. A physical side needs a
+comment saying why.
+
+| Write this | Not this |
+|---|---|
+| `padding-inline-start` / `-end` | `padding-left` / `-right` |
+| `padding-block-start` / `-end` | `padding-top` / `-bottom` |
+| `padding-block: a; padding-inline: b` | `padding: a b` |
+| `border-inline-start` (+ `-width` / `-style` / `-color`) | `border-left` |
+| `border-start-start-radius` … | `border-top-left-radius` … |
+| `inset-inline-start` / `-end` | `left` / `right` |
+| `text-align: start` / `end` | `text-align: left` / `right` |
+| `var(--os-safe-area-inline-start)` | `var(--os-safe-area-left)` |
+
+Corollaries:
+
+- **Component CSS API names carry the axis, never the side** — `--osui-x-padding-inline`,
+  `--osui-x-padding-block`, `--osui-x-padding-inline-start`. No `-x` / `-y` / `-left` / `-right`.
+- **Never put a multi-value box shorthand in a custom property.** It cannot mirror without
+  restating the whole value. Split it into `…-block` + `…-inline-start` + `…-inline-end`.
+- **Convert whole rules.** Logical and physical longhands that resolve to the same side have
+  no specificity relationship — the later declaration wins — so a half-converted rule fails
+  silently.
+- **`border-radius` shorthand only when the inline axis is asymmetric.** `8px 8px 0 0`
+  mirrors to itself.
+
+### Two traps that produce wrong RTL
+
+**1. Never mix a logical inset with a physical x-axis transform on the same element.**
+`transform` has no logical form, so it never mirrors. Pair it with `inset-inline-*` and the
+anchor flips in RTL while the transform does not:
+
+```scss
+// WRONG - in RTL the anchor moves to the right edge, translateX still pushes right
+inset-inline-start: 0;
+transform: translateX(8px);
+
+// RIGHT - both halves in the same coordinate system
+left: 0;
+transform: translateX(8px);
+```
+
+This bit the Switch (thumb slid outside its track in RTL) and every use of the centring
+idiom `left: 50%; transform: translateX(-50%)`. No grep catches this — it needs to know
+both declarations are on the same element — so it is a review check: **a rule with an
+x-axis transform keeps its inset physical.**
+
+**2. Before deleting an `.is-rtl` rule, check the base declaration is ours.** Some `.is-rtl`
+rules mirror physical CSS owned by the **platform** stylesheet or a vendor baseline, not by
+OSUI. Making our side logical does nothing for those - the physical base never mirrors, so
+the `.is-rtl` rule is still load-bearing. Popover ODC (platform's `margin-left: -50%`) and
+Scrollable Area are the two kept for this reason.
+
+### Still physical, on purpose
+
+`transform` (`translateX`, `scaleX`, `rotate`), `transform-origin`, `box-shadow` /
+`text-shadow` offsets, `background-position`, `linear-gradient(to right)`,
+`flex-direction: row-reverse`, `float` (the logical keywords need Chrome 118 / Safari 16.4),
+positional `top` / `bottom`, `env(safe-area-inset-*)`, everything `-servicestudio-*`, and
+the vendor baselines.
+
+### Direction-pinned subtrees
+
+Inside an element whose computed `direction` is `ltr`, a logical property resolves LTR and
+does **not** mirror. Three such islands exist: `.flatpickr-calendar` (vendor —
+`date-picker` / `month-picker` / `time-picker` provider SCSS is therefore excluded from the
+conversion and stays physical), `.osui-accordion-item__title`, and `.is-rtl .splide--ltr`.
+Check for a pin before converting anything inside a provider subtree.
+
+### Finding stragglers
+
+```bash
+grep -rnE '^[[:space:]]*(padding|margin|border)-(left|right|top|bottom)|^[[:space:]]*(left|right):' \
+  src/scss --include='*.scss' \
+  | grep -vE '_lib\.scss|splide-core|08-servicestudio|09-excluders|provider/_flatpickr|-servicestudio-'
+```
+
+Everything it returns should either be converted or carry a comment saying why it is
+physical. The durable guard is the stylelint `property-disallowed-list` rule described in
+`specs/plan-part-five.md` §7 — not yet wired, because stylelint 14 here has no
+`customSyntax: postcss-scss` and cannot parse `//` comments.
+
+See `specs/plan-part-five.md` for the full rationale and the follow-ups.

--- a/.storybook/platform/platform-core.css
+++ b/.storybook/platform/platform-core.css
@@ -233,6 +233,25 @@
 
 /* Right-To-Left Support */
 
+/*
+ * ADDED FOR STORYBOOK — not present in the vendored source.
+ *
+ * A real RTL app renders <html lang="ar" dir="rtl"> with <body class="… is-rtl …">, and
+ * the running platform gives the document an author-level `direction: rtl`. That rule is
+ * NOT in the extracted widget CSS this file was copied from, and without it OutSystems
+ * UI's own `body { direction: ltr }` reset (01-foundations/_resets.scss — an author
+ * declaration, so it outranks the UA mapping of the `dir` attribute) wins at <body> and
+ * every logical property in the bundle resolves LTR. The RTL toolbar toggle then appears
+ * to do nothing.
+ *
+ * Both selectors are (0,1,1), so they beat `body` (0,0,1) regardless of load order.
+ */
+[dir='rtl'] body,
+body.is-rtl {
+    direction: rtl;
+}
+
+
 .is-rtl [data-dropdown] > .dropdown-display:after {
     left: 5px;
     right: auto;

--- a/specs/plan-part-five.md
+++ b/specs/plan-part-five.md
@@ -1,0 +1,338 @@
+# Part Five: Logical Box-Model Properties
+
+**Status: implemented** on `ROU-13013` (one PR). Ticket: **ROU-13013** — _Implement start/end inline/block CSS rules for
+padding, margin and border on the new theme._
+
+Parts One–Three (`plan.md`, `plan-part-two.md`, `plan-part-three.md`) put a design-token
+system under OSUI; Part Four (`plan-part-four.md`) formalized the theme layer. Part Five
+changes the **axis vocabulary** of the box model: physical sides (`left` / `right` /
+`top` / `bottom`) become logical ones (`inline-start` / `inline-end` / `block-start` /
+`block-end`), and the `.is-rtl` rules that exist only to restate a physical side are
+deleted.
+
+The conversion landed as a single change on this branch; what follows is the record of
+what was converted, what deliberately was not, and the two traps that produce wrong RTL
+(§6.5, §6.6). The authoring rules are mirrored into `.claude/rules/scss.md` §15.
+
+---
+
+## 1. Scope
+
+**In scope.** Every `padding-*`, `margin-*` and `border-*` declaration in `src/scss/**` —
+sides, shorthands, and corner radii.
+
+**Required to finish the job.** `left` / `right` / `inset` → `inset-inline-*`, and
+`text-align: left|right` → `start|end`. Not box-model, but **20 of the 51 `.is-rtl` rule
+sets are positional**: without these, those blocks cannot be deleted and the ticket's
+outcome only half lands.
+
+**Out of scope.**
+
+- The RTL mechanism itself. `.is-rtl` on `<body>` plus the platform's own direction
+  handling works today as intended; nothing here changes how direction is established,
+  observed (`RTLObserver`), or passed to providers. No TypeScript changes.
+- Vendor baselines — `_*_lib.scss` and `splide-core.scss` are never edited (rules §10).
+- `-servicestudio-*` declarations and `08-servicestudio-preview/`: Service Studio's
+  renderer is not a browser and logical support cannot be assumed. They stay physical.
+- `writing-mode` / vertical text. The block-axis rewrite (`*-top` → `*-block-start`) is
+  vocabulary consistency only — it changes nothing visually, but the ticket asks for
+  "inline/block" and a half-logical box model is worse than a whole one (D3).
+- Positional `top` / `bottom` (218 declarations). `inset-inline-start` alongside `top` is
+  idiomatic, and insets play no part in mirroring.
+
+---
+
+## 2. Property mapping
+
+| Physical | Logical |
+|---|---|
+| `padding-left` / `padding-right` | `padding-inline-start` / `padding-inline-end` |
+| `margin-left` / `margin-right` | `margin-inline-start` / `margin-inline-end` |
+| `padding-top` / `padding-bottom` | `padding-block-start` / `padding-block-end` |
+| `padding: a b` | `padding-block: a; padding-inline: b` |
+| `padding: a b c` | `padding-block: a c; padding-inline: b` |
+| `padding: a b c d` (b = d) | `padding-block: a c; padding-inline: b` |
+| `padding: a b c d` (b ≠ d) | `padding-block: a c; padding-inline-start: d; padding-inline-end: b` |
+| `border-left` / `border-right` (+ `-width` / `-style` / `-color`) | `border-inline-start` / `border-inline-end` (+ suffix) |
+| `border-top-left-radius` | `border-start-start-radius` |
+| `border-top-right-radius` | `border-start-end-radius` |
+| `border-bottom-right-radius` | `border-end-end-radius` |
+| `border-bottom-left-radius` | `border-end-start-radius` |
+| `left` / `right` | `inset-inline-start` / `inset-inline-end` |
+| `text-align: left` / `right` | `text-align: start` / `end` |
+
+Browser floors are all 2020–21 (`*-inline-*`: Chrome 87 · Safari 14.1 · FF 66; logical
+corner radii: Chrome 89 · Safari 15 · FF 66) — below anything OSUI 2.x supports.
+`gulp-autoprefixer` neither prefixes nor polyfills them; no build change.
+
+### When *not* to convert
+
+- **`border-radius` shorthand that is symmetric on the inline axis.** `8px 8px 0 0`
+  mirrors to itself; converting it costs four longhands for nothing. Only the
+  inline-asymmetric ones are listed in the inventory (14 declarations, 4 files).
+- **Properties with no logical form:** `transform` (`translateX`, `scaleX`, `rotate`),
+  `transform-origin`, `box-shadow` / `text-shadow` offsets, `background-position`,
+  `linear-gradient(to right)`, `flex-direction: row-reverse`, `float` (D4),
+  `env(safe-area-inset-left|right)` (D5). These keep their `.is-rtl` rules.
+- **Vendor-owned geometry.** Where a provider mirrors itself (Splide's `--ltr` / `--rtl`,
+  VirtualSelect's `text-direction-rtl`), follow the provider rather than fight it.
+
+---
+
+## 3. Authoring rules
+
+To be folded into `.claude/rules/scss.md` (promote §7, add a §15) and `CSS-ARCHITECTURE.md`:
+
+1. **Logical is the default** for `padding`, `margin`, `border` and `inset` in all new and
+   touched SCSS. A physical side requires a comment naming the reason.
+2. **Component CSS API names carry the axis, never the side** —
+   `--osui-{component}-padding-inline`, `--osui-{component}-padding-block`,
+   `--osui-{component}-padding-inline-start`. Rename `--osui-sidebar-padding-x` / `-y`
+   (`_sidebar.scss:15-16`); never introduce `-left` / `-right` in a spacing var. (Extends D11.)
+3. **A custom property must not hold a multi-value box shorthand.** It cannot be mirrored
+   without restating the whole value, which is precisely why `_card-sectioned.scss` needs
+   an `.is-rtl` block at all. Split into `…-block` + `…-inline-start` + `…-inline-end`.
+   12 declarations, 1 file.
+4. **Convert whole rules, never single declarations** — see §6.1.
+5. **Re-sort after converting.** `.stylelintrc.json` enforces
+   `order/properties-alphabetical-order`, and the logical names sort differently
+   (`padding-block` < `padding-inline-end` < `padding-inline-start`).
+
+---
+
+## 4. What landed
+
+What is left to convert, at any time:
+
+```bash
+grep -rnE '^[[:space:]]*(padding|margin|border)-(left|right|top|bottom)|^[[:space:]]*(left|right):' \
+  src/scss --include='*.scss' \
+  | grep -vE '_lib\.scss|splide-core|08-servicestudio|09-excluders|provider/_flatpickr|-servicestudio-'
+```
+
+| Cat | What | Converted | Deleted from `.is-rtl` |
+|---|---|---:|---:|
+| A | `padding-*` / `margin-*` physical side | 127 | 89 |
+| B | `border-*` physical side | 27 | 17 |
+| C | corner / inline-asymmetric `border-radius` | 8 | 2 |
+| D | `padding` / `margin` shorthand | 113 | 6 |
+| E | `left` / `right` / `inset` | 216 | 57 |
+| F | `text-align` | 9 | 4 |
+| G | block axis (`*-top` / `*-bottom`) | 181 | — |
+| | **Total** | **681** in 92 files | **175** in 42 files |
+
+Plus, by hand:
+
+- **`_card-sectioned.scss`** — the six 4-value shorthand custom properties became twelve
+  `…-padding-block` / `…-padding-inline` pairs, and its `.is-rtl` block went with them.
+- **Safe areas (D5)** — `--os-safe-area-inline-start` / `-inline-end` added to `_root.scss`
+  and swapped under `.is-rtl`; **42** consumers now read the logical pair. Four reads of
+  the physical vars remain, each a pre-existing mismatch (a `right` safe area used for a
+  `top` offset, and similar) left exactly as it was.
+- **Utility loops** — `$osui-box-sides` became a physical-name → logical-side map, so
+  `.margin-left-s`, `.padding-top-m` and `.border-left-s` keep their public class names but
+  emit `margin-inline-start`, `padding-block-start`, `border-inline-start`.
+  `.margin-x-*` / `-y-*` collapsed to `margin-inline` / `margin-block`.
+- **`--osui-sidebar-padding-x` / `-y`** renamed to `-inline` / `-block` (D7).
+- **`[align='left'|'right']`** now resolve through `text-align: start|end` in `_text.scss`,
+  which preserves the RTL flip the deleted `.is-rtl` rule used to provide.
+
+**205** rules left empty by the deletions were pruned, along with their orphaned
+`// IsRTL ---` headers. **37** insets were then reverted to physical because they share an
+element with a physical x-axis transform (§6.5), and **2** `.is-rtl` rules were restored
+because they mirror platform-owned CSS (§6.6).
+
+### Verification performed
+
+Both bundles were compiled before and after and compared with a normaliser that resolves
+logical properties back to physical LTR longhands:
+
+- **LTR: zero value differences** on ODC and O11. Every remaining textual difference is a
+  custom-property rename (`--os-safe-area-left` → `--os-safe-area-inline-start`, the
+  card-sectioned split, the sidebar rename) or a newly added rule — no computed value moved.
+- `npx gulp createProduction --target` builds both platforms clean.
+- stylelint: net **zero** new violations (26 ordering violations introduced by the renamed
+  properties were re-sorted away). Note the repo's stylelint 14 setup has no
+  `customSyntax: postcss-scss`, so it cannot parse `//` comments — 367 pre-existing
+  "errors" are that, not real findings. Wiring it up (§7) needs that fixed first.
+
+---
+
+## 5. `.is-rtl` after the change
+
+**51 files → 21.** Thirty `.is-rtl` rule sets were deleted outright. What is left:
+
+| Why it stays | Files |
+|---|---|
+| `transform` (`translateX`, `scaleX`, `rotate`) and its transitions | `_menu.scss`, `_menu-layout-side.scss`, `_popover-odc.scss`, `_breadcrumbs.scss`, `_pagination.scss`, `_progresscircle.scss`, `_rating.scss` |
+| `transform-origin`, `justify-content`, `grid-column` | `_tabs.scss` |
+| RTL-specific `animation-name` (physical keyframe tracks) | `_feedback-message.scss` |
+| `direction` on a pinned subtree (§6.2) | `_accordion-item.scss`, `_carousel.scss`, `month-picker/provider/_flatpickr.scss` |
+| `flex-direction: row-reverse` on a vendor bar | `_lightbox-image.scss` |
+| `rotateY` | `_flipcontent.scss` |
+| `float` — kept physical per D4 | `_list-item-content.scss` |
+| vendor quirk / unrelated | `_rangeslider.scss`, `_resets.scss` (`.is-rtl-device`), `_popover.scss` (`display: inline`, still unexplained), `_submenu.scss` (two `background-color`) |
+| **documented exception** — direction-pinned Flatpickr calendar | `date-picker/provider/_flatpickr.scss` |
+| new — the safe-area inline remap (D5) | `_root.scss` |
+
+---
+
+## 6. CSS-level gotchas
+
+### 6.1 Physical and logical longhands cascade by order, not specificity
+
+Two declarations that resolve to the same side have **no** specificity relationship — the
+later one wins. A half-converted rule (`padding-inline-start` in the base rule, a stale
+`padding-left` further down the same partial or in a later-imported section) fails
+silently. Two consequences:
+
+- Convert a whole rule at a time, and grep the component for leftovers before moving on.
+- Bundle order is `root → resets → html-elements → page-layout → widgets → providers →
+  patterns → useful-classes → screen-transitions → keyframes → ss-preview` (`#All.js`).
+  `05-useful` utilities still win over patterns by order, exactly as today.
+
+### 6.2 Direction-pinned subtrees
+
+Inside an element whose computed `direction` is `ltr`, a logical property resolves to the
+LTR side — so converting declarations there changes nothing until the pin is lifted. Four
+pins exist:
+
+| Site | Effect on this work |
+|---|---|
+| `_flatpickr_lib.scss:10` — `.flatpickr-calendar { direction: ltr }` (**vendor**) | The whole calendar is pinned. Either add `.is-rtl .flatpickr-calendar { direction: rtl }` to the override file and convert — which also retires the `.flatpickr-months/-weekdays/-days { direction: rtl }` patch at `:561` — or leave the calendar's 78 declarations physical. Do not half-convert. Affects DatePicker, TimePicker, MonthPicker. |
+| `_accordion-item.scss:103` — `.osui-accordion-item__title { direction: ltr }` | Caret-side hack, undone at `:300`. Re-derive with flex `order` + logical padding to retire both. |
+| `_carousel.scss:222` — `.is-rtl .splide--ltr { direction: ltr }` | Leave alone; Splide owns its axis. |
+| `_resets.scss:63` — `body { direction: ltr }` | Note only: an author declaration on `<body>` outranks the UA `dir` mapping, so confirm what the platform sets it against before relying on logical properties in top-level layout rules (PR 2). |
+
+### 6.3 Deleting an `.is-rtl` rule drops specificity
+
+`.is-rtl .foo` is `(0,2,0)`; the base rule usually is not. Anything that was quietly losing
+to the RTL rule starts winning once it is gone. Check components with app-level override
+hooks — Header, Menu, Table — after each deletion.
+
+### 6.4 Safe areas cannot be expressed logically — D5
+
+`env(safe-area-inset-left|right)` is physical and has no logical form.
+`--os-safe-area-left` / `-right` (`_root.scss:104-106`) are read physically in 9 places
+(Menu, Header-native, ThemeGrid, Login, Floating Content, Sidebar, Section Index). Declare
+`--os-safe-area-inline-start` / `-inline-end` at `:root`, swap the pair once under
+`.is-rtl`, and have components read only the logical names. One three-line rule then
+replaces every physical safe-area mirror.
+
+### 6.5 A logical inset must never meet a physical x-transform
+
+`transform` has no logical form. When `inset-inline-start` and `translateX()` sit on the
+same element, RTL flips the anchor but not the transform and the element lands in the
+wrong place. Two shapes hit this:
+
+- the Switch thumb — `inset-inline-start: 0` + `translateX(var(--osui-switch-thumb-offset-*))`
+  put the knob outside its track in RTL;
+- the centring idiom — `left: 50%; transform: translateX(-50%)`, which is *symmetric* and
+  correct in both directions while both halves stay physical, and wrong the moment the
+  inset goes logical.
+
+**37 insets across 17 files** were reverted to `left` / `right` for this reason. Affected: Notification (9), noUiSlider (4), the `.absolute-center*` utilities (4),
+Floating Content (3), Menu, Sidebar, Icon Badge, Progress Circle, Bottom Sheet, Switch,
+Master Detail, Bulk Actions, Wizard, VirtualSelect, the icon libraries and the
+`absolute-center` mixin.
+
+A grep cannot catch this one — it needs to know that two declarations sit on the same
+element. Until the stylelint rule in §7 lands it is a review check: **if a rule has a
+`translateX` / `translate()` / `scaleX`, its inset stays physical.**
+
+### 6.6 Some `.is-rtl` rules mirror CSS we do not own
+
+An `.is-rtl` rule is only redundant if the base declaration it mirrors became logical. Two
+mirrored **platform** or unowned CSS and were kept:
+
+- **Popover ODC** — `margin-left: -50%` + `translateX(-50%)` on
+  `[data-popover] > .popover-bottom.align-center` is declared in the platform stylesheet
+  (`platform-core.css:523-527`), never in OSUI. Our RTL override is still the only thing
+  mirroring it.
+- **Scrollable Area** — the LTR sibling margin that
+  `.is-rtl .horizontal-scroll > :not(:first-child)` mirrors is not declared anywhere in the
+  bundle, so there is no logical declaration for RTL to inherit from.
+
+The check is mechanical: for each deleted declaration, does our own compiled bundle declare
+the mirrored property for that element? Three `.is-rtl` declarations now have no base
+counterpart, and all three are deliberate.
+
+### 6.7 App-level overrides stay physical
+
+Apps override OSUI with `padding-left` and friends from their own sheets, which load last
+and keep winning; overrides written inside a customer's own `.is-rtl` scope also keep
+working. What changes is that our value has moved to the other side in RTL, so an app
+override that was complementing one of our deleted blocks may now double up. List the
+removed blocks (§5) in the release notes.
+
+---
+
+## 7. Follow-ups not in this PR
+
+1. **Lift the Flatpickr pin.** `date-picker/provider/_flatpickr.scss`,
+   `month-picker/provider/_flatpickr.scss` and `time-picker/provider/_flatpickr.scss` were
+   left entirely physical and are excluded in both scripts. The vendor baseline pins
+   `.flatpickr-calendar { direction: ltr }` (§6.2), so converting them without lifting the
+   pin would half-mirror the calendar. Lifting it is a visual change across three patterns
+   and deserves its own change with its own Chromatic review.
+2. **Positional `top` / `bottom`** — 213 declarations, deliberately left physical (D3).
+3. **Enforcement.** Add `customSyntax: postcss-scss` to `.stylelintrc.json` (without it
+   stylelint cannot parse this codebase), wire `"lint:scss"` into `package.json`, then add
+   `property-disallowed-list` for the physical sides with `overrides` exempting
+   `_*_lib.scss`, `splide-core.scss`, the three Flatpickr files and
+   `08-servicestudio-preview/`.
+4. **Docs** — regenerate `npm run docs:css-api` for the renamed custom properties.
+
+## 7b. Behaviour changes to call out in the release notes
+
+Everything below is intentional; LTR is untouched in all cases.
+
+1. **`.border-left-*` / `.border-right-*` / `.border-top-*` / `.border-bottom-*` utilities
+   now mirror in RTL.** They never had an `.is-rtl` counterpart, so previously they stayed
+   physical while `.margin-left-*` and `.padding-left-*` flipped. They are now consistent
+   with the rest of the utility set.
+2. **Card Sectioned images gain their padding back.** `--card-sectioned-image-padding` was
+   declared without interpolation (`variables.$token-scale-600 …` reached the browser as
+   literal text), so the value was invalid at computed-value time and the image padding
+   resolved to `0`. The split into `…-padding-block` / `…-padding-inline` interpolates
+   correctly, so the intended 24px/16px padding now applies. This is a visible fix in both
+   directions.
+3. **Renamed custom properties** — apps setting these directly must update:
+   `--osui-sidebar-padding-x` → `-inline`, `--osui-sidebar-padding-y` → `-block`,
+   `--card-sectioned-{top,image,bottom}-padding` → `…-padding-block` + `…-padding-inline`.
+4. **Deleted `.is-rtl` rules** — 30 blocks. Apps that overrode OSUI *inside* their own
+   `.is-rtl` scope still win, but an override written to complement one of these blocks may
+   now double up.
+5. **Three RTL rules were not pure mirrors and are now mirrored consistently:** the
+   **Table** sort icon is spaced with `margin-inline-start` instead of a relative `right`
+   offset; the **Accordion item** placeholder loses a redundant RTL margin that duplicated
+   its flex `gap`; the sticky **Section Index** on phone had its RTL padding on the block
+   axis (`0 0 16px 0`) where the base rule puts it on the inline axis, and now mirrors the
+   base.
+
+---
+
+## 8. Decisions
+
+| # | Decision | Choice | Rationale |
+|---|---|---|---|
+| D1 | Convert `left` / `right` too? | Yes — mandatory | 20 of 51 `.is-rtl` rule sets are positional; without it they survive and the ticket half-lands |
+| D2 | Convert `text-align: left/right`? | Yes (9 base + 4 RTL) | Trivial, and it is what blocks `_table.scss` and `_text.scss` from REMOVE |
+| D3 | Convert `*-top` / `*-bottom`? | Yes for `padding`/`margin`/`border` (185); **no** for positional `top`/`bottom` insets (218) | The ticket says "inline/block"; a half-logical box model is worse than a fully logical one. `inset-inline-start` next to `top` is idiomatic, so insets stay physical |
+| D4 | `float: inline-start`? | No — keep physical, or replace the float with flex | Chrome 118 / Safari 16.4 is the only support floor above our baseline. 2 declarations, `_list-item-content.scss` |
+| D5 | Safe areas | Add `--os-safe-area-inline-start` / `-inline-end`, swapped once under `.is-rtl` | `env()` is physical; a variable remap keeps the theme invariant intact |
+| D6 | `border-radius` shorthands | Convert only when inline-asymmetric | `8px 8px 0 0` mirrors to itself |
+| D7 | Component CSS API naming | Axis suffixes (`-inline`, `-block`, `-inline-start`); no `-x` / `-y` / `-left` / `-right` | Mirror-correct by construction. Renames are breaking for apps setting them directly, so batch them in one PR and document them |
+| D8 | Vendor baselines | Never edited; mirror from the override file, lifting a `direction` pin there when needed | Existing rule (`.claude/rules/scss.md` §10) |
+| D9 | Service Studio preview | `-servicestudio-*` stays physical, exempt in stylelint | Not rendered by a browser; logical support cannot be assumed |
+
+---
+
+## 9. Still open
+
+1. **`.is-rtl .popover-top { display: inline }`** (`_popover.scss`) — no discoverable
+   physical motive; kept untouched pending archaeology.
+2. **Is the RTL Storybook variant in the Chromatic matrix?** The `direction` global exists
+   (`.storybook/preview.ts:196-204`); the RTL snapshots are what confirm the 30 deleted
+   blocks changed nothing. Confirm before merging.
+3. **Flatpickr pin** — follow-up 1 above.

--- a/specs/plan-part-five.md
+++ b/specs/plan-part-five.md
@@ -73,7 +73,8 @@ corner radii: Chrome 89 · Safari 15 · FF 66) — below anything OSUI 2.x suppo
 - **Properties with no logical form:** `transform` (`translateX`, `scaleX`, `rotate`),
   `transform-origin`, `box-shadow` / `text-shadow` offsets, `background-position`,
   `linear-gradient(to right)`, `flex-direction: row-reverse`, `float` (D4),
-  `env(safe-area-inset-left|right)` (D5). These keep their `.is-rtl` rules.
+  and every declaration reading a `--os-safe-area-*` var (D5). These keep their
+  `.is-rtl` rules.
 - **Vendor-owned geometry.** Where a provider mirrors itself (Splide's `--ltr` / `--rtl`,
   VirtualSelect's `text-direction-rtl`), follow the provider rather than fight it.
 
@@ -125,10 +126,10 @@ Plus, by hand:
 
 - **`_card-sectioned.scss`** — the six 4-value shorthand custom properties became twelve
   `…-padding-block` / `…-padding-inline` pairs, and its `.is-rtl` block went with them.
-- **Safe areas (D5)** — `--os-safe-area-inline-start` / `-inline-end` added to `_root.scss`
-  and swapped under `.is-rtl`; **42** consumers now read the logical pair. Four reads of
-  the physical vars remain, each a pre-existing mismatch (a `right` safe area used for a
-  `top` offset, and similar) left exactly as it was.
+- **Safe areas — deliberately untouched (D5).** Every declaration reading a
+  `--os-safe-area-*` var keeps both its physical property and its physical var, and the
+  `.is-rtl` rules that mirror them stay. `env()` has no logical form, so a logical property
+  reading it would flip the side without flipping the value.
 - **Utility loops** — `$osui-box-sides` became a physical-name → logical-side map, so
   `.margin-left-s`, `.padding-top-m` and `.border-left-s` keep their public class names but
   emit `margin-inline-start`, `padding-block-start`, `border-inline-start`.
@@ -148,8 +149,8 @@ Both bundles were compiled before and after and compared with a normaliser that 
 logical properties back to physical LTR longhands:
 
 - **LTR: zero value differences** on ODC and O11. Every remaining textual difference is a
-  custom-property rename (`--os-safe-area-left` → `--os-safe-area-inline-start`, the
-  card-sectioned split, the sidebar rename) or a newly added rule — no computed value moved.
+  custom-property rename (the card-sectioned split, the sidebar rename) or a newly added
+  rule — no computed value moved.
 - `npx gulp createProduction --target` builds both platforms clean.
 - stylelint: net **zero** new violations (26 ordering violations introduced by the renamed
   properties were re-sorted away). Note the repo's stylelint 14 setup has no
@@ -172,8 +173,8 @@ logical properties back to physical LTR longhands:
 | `rotateY` | `_flipcontent.scss` |
 | `float` — kept physical per D4 | `_list-item-content.scss` |
 | vendor quirk / unrelated | `_rangeslider.scss`, `_resets.scss` (`.is-rtl-device`), `_popover.scss` (`display: inline`, still unexplained), `_submenu.scss` (two `background-color`) |
+| anchored off a `--os-safe-area-*` var (D5) | `section-index/_sectionindex.scss` |
 | **documented exception** — direction-pinned Flatpickr calendar | `date-picker/provider/_flatpickr.scss` |
-| new — the safe-area inline remap (D5) | `_root.scss` |
 
 ---
 
@@ -210,14 +211,18 @@ pins exist:
 to the RTL rule starts winning once it is gone. Check components with app-level override
 hooks — Header, Menu, Table — after each deletion.
 
-### 6.4 Safe areas cannot be expressed logically — D5
+### 6.4 Safe areas stay physical, end to end — D5
 
-`env(safe-area-inset-left|right)` is physical and has no logical form.
-`--os-safe-area-left` / `-right` (`_root.scss:104-106`) are read physically in 9 places
-(Menu, Header-native, ThemeGrid, Login, Floating Content, Sidebar, Section Index). Declare
-`--os-safe-area-inline-start` / `-inline-end` at `:root`, swap the pair once under
-`.is-rtl`, and have components read only the logical names. One three-line rule then
-replaces every physical safe-area mirror.
+`env(safe-area-inset-*)` is physical and has no logical form, and
+`--os-safe-area-top/right/bottom/left` (`_root.scss`) carry those values. A logical
+property reading one of them is the §6.5 mismatch in another guise: `padding-inline-start:
+var(--os-safe-area-left)` flips to the right edge in RTL while still spending the *left*
+inset.
+
+So the whole safe-area surface is out of scope: the vars keep their physical names, the
+**44** declarations that read them keep their physical properties, and the `.is-rtl` rules
+that mirror them — Section Index's sticky rail — stay. This is settled, sensible code; it
+is not what the ticket is about.
 
 ### 6.5 A logical inset must never meet a physical x-transform
 
@@ -320,7 +325,7 @@ Everything below is intentional; LTR is untouched in all cases.
 | D2 | Convert `text-align: left/right`? | Yes (9 base + 4 RTL) | Trivial, and it is what blocks `_table.scss` and `_text.scss` from REMOVE |
 | D3 | Convert `*-top` / `*-bottom`? | Yes for `padding`/`margin`/`border` (185); **no** for positional `top`/`bottom` insets (218) | The ticket says "inline/block"; a half-logical box model is worse than a fully logical one. `inset-inline-start` next to `top` is idiomatic, so insets stay physical |
 | D4 | `float: inline-start`? | No — keep physical, or replace the float with flex | Chrome 118 / Safari 16.4 is the only support floor above our baseline. 2 declarations, `_list-item-content.scss` |
-| D5 | Safe areas | Add `--os-safe-area-inline-start` / `-inline-end`, swapped once under `.is-rtl` | `env()` is physical; a variable remap keeps the theme invariant intact |
+| D5 | Safe areas | Out of scope — vars, properties and `.is-rtl` mirrors all left as they are | `env()` is physical, so a logical property reading it flips the side but not the value. Existing code already handles this correctly |
 | D6 | `border-radius` shorthands | Convert only when inline-asymmetric | `8px 8px 0 0` mirrors to itself |
 | D7 | Component CSS API naming | Axis suffixes (`-inline`, `-block`, `-inline-start`); no `-x` / `-y` / `-left` / `-right` | Mirror-correct by construction. Renames are breaking for apps setting them directly, so batch them in one PR and document them |
 | D8 | Vendor baselines | Never edited; mirror from the override file, lifting a `direction` pin there when needed | Existing rule (`.claude/rules/scss.md` §10) |

--- a/src/scss/00-abstract/_mixins.scss
+++ b/src/scss/00-abstract/_mixins.scss
@@ -43,7 +43,7 @@
 /// AppLogo
 @mixin app-logo {
 	border-radius: variables.$token-border-radius-100;
-	margin-right: variables.$token-scale-200;
+	margin-inline-end: variables.$token-scale-200;
 	max-height: var(--size-header);
 	max-width: 120px;
 }
@@ -58,7 +58,7 @@
 
 ///
 @mixin absolute-left-top($left: 0, $top: 0) {
-	left: $left;
+	inset-inline-start: $left;
 	position: absolute;
 	top: $top;
 }

--- a/src/scss/00-abstract/_setup-global-vars.scss
+++ b/src/scss/00-abstract/_setup-global-vars.scss
@@ -17,7 +17,15 @@ $footer-height: 0px;
 /* Build helpers — name lists iterated by @each for utility class generation    */
 /* ---------------------------------------------------------------------------- */
 $osui-devices: 'phone', 'tablet', 'desktop';
-$osui-box-sides: 'top', 'right', 'bottom', 'left';
+// Physical class-name suffix -> logical box side. The generated class names are public
+// API (`.margin-left-s`, `.border-top-m`) and keep their physical spelling; the property
+// they emit is logical, so the utilities mirror in RTL without an `.is-rtl` duplicate.
+$osui-box-sides: (
+	'top': 'block-start',
+	'right': 'inline-end',
+	'bottom': 'block-end',
+	'left': 'inline-start',
+);
 $osui-box-corners: 'top-left', 'top-right', 'bottom-right', 'bottom-left';
 $osui-border-radius-box-sides:
 	'top' 'left' 'right',

--- a/src/scss/01-foundations/_icon-library-o11.scss
+++ b/src/scss/01-foundations/_icon-library-o11.scss
@@ -136,6 +136,17 @@
 	}
 }
 
+// IsRTL — the chevron's base position is deliberately physical (right: 16px,
+// paired with a physical rotate), so it needs a hand-written mirror
+.is-rtl {
+	.dropdown-container {
+		&:after {
+			left: 16px;
+			right: auto;
+		}
+	}
+}
+
 // Table Widget - Sortable Icon
 .sortable-icon {
 	display: inline-block;

--- a/src/scss/01-foundations/_icon-library-o11.scss
+++ b/src/scss/01-foundations/_icon-library-o11.scss
@@ -86,8 +86,8 @@
 	&-container {
 		&:after {
 			border: variables.$token-border-size-050 solid variables.$token-primitives-neutral-700;
-			border-right: variables.$token-border-size-0 !important;
-			border-top: variables.$token-border-size-0 !important;
+			border-inline-end: variables.$token-border-size-0 !important;
+			border-block-start: variables.$token-border-size-0 !important;
 			bottom: 0;
 			box-sizing: border-box;
 			content: '';
@@ -116,8 +116,8 @@
 		&.dropdown-container {
 			&:after {
 				border: variables.$token-border-size-050 solid variables.$token-primitives-neutral-700;
-				border-right: variables.$token-border-size-0 !important;
-				border-top: variables.$token-border-size-0 !important;
+				border-inline-end: variables.$token-border-size-0 !important;
+				border-block-start: variables.$token-border-size-0 !important;
 				transform: rotate(-45deg) translateY(0) translateX(0);
 			}
 		}
@@ -133,40 +133,31 @@
 	}
 }
 
-.is-rtl {
-	.dropdown-container {
-		&:after {
-			left: 16px;
-			right: auto;
-		}
-	}
-}
-
 // Table Widget - Sortable Icon
 .sortable-icon {
 	display: inline-block;
 	height: 11px;
-	margin-left: variables.$token-scale-200;
+	margin-inline-start: variables.$token-scale-200;
 	position: relative;
 	width: 10px;
 
 	&:before,
 	&:after {
-		border-left: 4px solid transparent;
-		border-right: 4px solid transparent;
+		border-inline-start: 4px solid transparent;
+		border-inline-end: 4px solid transparent;
 		content: '';
-		left: 0;
+		inset-inline-start: 0;
 		position: absolute;
 	}
 
 	// currentColor keeps the arrow in lockstep with the header text color
 	// (default/hover/.sorted) without a separate state rule per color
 	&:before {
-		border-bottom: 4px solid currentColor;
+		border-block-end: 4px solid currentColor;
 	}
 
 	&:after {
-		border-top: 4px solid currentColor;
+		border-block-start: 4px solid currentColor;
 		bottom: 0;
 	}
 }

--- a/src/scss/01-foundations/_icon-library-o11.scss
+++ b/src/scss/01-foundations/_icon-library-o11.scss
@@ -86,8 +86,10 @@
 	&-container {
 		&:after {
 			border: variables.$token-border-size-050 solid variables.$token-primitives-neutral-700;
-			border-inline-end: variables.$token-border-size-0 !important;
-			border-block-start: variables.$token-border-size-0 !important;
+			// physical sides: these borders draw the chevron glyph under a physical
+			// rotate transform, and its position is deliberately physical (right: 16px)
+			border-right: variables.$token-border-size-0 !important;
+			border-top: variables.$token-border-size-0 !important;
 			bottom: 0;
 			box-sizing: border-box;
 			content: '';
@@ -116,8 +118,9 @@
 		&.dropdown-container {
 			&:after {
 				border: variables.$token-border-size-050 solid variables.$token-primitives-neutral-700;
-				border-inline-end: variables.$token-border-size-0 !important;
-				border-block-start: variables.$token-border-size-0 !important;
+				// physical sides: chevron glyph under a physical rotate (see above)
+				border-right: variables.$token-border-size-0 !important;
+				border-top: variables.$token-border-size-0 !important;
 				transform: rotate(-45deg) translateY(0) translateX(0);
 			}
 		}

--- a/src/scss/01-foundations/_icon-library-odc.scss
+++ b/src/scss/01-foundations/_icon-library-odc.scss
@@ -133,7 +133,7 @@ body.iconLibrary-phosphor {
 		color: variables.$token-icon-subtlest;
 		content: var(--osui-icon-search);
 		font-family: var(--osui-icon-font-family);
-		left: variables.$token-scale-400;
+		inset-inline-start: variables.$token-scale-400;
 		pointer-events: none;
 		position: absolute;
 		top: 50%;
@@ -141,19 +141,7 @@ body.iconLibrary-phosphor {
 	}
 
 	.form-control[data-input] {
-		padding-left: variables.$token-scale-1000;
-	}
-}
-
-.is-rtl .osui-search .osui-search__input > span {
-	&::after {
-		left: auto;
-		right: variables.$token-scale-400;
-	}
-
-	.form-control[data-input] {
-		padding-left: variables.$token-scale-400;
-		padding-right: variables.$token-scale-1000;
+		padding-inline-start: variables.$token-scale-1000;
 	}
 }
 
@@ -193,16 +181,11 @@ body.iconLibrary-phosphor {
 	line-height: 1;
 	pointer-events: none;
 	position: absolute;
-	right: variables.$token-scale-400;
+	inset-inline-end: variables.$token-scale-400;
 	top: 50%;
 	transform: translateY(-50%);
 	transition: transform 200ms ease;
 	width: var(--osui-dropdown-arrow-size, #{variables.$token-scale-400});
-}
-
-.is-rtl .dropdown-container:after {
-	left: variables.$token-scale-400;
-	right: auto;
 }
 
 .dropdown-expanded.dropdown-container {
@@ -228,7 +211,7 @@ body.iconLibrary-phosphor {
 	height: 11px;
 	justify-content: center;
 	line-height: 0.5; // compress each glyph's line-box so the up/down chevrons stack without overlapping
-	margin-left: variables.$token-scale-200;
+	margin-inline-start: variables.$token-scale-200;
 	position: relative;
 	vertical-align: middle;
 	width: 10px;
@@ -264,7 +247,7 @@ body.iconLibrary-phosphor {
 			font-family: var(--osui-icon-font-family);
 			font-size: 24px;
 			height: 100%;
-			left: 0;
+			inset-inline-start: 0;
 			line-height: 1;
 			position: absolute;
 			top: 0;
@@ -319,7 +302,7 @@ body.iconLibrary-phosphor {
 			content: var(--osui-icon-sent);
 			position: absolute;
 			top: 0;
-			left: 0;
+			inset-inline-start: 0;
 			font-family: var(--osui-icon-font-family);
 		}
 
@@ -335,7 +318,7 @@ body.iconLibrary-phosphor {
 			&:after {
 				content: var(--osui-icon-time);
 				font-family: var(--osui-icon-font-family);
-				left: 0;
+				inset-inline-start: 0;
 				position: absolute;
 				top: 0;
 			}
@@ -382,12 +365,7 @@ body.iconLibrary-phosphor {
 	font-size: variables.$token-font-size-300;
 	line-height: 1;
 	display: flex;
-	left: 1px;
-}
-
-.is-rtl .vscomp-wrapper.multiple .vscomp-option.selected .checkbox-icon:after {
-	left: auto;
-	right: 1px;
+	inset-inline-start: 1px;
 }
 
 .osui-dropdown-search {
@@ -507,6 +485,21 @@ body.iconLibrary-phosphor {
 	color: variables.$token-primitives-neutral-1000;
 }
 
+// Splide swaps the arrow BUTTONS when it runs RTL (`.splide__arrows--rtl`), but the glyph
+// is `content` on ::after and does not follow — leaving both arrows pointing inward.
+// Swap the glyphs to match the buttons.
+.splide--rtl {
+	.splide__arrow--next:after {
+		content: var(--osui-icon-chevron-left);
+		transform: translateX(-1px);
+	}
+
+	.splide__arrow--prev:after {
+		content: var(--osui-icon-chevron-right);
+		transform: translateX(1px);
+	}
+}
+
 .splide__arrow--next:after {
 	content: var(--osui-icon-chevron-right);
 	transform: translateX(1px);
@@ -620,12 +613,12 @@ body.iconLibrary-phosphor {
 
 .pswp__button--arrow--right:before {
 	content: var(--osui-icon-arrow-next);
-	right: variables.$token-scale-100;
+	inset-inline-end: variables.$token-scale-100;
 }
 
 .pswp__button--arrow--left:before {
 	content: var(--osui-icon-arrow-previous);
-	left: variables.$token-scale-100;
+	inset-inline-start: variables.$token-scale-100;
 }
 
 // Password Policy
@@ -638,7 +631,7 @@ body.iconLibrary-phosphor {
 		content: var(--osui-icon-circle-x);
 		font-family: var(--osui-icon-font-family);
 		top: 0;
-		left: 0;
+		inset-inline-start: 0;
 	}
 
 	&.is-valid::after {

--- a/src/scss/01-foundations/_resets.scss
+++ b/src/scss/01-foundations/_resets.scss
@@ -93,7 +93,7 @@ body {
 /* ============================================================================ */
 ///
 abbr[title] {
-	border-bottom: 0;
+	border-block-end: 0;
 	text-decoration: underline;
 }
 
@@ -116,7 +116,7 @@ label {
 ///
 [data-label].mandatory:after {
 	color: variables.$token-semantics-danger-base;
-	margin-left: variables.$token-scale-100;
+	margin-inline-start: variables.$token-scale-100;
 }
 
 /* ============================================================================ */

--- a/src/scss/01-foundations/_root.scss
+++ b/src/scss/01-foundations/_root.scss
@@ -104,10 +104,6 @@
 	--os-safe-area-right: #{safe-area(right)};
 	--os-safe-area-bottom: #{safe-area(bottom)};
 	--os-safe-area-left: #{safe-area(left)};
-	// env() is physical and has no logical form, so the inline pair is remapped by
-	// direction below. Components read only these two, never -left / -right.
-	--os-safe-area-inline-start: var(--os-safe-area-left);
-	--os-safe-area-inline-end: var(--os-safe-area-right);
 
 	// ─── Theme layer · z-index system ────────────────────────────────────
 	--layer-system-scale: 100;
@@ -132,13 +128,4 @@
 	--osui-popup-layer: var(--layer-global-off-canvas);
 	--osui-sidebar-layer: var(--layer-global-off-canvas);
 	--osui-menu-layer: calc(var(--layer-global-navigation) + var(--layer-local-tier-2));
-}
-
-/* ============================================================================ */
-/* Safe areas · inline axis follows the reading direction                       */
-/* ============================================================================ */
-///
-.is-rtl {
-	--os-safe-area-inline-start: var(--os-safe-area-right);
-	--os-safe-area-inline-end: var(--os-safe-area-left);
 }

--- a/src/scss/01-foundations/_root.scss
+++ b/src/scss/01-foundations/_root.scss
@@ -104,6 +104,10 @@
 	--os-safe-area-right: #{safe-area(right)};
 	--os-safe-area-bottom: #{safe-area(bottom)};
 	--os-safe-area-left: #{safe-area(left)};
+	// env() is physical and has no logical form, so the inline pair is remapped by
+	// direction below. Components read only these two, never -left / -right.
+	--os-safe-area-inline-start: var(--os-safe-area-left);
+	--os-safe-area-inline-end: var(--os-safe-area-right);
 
 	// ─── Theme layer · z-index system ────────────────────────────────────
 	--layer-system-scale: 100;
@@ -128,4 +132,13 @@
 	--osui-popup-layer: var(--layer-global-off-canvas);
 	--osui-sidebar-layer: var(--layer-global-off-canvas);
 	--osui-menu-layer: calc(var(--layer-global-navigation) + var(--layer-local-tier-2));
+}
+
+/* ============================================================================ */
+/* Safe areas · inline axis follows the reading direction                       */
+/* ============================================================================ */
+///
+.is-rtl {
+	--os-safe-area-inline-start: var(--os-safe-area-right);
+	--os-safe-area-inline-end: var(--os-safe-area-left);
 }

--- a/src/scss/02-layout/_content.scss
+++ b/src/scss/02-layout/_content.scss
@@ -13,7 +13,7 @@
 	position: relative;
 
 	&-breadcrumbs {
-		margin-bottom: variables.$token-scale-400;
+		margin-block-end: variables.$token-scale-400;
 	}
 
 	&-top {
@@ -21,7 +21,7 @@
 
 		&-title {
 			flex: 1;
-			margin-bottom: variables.$token-scale-800;
+			margin-block-end: variables.$token-scale-800;
 
 			// Retro Compatilibity
 			.Title_Links {
@@ -33,8 +33,8 @@
 		&-actions {
 			flex: 1;
 			justify-content: flex-end;
-			margin-bottom: variables.$token-scale-800;
-			text-align: right;
+			margin-block-end: variables.$token-scale-800;
+			text-align: end;
 		}
 
 		&-title,

--- a/src/scss/02-layout/_header-layout-native.scss
+++ b/src/scss/02-layout/_header-layout-native.scss
@@ -18,7 +18,8 @@
 		top: 0;
 
 		&-top {
-			padding: 0 variables.$token-scale-800;
+			padding-block: 0;
+			padding-inline: variables.$token-scale-800;
 		}
 
 		&-title {
@@ -34,15 +35,15 @@
 
 		&-left {
 			flex: 1;
-			margin-right: variables.$token-scale-400;
+			margin-inline-end: variables.$token-scale-400;
 		}
 
 		&-right {
 			display: flex;
 			flex: 1;
 			justify-content: flex-end;
-			margin-left: variables.$token-scale-400;
-			margin-right: auto;
+			margin-inline-start: variables.$token-scale-400;
+			margin-inline-end: auto;
 
 			// ServiceStudio Preview
 			& {
@@ -67,7 +68,7 @@
 	}
 
 	.menu-icon {
-		margin-right: 0;
+		margin-inline-end: 0;
 	}
 }
 
@@ -77,8 +78,8 @@
 		.header,
 		&:not(.blank) .main-content,
 		.bottom-bar-wrapper {
-			padding-left: var(--os-safe-area-left);
-			padding-right: var(--os-safe-area-right);
+			padding-inline-start: var(--os-safe-area-inline-start);
+			padding-inline-end: var(--os-safe-area-inline-end);
 		}
 	}
 }
@@ -89,7 +90,8 @@
 .phone {
 	.layout-native {
 		.header-top {
-			padding: 0 variables.$token-scale-600;
+			padding-block: 0;
+			padding-inline: variables.$token-scale-600;
 		}
 	}
 }
@@ -121,9 +123,9 @@
 
 		.header,
 		.app-menu-content {
-			padding-top: #{android-safe-area-top()};
-			padding-right: var(--safe-area-inset-right, 0px);
-			padding-left: var(--safe-area-inset-left, 0px);
+			padding-block-start: #{android-safe-area-top()};
+			padding-inline-end: var(--safe-area-inset-right, 0px);
+			padding-inline-start: var(--safe-area-inset-left, 0px);
 		}
 	}
 }
@@ -131,22 +133,6 @@
 ///
 .ios {
 	.layout-native .header {
-		padding-top: var(--os-safe-area-top);
-	}
-}
-
-// IsRTL -------------------------------------------------------------------------
-///
-.is-rtl {
-	.layout-native {
-		.header-left {
-			margin-left: variables.$token-scale-400;
-			margin-right: 0;
-		}
-
-		.header-right {
-			margin-left: auto;
-			margin-right: variables.$token-scale-400;
-		}
+		padding-block-start: var(--os-safe-area-top);
 	}
 }

--- a/src/scss/02-layout/_header-layout-native.scss
+++ b/src/scss/02-layout/_header-layout-native.scss
@@ -78,8 +78,8 @@
 		.header,
 		&:not(.blank) .main-content,
 		.bottom-bar-wrapper {
-			padding-inline-start: var(--os-safe-area-inline-start);
-			padding-inline-end: var(--os-safe-area-inline-end);
+			padding-left: var(--os-safe-area-left);
+			padding-right: var(--os-safe-area-right);
 		}
 	}
 }
@@ -133,6 +133,6 @@
 ///
 .ios {
 	.layout-native .header {
-		padding-block-start: var(--os-safe-area-top);
+		padding-top: var(--os-safe-area-top);
 	}
 }

--- a/src/scss/02-layout/_header-layout-side.scss
+++ b/src/scss/02-layout/_header-layout-side.scss
@@ -9,19 +9,19 @@
 		&.aside {
 			&-expandable {
 				.header {
-					left: 0;
+					inset-inline-start: 0;
 				}
 			}
 
 			&-overlay {
 				.header {
-					left: 0;
+					inset-inline-start: 0;
 				}
 			}
 		}
 
 		.header {
-			left: var(--size-side-menu);
+			inset-inline-start: var(--size-side-menu);
 		}
 	}
 
@@ -31,16 +31,16 @@
 
 	.aside-expandable {
 		&:not(.fixed-header) .main .header {
-			margin-left: calc(var(--size-side-menu) * -1);
+			margin-inline-start: calc(var(--size-side-menu) * -1);
 		}
 
 		&.menu-visible {
 			&:not(.fixed-header) .main .header {
-				margin-left: 0;
+				margin-inline-start: 0;
 			}
 
 			.header {
-				left: 0;
+				inset-inline-start: 0;
 			}
 		}
 	}
@@ -56,7 +56,7 @@
 .desktop {
 	.layout-side.layout-native.aside-expandable {
 		.header {
-			margin-left: 0;
+			margin-inline-start: 0;
 		}
 	}
 
@@ -73,12 +73,12 @@
 	.layout-side {
 		&.aside-expandable:not(.fixed-header) {
 			.main .header {
-				margin-left: 0;
+				margin-inline-start: 0;
 			}
 		}
 
 		&.fixed-header .header {
-			left: 0;
+			inset-inline-start: 0;
 		}
 	}
 }
@@ -96,34 +96,5 @@
 .phone {
 	.layout-side.layout-native.aside-expandable .main .header {
 		z-index: var(--layer-global-navigation);
-	}
-}
-
-// IsRTL -------------------------------------------------------------------------
-///
-.is-rtl {
-	&.tablet,
-	&.phone {
-		left: 0;
-		right: 0;
-	}
-
-	.layout-side {
-		&.fixed-header {
-			&.aside-expandable .header {
-				left: 0;
-				right: 0;
-			}
-
-			.header {
-				left: 0;
-				right: var(--size-side-menu);
-			}
-		}
-	}
-
-	.aside-expandable.menu-visible .header {
-		left: 0;
-		right: 0;
 	}
 }

--- a/src/scss/02-layout/_header.scss
+++ b/src/scss/02-layout/_header.scss
@@ -22,7 +22,7 @@
 	}
 
 	&-logo {
-		padding-right: variables.$token-scale-400;
+		padding-inline-end: variables.$token-scale-400;
 
 		.application-name {
 			word-break: break-word;
@@ -37,7 +37,7 @@
 		height: 100%;
 
 		& > [data-block*='ApplicationTitle'] .application-name {
-			margin-right: variables.$token-scale-600;
+			margin-inline-end: variables.$token-scale-600;
 		}
 	}
 
@@ -49,10 +49,10 @@
 ///
 .fixed-header {
 	.header {
-		left: 0;
+		inset-inline-start: 0;
 		position: -webkit-sticky; //Fix for older iPhones
 		position: sticky;
-		right: 0;
+		inset-inline-end: 0;
 		top: 0;
 	}
 }
@@ -110,37 +110,10 @@
 .phone {
 	.layout-top .header-navigation {
 		height: 100vh;
-		left: 0;
+		inset-inline-start: 0;
 		position: fixed;
 		top: 0;
 		z-index: var(--layer-global-navigation);
-	}
-}
-
-// IsRTL -------------------------------------------------------------------------
-///
-.is-rtl {
-	.header {
-		&-logo {
-			padding-left: variables.$token-scale-400;
-			padding-right: 0;
-		}
-
-		.header-content > [data-block*='ApplicationTitle'] .application-name {
-			margin-right: 0;
-			margin-left: variables.$token-scale-600;
-		}
-	}
-
-	.app-logo,
-	.layout-side .app-logo {
-		margin-left: variables.$token-scale-200;
-		margin-right: 0;
-	}
-
-	.menu-icon {
-		margin-left: variables.$token-scale-600;
-		margin-right: 0;
 	}
 }
 

--- a/src/scss/02-layout/_layout.scss
+++ b/src/scss/02-layout/_layout.scss
@@ -40,11 +40,11 @@ body,
 
 		&-side {
 			.main {
-				margin-left: var(--size-side-menu);
+				margin-inline-start: var(--size-side-menu);
 			}
 
 			&.aside-overlay .main {
-				margin-left: 0;
+				margin-inline-start: 0;
 			}
 		}
 
@@ -62,7 +62,7 @@ body,
 
 	&.aside-expandable {
 		.main {
-			margin-left: 0;
+			margin-inline-start: 0;
 		}
 	}
 
@@ -75,7 +75,7 @@ body,
 
 .main,
 .fixed-header .main {
-	padding-top: 0;
+	padding-block-start: 0;
 }
 
 ///
@@ -110,7 +110,7 @@ body,
 		}
 
 		.header {
-			padding-top: var(--os-safe-area-top);
+			padding-block-start: var(--os-safe-area-top);
 		}
 	}
 }
@@ -152,7 +152,7 @@ body,
 					&-visible,
 					&-expandable {
 						.main {
-							margin-left: var(--size-side-menu);
+							margin-inline-start: var(--size-side-menu);
 							width: calc(100% - var(--size-side-menu));
 						}
 					}
@@ -162,11 +162,11 @@ body,
 
 		.layout-side.layout-native.aside-expandable {
 			&.menu-visible .main {
-				margin-left: var(--size-side-menu);
+				margin-inline-start: var(--size-side-menu);
 			}
 
 			.main {
-				margin-right: 0;
+				margin-inline-end: 0;
 			}
 		}
 	}
@@ -176,72 +176,16 @@ body,
 .tablet,
 .phone {
 	.layout-side .main {
-		margin-left: 0;
+		margin-inline-start: 0;
 	}
 }
 
 ///
 .phone {
 	.layout:not(.layout-native) [class*='ThemeGrid_Width']:not(.no-responsive) {
-		margin: variables.$token-scale-0 variables.$token-scale-0 variables.$token-scale-400 variables.$token-scale-0;
+		margin-block: variables.$token-scale-0 variables.$token-scale-400;
+		margin-inline: variables.$token-scale-0;
 		width: 100%;
-	}
-}
-
-// IsRTL -------------------------------------------------------------------------
-///
-.is-rtl {
-	&.tablet {
-		.layout-native {
-			&.aside {
-				&-visible,
-				&-expandable {
-					.main {
-						margin-left: 0;
-					}
-				}
-			}
-		}
-
-		.layout-side .main {
-			margin-right: 0;
-		}
-
-		&.landscape {
-			.layout-side.layout-native.aside-expandable {
-				&.menu-visible .main {
-					margin-left: 0;
-					margin-right: var(--size-side-menu);
-				}
-
-				.main {
-					margin-right: 0;
-				}
-			}
-		}
-	}
-
-	&.phone {
-		.layout-side .main {
-			margin-right: 0;
-		}
-	}
-
-	.layout-side {
-		.main {
-			margin-left: 0;
-			margin-right: var(--size-side-menu);
-		}
-
-		&.aside-overlay .main {
-			margin-right: 0;
-		}
-	}
-
-	.aside-expandable {
-		.main {
-			margin-right: 0;
-		}
 	}
 }
 

--- a/src/scss/02-layout/_layout.scss
+++ b/src/scss/02-layout/_layout.scss
@@ -138,7 +138,7 @@ body,
 		}
 
 		.header {
-			padding-block-start: var(--os-safe-area-top);
+			padding-top: var(--os-safe-area-top);
 		}
 	}
 }

--- a/src/scss/02-layout/_login.scss
+++ b/src/scss/02-layout/_login.scss
@@ -38,9 +38,8 @@
 	.login {
 		&-screen {
 			background-color: var(--background-color-login, var(--color-background-login));
-			padding-block: var(--os-safe-area-top) var(--os-safe-area-bottom);
-			padding-inline-end: var(--os-safe-area-inline-end);
-			padding-inline-start: var(--os-safe-area-inline-start);
+			padding: var(--os-safe-area-top) var(--os-safe-area-right) var(--os-safe-area-bottom)
+				var(--os-safe-area-left);
 		}
 
 		&-form {
@@ -88,7 +87,7 @@
 			}
 
 			&-button .btn {
-				padding-block-end: var(--os-safe-area-bottom);
+				padding-bottom: var(--os-safe-area-bottom);
 			}
 		}
 

--- a/src/scss/02-layout/_login.scss
+++ b/src/scss/02-layout/_login.scss
@@ -38,8 +38,9 @@
 	.login {
 		&-screen {
 			background-color: var(--background-color-login, var(--color-background-login));
-			padding: var(--os-safe-area-top) var(--os-safe-area-right) var(--os-safe-area-bottom)
-				var(--os-safe-area-left);
+			padding-block: var(--os-safe-area-top) var(--os-safe-area-bottom);
+			padding-inline-end: var(--os-safe-area-inline-end);
+			padding-inline-start: var(--os-safe-area-inline-start);
 		}
 
 		&-form {
@@ -63,16 +64,17 @@
 // Responsive --------------------------------------------------------------------
 ///
 .android .layout-native .login-screen {
-	padding-top: #{android-safe-area-top()};
-	padding-bottom: var(--safe-area-inset-bottom, 0px);
-	padding-left: var(--safe-area-inset-left, 0px);
-	padding-right: var(--safe-area-inset-right, 0px);
+	padding-block-start: #{android-safe-area-top()};
+	padding-block-end: var(--safe-area-inset-bottom, 0px);
+	padding-inline-start: var(--safe-area-inset-left, 0px);
+	padding-inline-end: var(--safe-area-inset-right, 0px);
 }
 
 ///
 .phone {
 	.login-form {
-		margin: variables.$token-scale-0 variables.$token-scale-400;
+		margin-block: variables.$token-scale-0;
+		margin-inline: variables.$token-scale-400;
 		min-width: auto;
 		padding: variables.$token-scale-800;
 		width: 100%;
@@ -86,12 +88,12 @@
 			}
 
 			&-button .btn {
-				padding-bottom: var(--os-safe-area-bottom);
+				padding-block-end: var(--os-safe-area-bottom);
 			}
 		}
 
 		&.blank .login-button .btn {
-			padding-bottom: variables.$token-scale-0;
+			padding-block-end: variables.$token-scale-0;
 		}
 	}
 }

--- a/src/scss/02-layout/_menu-app-login-info.scss
+++ b/src/scss/02-layout/_menu-app-login-info.scss
@@ -8,7 +8,8 @@
 ///
 .layout-side {
 	.app-login-info {
-		padding: variables.$token-scale-400 variables.$token-scale-600;
+		padding-block: variables.$token-scale-400;
+		padding-inline: variables.$token-scale-600;
 	}
 
 	.user-info {
@@ -20,7 +21,8 @@
 .tablet,
 .phone {
 	.app-login-info {
-		padding: variables.$token-scale-400 variables.$token-scale-600;
+		padding-block: variables.$token-scale-400;
+		padding-inline: variables.$token-scale-600;
 	}
 
 	.user-info {

--- a/src/scss/02-layout/_menu-app-menu-links.scss
+++ b/src/scss/02-layout/_menu-app-menu-links.scss
@@ -138,7 +138,7 @@ body {
 .landscape {
 	.layout-native {
 		.app-menu-links {
-			padding-inline-start: calc(var(--os-safe-area-inline-start) / 2);
+			padding-left: calc(var(--os-safe-area-left) / 2);
 		}
 	}
 }

--- a/src/scss/02-layout/_menu-app-menu-links.scss
+++ b/src/scss/02-layout/_menu-app-menu-links.scss
@@ -13,8 +13,8 @@
 	// Service Studio Preview
 	& {
 		-servicestudio-align-items: center;
-		-servicestudio-display: flex;
 		-servicestudio-column-gap: variables.$token-scale-600;
+		-servicestudio-display: flex;
 	}
 
 	// Service Studio Preview
@@ -79,12 +79,12 @@ body {
 	.app-menu-links {
 		a {
 			align-items: center;
-			border-bottom: variables.$token-border-size-050 solid transparent;
-			border-top: variables.$token-border-size-050 solid transparent;
+			border-block-end: variables.$token-border-size-050 solid transparent;
+			border-block-start: variables.$token-border-size-050 solid transparent;
 			display: inline-flex;
 
 			&.active {
-				border-bottom: variables.$token-border-size-050 solid transparent;
+				border-block-end: variables.$token-border-size-050 solid transparent;
 			}
 		}
 	}
@@ -95,12 +95,13 @@ body {
 .menu-visible {
 	.app-menu-links {
 		a {
-			border-bottom: 0;
-			border-left: 0;
+			border-block-end: 0;
+			border-block-start: 0;
+			border-inline-start: 0;
 			border-radius: variables.$token-border-radius-200;
-			border-top: 0;
-			margin-left: 0;
-			padding: variables.$token-scale-200 variables.$token-scale-400;
+			margin-inline-start: 0;
+			padding-block: variables.$token-scale-200;
+			padding-inline: variables.$token-scale-400;
 		}
 	}
 }
@@ -127,7 +128,7 @@ body {
 
 	> a.active {
 		background-color: variables.$token-bg-primary-subtle-default;
-		border-left: 0;
+		border-inline-start: 0;
 		border-radius: variables.$token-border-radius-200;
 	}
 }
@@ -137,7 +138,7 @@ body {
 .landscape {
 	.layout-native {
 		.app-menu-links {
-			padding-left: calc(var(--os-safe-area-left) / 2);
+			padding-inline-start: calc(var(--os-safe-area-inline-start) / 2);
 		}
 	}
 }
@@ -154,9 +155,9 @@ body {
 .phone,
 .tablet {
 	.app-menu-links {
+		-webkit-overflow-scrolling: touch;
 		display: flex;
 		flex-direction: column;
-		-webkit-overflow-scrolling: touch;
 		overflow-y: auto;
 		padding: variables.$token-scale-200;
 		width: 100%;
@@ -172,7 +173,7 @@ body {
 	}
 
 	.layout:not(.layout-side) .app-menu-links a.active {
-		border-bottom: 0;
+		border-block-end: 0;
 	}
 }
 

--- a/src/scss/02-layout/_menu-header-logo.scss
+++ b/src/scss/02-layout/_menu-header-logo.scss
@@ -9,7 +9,8 @@
 .layout-side {
 	.header-logo {
 		height: var(--size-header);
-		padding: variables.$token-scale-0 variables.$token-scale-600;
+		padding-block: variables.$token-scale-0;
+		padding-inline: variables.$token-scale-600;
 	}
 }
 
@@ -18,6 +19,7 @@
 .phone {
 	.header-logo {
 		height: var(--size-header);
-		padding: variables.$token-scale-0 variables.$token-scale-600;
+		padding-block: variables.$token-scale-0;
+		padding-inline: variables.$token-scale-600;
 	}
 }

--- a/src/scss/02-layout/_menu-layout-native.scss
+++ b/src/scss/02-layout/_menu-layout-native.scss
@@ -37,7 +37,7 @@
 			&.layout-side {
 				&.aside-expandable {
 					.app-menu-content {
-						padding-block-start: calc(var(--size-header) + var(--size-header-content) + var(--os-safe-area-top));
+						padding-top: calc(var(--size-header) + var(--size-header-content) + var(--os-safe-area-top));
 					}
 
 					&.hide-header-on-scroll:not(.header-is--visible) {
@@ -103,7 +103,7 @@
 			&.layout-side {
 				&.aside-expandable {
 					.app-menu-content {
-						padding-block-start: calc(var(--size-header) + var(--size-header-content) + var(--os-safe-area-top));
+						padding-top: calc(var(--size-header) + var(--size-header-content) + var(--os-safe-area-top));
 					}
 				}
 			}

--- a/src/scss/02-layout/_menu-layout-native.scss
+++ b/src/scss/02-layout/_menu-layout-native.scss
@@ -21,8 +21,8 @@
 			background: transparent;
 			content: '';
 			height: 100%;
+			inset-inline-end: -24px;
 			position: absolute;
-			right: -24px;
 			top: calc(var(--size-header) + var(--size-header-content));
 			width: variables.$token-scale-600;
 		}
@@ -37,12 +37,12 @@
 			&.layout-side {
 				&.aside-expandable {
 					.app-menu-content {
-						padding-top: calc(var(--size-header) + var(--size-header-content) + var(--os-safe-area-top));
+						padding-block-start: calc(var(--size-header) + var(--size-header-content) + var(--os-safe-area-top));
 					}
 
 					&.hide-header-on-scroll:not(.header-is--visible) {
 						.app-menu-content {
-							padding-top: var(--size-header-content);
+							padding-block-start: var(--size-header-content);
 						}
 					}
 				}
@@ -72,9 +72,7 @@
 				&.layout-side {
 					&.aside-expandable {
 						.app-menu-content {
-							padding-top: calc(
-								var(--size-header) + var(--size-header-content) + #{android-safe-area-top()}
-							);
+							padding-block-start: calc( var(--size-header) + var(--size-header-content) + #{android-safe-area-top()} );
 						}
 					}
 				}
@@ -96,7 +94,7 @@
 				&-expandable {
 					.app-menu-content {
 						box-shadow: variables.$token-elevation-2;
-						left: 0;
+						inset-inline-start: 0;
 						z-index: var(--osui-menu-layer);
 					}
 				}
@@ -105,7 +103,7 @@
 			&.layout-side {
 				&.aside-expandable {
 					.app-menu-content {
-						padding-top: calc(var(--size-header) + var(--size-header-content) + var(--os-safe-area-top));
+						padding-block-start: calc(var(--size-header) + var(--size-header-content) + var(--os-safe-area-top));
 					}
 				}
 			}
@@ -113,26 +111,7 @@
 
 		.layout-side.layout-native.aside-expandable.hide-header-on-scroll:not(.header-is--visible) {
 			.app-menu-content {
-				padding-top: var(--size-header-content);
-			}
-		}
-	}
-}
-
-// IsRTL -------------------------------------------------------------------------
-///
-.is-rtl {
-	.tablet {
-		&.landscape {
-			&.landscape {
-				&.aside {
-					&-visible,
-					&-expandable {
-						.app-menu-content {
-							right: 0;
-						}
-					}
-				}
+				padding-block-start: var(--size-header-content);
 			}
 		}
 	}

--- a/src/scss/02-layout/_menu-layout-side.scss
+++ b/src/scss/02-layout/_menu-layout-side.scss
@@ -54,13 +54,13 @@
 .desktop {
 	.layout-side {
 		&:not(.layout-native):not(.aside-overlay) .app-menu-content {
-			left: 0;
-			right: 0;
+			inset-inline-end: 0;
+			inset-inline-start: 0;
 			transform: none;
 		}
 
 		&.aside-expandable:not(.fixed-header) .app-menu-content {
-			padding-top: var(--size-header);
+			padding-block-start: var(--size-header);
 			top: 0;
 		}
 	}
@@ -72,7 +72,7 @@
 			}
 
 			.main {
-				margin-left: var(--size-side-menu);
+				margin-inline-start: var(--size-side-menu);
 			}
 		}
 
@@ -94,38 +94,16 @@
 	}	
 }
 
-
 // IsRTL -------------------------------------------------------------------------
 ///
 .is-rtl {
-	&.desktop {
-		.aside-expandable.menu-visible {
-			.main {
-				margin-left: 0;
-				margin-right: var(--size-side-menu);
-			}
-		}
-	}
-	.layout-side .app-menu-content {
-		left: auto;
-	}
 
 	.app-menu-content {
-		right: calc(-1 * var(--size-side-menu));
 		transition: transform 330ms ease-in;
 	}
 
 	.app-menu-content.is--open {
-		right: 0;
 		transform: translateX(0) translateZ(0);
 		transition: transform 130ms ease-out;
-	}
-
-	&:not(.portrait) {
-		.layout-side.layout-native.aside-visible {
-			.app-menu-content {
-				right: 0;
-			}
-		}
 	}
 }

--- a/src/scss/02-layout/_menu.scss
+++ b/src/scss/02-layout/_menu.scss
@@ -32,7 +32,7 @@
 .app-menu-overlay {
 	background-color: variables.$token-backdrop;
 	height: 100vh;
-	left: 0;
+	inset-inline-start: 0;
 	opacity: 0;
 	pointer-events: none;
 	position: fixed;
@@ -153,7 +153,7 @@
 	.app-menu-content {
 		&,
 		&.is--open {
-			left: 0;
+			inset-inline-start: 0;
 		}
 	}
 }
@@ -162,7 +162,8 @@
 .tablet,
 .phone {
 	.app-login-info {
-		padding: variables.$token-scale-200 variables.$token-scale-600;
+		padding-block: variables.$token-scale-200;
+		padding-inline: variables.$token-scale-600;
 	}
 
 	.app-menu-content {
@@ -199,8 +200,8 @@
 ///
 .phone {
 	.app-menu-content {
-		padding-bottom: var(--os-safe-area-bottom);
-		padding-left: var(--os-safe-area-left);
+		padding-block-end: var(--os-safe-area-bottom);
+		padding-inline-start: var(--os-safe-area-inline-start);
 	}
 }
 
@@ -208,16 +209,16 @@
 .android {
 	&.portrait {
 		.app-menu-content {
-			padding-top: #{android-safe-area-top()};
+			padding-block-start: #{android-safe-area-top()};
 		}
 	}
 
 	&.landscape {
 		.app-menu-content {
-			padding-left: max(var(--os-safe-area-left), var(--safe-area-status-bar, 0px));
-			padding-right: max(var(--os-safe-area-right), 0px);
-			padding-top: var(--safe-area-inset-top, 0px);
-			padding-bottom: var(--safe-area-inset-bottom, 0px);
+			padding-inline-start: max(var(--os-safe-area-inline-start), var(--safe-area-status-bar, 0px));
+			padding-inline-end: max(var(--os-safe-area-inline-end), 0px);
+			padding-block-start: var(--safe-area-inset-top, 0px);
+			padding-block-end: var(--safe-area-inset-bottom, 0px);
 		}
 	}
 }
@@ -225,8 +226,8 @@
 ///
 .ios {
 	.app-menu-content {
-		padding-bottom: var(--os-safe-area-bottom);
-		padding-top: var(--os-safe-area-top);
+		padding-block-end: var(--os-safe-area-bottom);
+		padding-block-start: var(--os-safe-area-top);
 	}
 }
 
@@ -234,14 +235,10 @@
 ///
 .is-rtl {
 	.app-menu-content {
-		left: auto;
-		right: calc(-1 * var(--size-side-menu));
 		transition: transform 130ms ease-in;
 	}
 
 	.app-menu-content.is--open {
-		left: auto;
-		right: 0;
 		transform: translateX(0) translateZ(0);
 		transition: transform 130ms ease-out;
 	}

--- a/src/scss/02-layout/_menu.scss
+++ b/src/scss/02-layout/_menu.scss
@@ -200,8 +200,8 @@
 ///
 .phone {
 	.app-menu-content {
-		padding-block-end: var(--os-safe-area-bottom);
-		padding-inline-start: var(--os-safe-area-inline-start);
+		padding-bottom: var(--os-safe-area-bottom);
+		padding-left: var(--os-safe-area-left);
 	}
 }
 
@@ -215,8 +215,8 @@
 
 	&.landscape {
 		.app-menu-content {
-			padding-inline-start: max(var(--os-safe-area-inline-start), var(--safe-area-status-bar, 0px));
-			padding-inline-end: max(var(--os-safe-area-inline-end), 0px);
+			padding-left: max(var(--os-safe-area-left), var(--safe-area-status-bar, 0px));
+			padding-right: max(var(--os-safe-area-right), 0px);
 			padding-block-start: var(--safe-area-inset-top, 0px);
 			padding-block-end: var(--safe-area-inset-bottom, 0px);
 		}
@@ -226,8 +226,8 @@
 ///
 .ios {
 	.app-menu-content {
-		padding-block-end: var(--os-safe-area-bottom);
-		padding-block-start: var(--os-safe-area-top);
+		padding-bottom: var(--os-safe-area-bottom);
+		padding-top: var(--os-safe-area-top);
 	}
 }
 

--- a/src/scss/02-layout/_section.scss
+++ b/src/scss/02-layout/_section.scss
@@ -11,7 +11,8 @@
 	position: relative;
 
 	.ThemeGrid_Container {
-		padding: variables.$token-scale-0 variables.$token-scale-1000;
+		padding-block: variables.$token-scale-0;
+		padding-inline: variables.$token-scale-1000;
 	}
 }
 

--- a/src/scss/02-layout/_themegrid-container.scss
+++ b/src/scss/02-layout/_themegrid-container.scss
@@ -7,14 +7,16 @@
 
 ///
 .ThemeGrid_Container {
-	margin: variables.$token-scale-0 auto;
+	margin-block: variables.$token-scale-0;
+	margin-inline: auto;
 	width: 100%;
 }
 
 ///
 .header {
 	.ThemeGrid_Container {
-		padding: variables.$token-scale-0 variables.$token-scale-1000;
+		padding-block: variables.$token-scale-0;
+		padding-inline: variables.$token-scale-1000;
 	}
 }
 
@@ -25,7 +27,8 @@
 	}
 
 	.footer.ThemeGrid_Container {
-		padding: variables.$token-scale-400 variables.$token-scale-1000;
+		padding-block: variables.$token-scale-400;
+		padding-inline: variables.$token-scale-1000;
 	}
 }
 
@@ -35,7 +38,8 @@
 .tablet {
 	.header {
 		.ThemeGrid_Container {
-			padding: variables.$token-scale-0 variables.$token-scale-600;
+			padding-block: variables.$token-scale-0;
+			padding-inline: variables.$token-scale-600;
 		}
 	}
 
@@ -44,7 +48,8 @@
 	}
 
 	.footer.ThemeGrid_Container {
-		padding: variables.$token-scale-400 variables.$token-scale-600;
+		padding-block: variables.$token-scale-400;
+		padding-inline: variables.$token-scale-600;
 	}
 }
 
@@ -52,21 +57,21 @@
 .phone {
 	.header {
 		.ThemeGrid_Container {
-			padding-left: calc(var(--os-safe-area-left) + variables.$token-scale-400);
-			padding-right: calc(var(--os-safe-area-right) + variables.$token-scale-400);
+			padding-inline-end: calc(var(--os-safe-area-inline-end) + variables.$token-scale-400);
+			padding-inline-start: calc(var(--os-safe-area-inline-start) + variables.$token-scale-400);
 		}
 	}
 
 	.main-content.ThemeGrid_Container {
-		padding-bottom: variables.$token-scale-400;
-		padding-left: calc(var(--os-safe-area-left) + variables.$token-scale-400);
-		padding-right: calc(var(--os-safe-area-right) + variables.$token-scale-400);
-		padding-top: variables.$token-scale-400;
+		padding-block-end: variables.$token-scale-400;
+		padding-block-start: variables.$token-scale-400;
+		padding-inline-end: calc(var(--os-safe-area-inline-end) + variables.$token-scale-400);
+		padding-inline-start: calc(var(--os-safe-area-inline-start) + variables.$token-scale-400);
 	}
 
 	.footer.ThemeGrid_Container {
-		padding-left: calc(var(--os-safe-area-left) + variables.$token-scale-400);
-		padding-right: calc(var(--os-safe-area-right) + variables.$token-scale-400);
+		padding-inline-end: calc(var(--os-safe-area-inline-end) + variables.$token-scale-400);
+		padding-inline-start: calc(var(--os-safe-area-inline-start) + variables.$token-scale-400);
 	}
 }
 
@@ -82,5 +87,5 @@
 // Android
 // Gives a padding to the content, this avoids some content to be unreachable under the bottom bar
 .android .main:has(.footer:empty) .content {
-	padding-bottom: var(--safe-area-inset-bottom, 0px);
+	padding-block-end: var(--safe-area-inset-bottom, 0px);
 }

--- a/src/scss/02-layout/_themegrid-container.scss
+++ b/src/scss/02-layout/_themegrid-container.scss
@@ -57,21 +57,21 @@
 .phone {
 	.header {
 		.ThemeGrid_Container {
-			padding-inline-end: calc(var(--os-safe-area-inline-end) + variables.$token-scale-400);
-			padding-inline-start: calc(var(--os-safe-area-inline-start) + variables.$token-scale-400);
+			padding-right: calc(var(--os-safe-area-right) + variables.$token-scale-400);
+			padding-left: calc(var(--os-safe-area-left) + variables.$token-scale-400);
 		}
 	}
 
 	.main-content.ThemeGrid_Container {
 		padding-block-end: variables.$token-scale-400;
 		padding-block-start: variables.$token-scale-400;
-		padding-inline-end: calc(var(--os-safe-area-inline-end) + variables.$token-scale-400);
-		padding-inline-start: calc(var(--os-safe-area-inline-start) + variables.$token-scale-400);
+		padding-right: calc(var(--os-safe-area-right) + variables.$token-scale-400);
+		padding-left: calc(var(--os-safe-area-left) + variables.$token-scale-400);
 	}
 
 	.footer.ThemeGrid_Container {
-		padding-inline-end: calc(var(--os-safe-area-inline-end) + variables.$token-scale-400);
-		padding-inline-start: calc(var(--os-safe-area-inline-start) + variables.$token-scale-400);
+		padding-right: calc(var(--os-safe-area-right) + variables.$token-scale-400);
+		padding-left: calc(var(--os-safe-area-left) + variables.$token-scale-400);
 	}
 }
 

--- a/src/scss/03-widgets/_btn.scss
+++ b/src/scss/03-widgets/_btn.scss
@@ -301,7 +301,7 @@
 		> .btn {
 			border-radius: 0;
 			height: 100%;
-			padding-block-end: var(--os-safe-area-bottom);
+			padding-bottom: var(--os-safe-area-bottom);
 		}
 	}
 

--- a/src/scss/03-widgets/_btn.scss
+++ b/src/scss/03-widgets/_btn.scss
@@ -55,7 +55,8 @@
 	justify-content: center;
 	line-height: variables.$token-font-line-height-400;
 	margin: 0;
-	padding: variables.$token-scale-0 variables.$token-scale-400;
+	padding-block: variables.$token-scale-0;
+	padding-inline: variables.$token-scale-400;
 	position: relative;
 	transition:
 		background-color variables.$token-transition-time-100 variables.$token-transition-curve-base,
@@ -94,7 +95,7 @@
 	}
 
 	& + .btn {
-		margin-left: variables.$token-scale-600;
+		margin-inline-start: variables.$token-scale-600;
 	}
 
 	// Variants
@@ -110,7 +111,8 @@
 	&-small {
 		font-size: variables.$token-font-size-300;
 		height: variables.$token-scale-800;
-		padding: variables.$token-scale-0 variables.$token-scale-200;
+		padding-block: variables.$token-scale-0;
+		padding-inline: variables.$token-scale-200;
 	}
 
 	&-large {
@@ -230,18 +232,18 @@
 	.layout:not(.layout-native) {
 		.btn {
 			display: inline-flex;
-			margin-left: 0;
+			margin-inline-start: 0;
 			width: 100%;
 
 			& + .btn {
-				margin-top: variables.$token-scale-400;
+				margin-block-start: variables.$token-scale-400;
 			}
 		}
 
 		.flex-direction-column-reverse {
 			& + .btn {
-				margin-bottom: variables.$token-scale-400;
-				margin-top: variables.$token-scale-0;
+				margin-block-end: variables.$token-scale-400;
+				margin-block-start: variables.$token-scale-0;
 			}
 		}
 	}
@@ -274,13 +276,13 @@
 		> .btn {
 			border-radius: 0;
 			height: 100%;
-			padding-bottom: var(--os-safe-area-bottom);
+			padding-block-end: var(--os-safe-area-bottom);
 		}
 	}
 
 	.bottom-bar {
 		.btn {
-			padding-bottom: variables.$token-scale-0;
+			padding-block-end: variables.$token-scale-0;
 		}
 	}
 }

--- a/src/scss/03-widgets/_bulk-actions.scss
+++ b/src/scss/03-widgets/_bulk-actions.scss
@@ -19,12 +19,14 @@
 		display: block;
 
 		&:checked:after {
+			// physical sides: these borders draw the check glyph under the platform's
+			// physical rotate transform — a checkmark must not mirror in RTL
 			border: variables.$token-border-size-050 solid var(--color-text-inverse);
-			border-block-start: variables.$token-border-size-0 !important;
-			border-inline-end: variables.$token-border-size-0 !important;
+			border-top: variables.$token-border-size-0 !important;
+			border-right: variables.$token-border-size-0 !important;
 			display: block;
 			height: variables.$token-scale-050;
-			inset-inline-start: variables.$token-scale-100;
+			left: variables.$token-scale-100; // physical: positions the rotated glyph
 			top: 5px;
 			width: 7px;
 		}

--- a/src/scss/03-widgets/_bulk-actions.scss
+++ b/src/scss/03-widgets/_bulk-actions.scss
@@ -20,11 +20,11 @@
 
 		&:checked:after {
 			border: variables.$token-border-size-050 solid var(--color-text-inverse);
-			border-right: variables.$token-border-size-0 !important;
-			border-top: variables.$token-border-size-0 !important;
+			border-block-start: variables.$token-border-size-0 !important;
+			border-inline-end: variables.$token-border-size-0 !important;
 			display: block;
 			height: variables.$token-scale-050;
-			left: variables.$token-scale-100;
+			inset-inline-start: variables.$token-scale-100;
 			top: 5px;
 			width: 7px;
 		}

--- a/src/scss/03-widgets/_button-group.scss
+++ b/src/scss/03-widgets/_button-group.scss
@@ -9,7 +9,8 @@
 .button-group {
 	background-color: transparent;
 	border-radius: 0;
-	padding: variables.$token-scale-200 variables.$token-scale-0;
+	padding-block: variables.$token-scale-200;
+	padding-inline: variables.$token-scale-0;
 
 	&-item {
 		// ─── Component CSS API ─────────────────────────────────────────────
@@ -31,13 +32,16 @@
 		font-size: variables.$token-font-size-400;
 		font-weight: variables.$token-font-weight-medium;
 		min-height: var(--osui-button-group-min-height);
-		padding: variables.$token-scale-0 variables.$token-scale-400;
+		padding-block: variables.$token-scale-0;
+		padding-inline: variables.$token-scale-400;
 		position: relative;
 		white-space: nowrap;
 
 		&:first-child {
-			border-radius: variables.$token-border-radius-200 variables.$token-border-radius-0 variables.$token-border-radius-0
-				variables.$token-border-radius-200;
+			border-end-end-radius: variables.$token-border-radius-0;
+			border-end-start-radius: variables.$token-border-radius-200;
+			border-start-end-radius: variables.$token-border-radius-0;
+			border-start-start-radius: variables.$token-border-radius-200;
 		}
 
 		&[disabled] {
@@ -53,12 +57,14 @@
 
 		&[disabled]:not(:first-child),
 		&:not(:first-child) {
-			border-left: variables.$token-border-size-0;
+			border-inline-start: variables.$token-border-size-0;
 		}
 
 		&:last-child {
-			border-radius: variables.$token-border-radius-0 variables.$token-border-radius-200 variables.$token-border-radius-200
-				variables.$token-border-radius-0;
+			border-end-end-radius: variables.$token-border-radius-200;
+			border-end-start-radius: variables.$token-border-radius-0;
+			border-start-end-radius: variables.$token-border-radius-200;
+			border-start-start-radius: variables.$token-border-radius-0;
 		}
 
 		&.button-group-selected-item {
@@ -104,7 +110,7 @@
 		.button-group-item {
 			background-color: var(--background-color-header, var(--color-background-header));
 			border: 0;
-			border-bottom: variables.$token-border-size-050 solid transparent;
+			border-block-end: variables.$token-border-size-050 solid transparent;
 			color: var(--color-text-subtlest);
 
 			&:last-child {
@@ -112,7 +118,7 @@
 			}
 
 			&.button-group-selected-item {
-				border-bottom: variables.$token-border-size-050 solid variables.$token-semantics-primary-base;
+				border-block-end: variables.$token-border-size-050 solid variables.$token-semantics-primary-base;
 				color: var(--color-text);
 			}
 
@@ -120,34 +126,9 @@
 				color: var(--color-text-disabled);
 
 				&.button-group-selected-item {
-					border-bottom: variables.$token-border-size-050 solid var(--color-text-disabled);
+					border-block-end: variables.$token-border-size-050 solid var(--color-text-disabled);
 				}
 			}
-		}
-	}
-}
-
-// IsRTL -------------------------------------------------------------------------
-///
-.is-rtl {
-	.button-group-item {
-		&:first-child {
-			border-radius: variables.$token-border-radius-0 variables.$token-border-radius-200 variables.$token-border-radius-200
-				variables.$token-border-radius-0;
-		}
-
-		&:not(:first-child) {
-			border-left: variables.$token-border-size-025 solid variables.$token-semantics-primary-base;
-			border-right: variables.$token-border-size-0;
-
-			&[disabled] {
-				border-left: variables.$token-border-size-025 solid var(--color-border);
-			}
-		}
-
-		&:last-child {
-			border-radius: variables.$token-border-radius-200 variables.$token-border-radius-0 variables.$token-border-radius-0
-				variables.$token-border-radius-200;
 		}
 	}
 }
@@ -163,9 +144,9 @@
 				bottom: -1px;
 				box-shadow: 0 0 0 variables.$token-border-size-075 var(--color-focus-outer);
 				content: '';
-				left: -1px;
+				inset-inline-start: -1px;
 				position: absolute;
-				right: -1px;
+				inset-inline-end: -1px;
 				top: -1px;
 				z-index: var(--layer-global-screen);
 			}
@@ -182,9 +163,9 @@
 			display: block;
 			position: absolute;
 			top: 0;
-			right: 0;
+			inset-inline-end: 0;
 			bottom: 0;
-			left: 0;
+			inset-inline-start: 0;
 			border: variables.$token-border-size-075 solid variables.$token-semantics-primary-base;
 		}
 	}

--- a/src/scss/03-widgets/_checkbox.scss
+++ b/src/scss/03-widgets/_checkbox.scss
@@ -47,12 +47,14 @@
 		}
 
 		&:after {
+			// physical sides: these borders draw the check glyph under the platform's
+			// physical rotate transform — a checkmark must not mirror in RTL
 			border: variables.$token-border-size-075 solid var(--color-text-inverse);
-			border-inline-end: variables.$token-border-size-0 !important;
-			border-block-start: variables.$token-border-size-0 !important;
+			border-right: variables.$token-border-size-0 !important;
+			border-top: variables.$token-border-size-0 !important;
 			display: block;
 			height: variables.$token-scale-100;
-			inset-inline-start: 5px;
+			left: 5px; // physical: positions the rotated glyph
 			top: 7px;
 			width: variables.$token-scale-300;
 		}
@@ -84,7 +86,7 @@
 
 		&:checked {
 			&:after {
-				inset-inline-start: 9px;
+				left: 9px; // physical: positions the rotated check glyph (see above)
 				top: 11px;
 			}
 		}

--- a/src/scss/03-widgets/_checkbox.scss
+++ b/src/scss/03-widgets/_checkbox.scss
@@ -48,11 +48,11 @@
 
 		&:after {
 			border: variables.$token-border-size-075 solid var(--color-text-inverse);
-			border-right: variables.$token-border-size-0 !important;
-			border-top: variables.$token-border-size-0 !important;
+			border-inline-end: variables.$token-border-size-0 !important;
+			border-block-start: variables.$token-border-size-0 !important;
 			display: block;
 			height: variables.$token-scale-100;
-			left: 5px;
+			inset-inline-start: 5px;
 			top: 7px;
 			width: variables.$token-scale-300;
 		}
@@ -84,7 +84,7 @@
 
 		&:checked {
 			&:after {
-				left: 9px;
+				inset-inline-start: 9px;
 				top: 11px;
 			}
 		}

--- a/src/scss/03-widgets/_dropdown.scss
+++ b/src/scss/03-widgets/_dropdown.scss
@@ -44,7 +44,8 @@
 				display: flex;
 				font-size: variables.$token-font-size-350;
 				height: variables.$token-scale-1000;
-				padding: variables.$token-scale-0 variables.$token-scale-400;
+				padding-block: variables.$token-scale-0;
+				padding-inline: variables.$token-scale-400;
 				width: 100%;
 
 				&:hover {
@@ -87,7 +88,7 @@
 			border: var(--osui-dropdown-border-width) solid var(--osui-dropdown-list-border-color);
 			border-radius: var(--osui-dropdown-border-radius);
 			box-shadow: var(--osui-dropdown-list-shadow);
-			left: 0 !important;
+			inset-inline-start: 0 !important;
 			max-height: var(--osui-dropdown-list-max-height);
 			overflow-y: auto;
 			position: absolute;
@@ -112,7 +113,8 @@
 			cursor: pointer;
 			display: flex;
 			justify-content: space-between;
-			padding: #{variables.$token-scale-200} #{variables.$token-scale-400};
+			padding-block: #{variables.$token-scale-200};
+			padding-inline: #{variables.$token-scale-400};
 
 			&:hover,
 			&-selected:hover {
@@ -130,7 +132,7 @@
 					flex-shrink: 0;
 					font-family: var(--osui-icon-font-family);
 					font-size: variables.$token-font-size-400;
-					margin-left: variables.$token-scale-200;
+					margin-inline-start: variables.$token-scale-200;
 				}
 			}
 
@@ -157,13 +159,13 @@
 	// Is expanded
 	&-expanded {
 		&-down div.dropdown-list {
-			margin-top: variables.$token-scale-100;
+			margin-block-start: variables.$token-scale-100;
 			top: 100% !important;
 		}
 
 		&-up div.dropdown-list {
 			bottom: 100% !important;
-			margin-bottom: variables.$token-scale-100;
+			margin-block-end: variables.$token-scale-100;
 			top: auto !important;
 		}
 	}

--- a/src/scss/03-widgets/_feedback-message.scss
+++ b/src/scss/03-widgets/_feedback-message.scss
@@ -27,23 +27,24 @@
 	font-size: variables.$token-font-size-350;
 	font-weight: variables.$token-font-weight-medium;
 	gap: variables.$token-scale-200;
-	left: 50%;
+	inset-inline-start: 50%;
 	max-width: var(--osui-feedback-message-max-width);
 	min-width: var(--osui-feedback-message-min-width);
-	padding: variables.$token-scale-300 variables.$token-scale-400;
+	padding-block: variables.$token-scale-300;
+	padding-inline: variables.$token-scale-400;
 
 	i {
 		align-self: flex-start;
 		color: var(--osui-feedback-message-icon-color);
 		font-size: variables.$token-font-size-500;
-		margin-top: #{variables.$token-scale-050}; // 2px icon vertical offset
+		margin-block-start: #{variables.$token-scale-050}; // 2px icon vertical offset
 		position: relative;
 	}
 }
 
 ///
 .feedback-message-text {
-	padding-left: 0;
+	padding-inline-start: 0;
 }
 
 // Mantain due to Retro Compatibility
@@ -89,13 +90,13 @@ div.feedback-message-warning {
 
 	&.ios {
 		.feedback-message {
-			padding-top: calc(var(--os-safe-area-top) + variables.$token-scale-400);
+			padding-block-start: calc(var(--os-safe-area-top) + variables.$token-scale-400);
 		}
 	}
 }
 
 .android .feedback-message {
-	padding-top: calc(#{android-safe-area-top()} + variables.$token-scale-400);
+	padding-block-start: calc(#{android-safe-area-top()} + variables.$token-scale-400);
 }
 
 // IsRTL -------------------------------------------------------------------------
@@ -104,7 +105,6 @@ div.feedback-message-warning {
 		.feedback-message {
 			animation-name: feedbackMessageSlideDownPhoneRTL;
 			border-radius: 0;
-			left: 0;
 			max-width: 100%;
 			min-width: 100%;
 

--- a/src/scss/03-widgets/_feedback-message.scss
+++ b/src/scss/03-widgets/_feedback-message.scss
@@ -90,7 +90,7 @@ div.feedback-message-warning {
 
 	&.ios {
 		.feedback-message {
-			padding-block-start: calc(var(--os-safe-area-top) + variables.$token-scale-400);
+			padding-top: calc(var(--os-safe-area-top) + variables.$token-scale-400);
 		}
 	}
 }

--- a/src/scss/03-widgets/_feedback-message.scss
+++ b/src/scss/03-widgets/_feedback-message.scss
@@ -27,7 +27,7 @@
 	font-size: variables.$token-font-size-350;
 	font-weight: variables.$token-font-weight-medium;
 	gap: variables.$token-scale-200;
-	inset-inline-start: 50%;
+	left: 50%; // physical: centring pair with the keyframes' translateX(-50%), which never mirrors
 	max-width: var(--osui-feedback-message-max-width);
 	min-width: var(--osui-feedback-message-min-width);
 	padding-block: variables.$token-scale-300;
@@ -105,6 +105,7 @@ div.feedback-message-warning {
 		.feedback-message {
 			animation-name: feedbackMessageSlideDownPhoneRTL;
 			border-radius: 0;
+			left: 0; // physical: the RTL phone keyframes use translateX(0), so the base left: 50% must be re-anchored
 			max-width: 100%;
 			min-width: 100%;
 

--- a/src/scss/03-widgets/_form.scss
+++ b/src/scss/03-widgets/_form.scss
@@ -9,12 +9,12 @@
 .form {
 	&.OSFillParent {
 		.form-control[class*='ThemeGrid_Width'].not-valid ~ span.validation-message {
-			left: 22px;
+			inset-inline-start: 22px;
 		}
 	}
 
 	label {
-		margin-bottom: variables.$token-scale-200;
+		margin-block-end: variables.$token-scale-200;
 	}
 
 	.dropdown,
@@ -22,7 +22,7 @@
 	input[data-input],
 	textarea[data-textarea],
 	[data-switch] {
-		margin-bottom: variables.$token-scale-600;
+		margin-block-end: variables.$token-scale-600;
 	}
 
 	span {
@@ -30,7 +30,7 @@
 
 		&.validation-message {
 			bottom: -32px;
-			left: 0;
+			inset-inline-start: 0;
 			position: absolute;
 			white-space: nowrap;
 			width: 100%;
@@ -40,7 +40,7 @@
 	& > span.input-text {
 		.form-control[class*='ThemeGrid_Width'].not-valid {
 			& + span.validation-message {
-				left: 0;
+				inset-inline-start: 0;
 			}
 		}
 	}
@@ -96,18 +96,18 @@
 span.validation-message {
 	color: variables.$token-text-danger;
 	font-size: variables.$token-font-size-300;
-	margin-left: variables.$token-scale-0;
+	margin-inline-start: variables.$token-scale-0;
 }
 
 ///
 .form-control[class*='ThemeGrid_Width'].not-valid + span.validation-message {
-	left: 10px;
+	inset-inline-start: 10px;
 }
 
 // Responsive --------------------------------------------------------------------
 .phone {
 	.layout-native .form.OSFillParent .form-control[class*='ThemeGrid_Width'].not-valid + span.validation-message {
-		left: variables.$token-scale-150;
+		inset-inline-start: variables.$token-scale-150;
 	}
 
 	.form.OSFillParent span.input-text .form-control[class*='ThemeGrid_Width'].not-valid + span.validation-message,
@@ -116,19 +116,6 @@ span.validation-message {
 		.form-control[class*='ThemeGrid_Width'].not-valid.ThemeGrid_MarginGutter
 		+ span.validation-message,
 	.form-control[class*='ThemeGrid_Width'].not-valid + span.validation-message {
-		left: 0;
-	}
-}
-
-// IsRTL -------------------------------------------------------------------------
-///
-.is-rtl {
-	form {
-		&.OSFillParent {
-			.form-control[class*='ThemeGrid_Width'].not-valid ~ span.validation-message {
-				left: initial;
-				right: 22px;
-			}
-		}
+		inset-inline-start: 0;
 	}
 }

--- a/src/scss/03-widgets/_inputs-and-textareas.scss
+++ b/src/scss/03-widgets/_inputs-and-textareas.scss
@@ -64,7 +64,8 @@
 
 	&[data-input] {
 		height: variables.$token-scale-1000;
-		padding: variables.$token-scale-0 variables.$token-scale-400;
+		padding-block: variables.$token-scale-0;
+		padding-inline: variables.$token-scale-400;
 	}
 
 	&[data-textarea] {
@@ -79,7 +80,8 @@
 			&[data-input] {
 				font-size: variables.$token-font-size-300;
 				height: variables.$token-scale-800;
-				padding: variables.$token-scale-0 variables.$token-scale-200;
+				padding-block: variables.$token-scale-0;
+				padding-inline: variables.$token-scale-200;
 			}
 
 			&[data-textarea] {
@@ -125,14 +127,14 @@
 	color: var(--color-text-subtlest);
 	font-size: variables.$token-font-size-300;
 	line-height: variables.$token-font-line-height-400;
-	margin-top: variables.$token-scale-100;
+	margin-block-start: variables.$token-scale-100;
 }
 
 span.validation-message {
 	color: variables.$token-text-danger;
 	display: block;
 	font-size: variables.$token-font-size-300;
-	margin-top: variables.$token-scale-100;
+	margin-block-start: variables.$token-scale-100;
 }
 
 .char-counter {
@@ -175,11 +177,11 @@ span.validation-message {
 			&[data-input] {
 				background-color: var(--background-color-header, var(--color-background-header));
 				border: 0;
-				border-bottom: variables.$token-border-size-025 solid transparent;
+				border-block-end: variables.$token-border-size-025 solid transparent;
 				border-radius: 0;
 
 				&:focus {
-					border-bottom: variables.$token-border-size-025 solid var(--osui-input-focus-border-color);
+					border-block-end: variables.$token-border-size-025 solid var(--osui-input-focus-border-color);
 				}
 			}
 		}

--- a/src/scss/03-widgets/_list-item.scss
+++ b/src/scss/03-widgets/_list-item.scss
@@ -16,13 +16,14 @@
 	--osui-list-item-selected-icon-color:     #{variables.$token-icon-select};
 	// ───────────────────────────────────────────────────────────────────
 
-	border-bottom: variables.$token-border-size-025 solid var(--osui-list-item-border-color);
-	padding: variables.$token-space-300 variables.$token-space-600;
+	border-block-end: variables.$token-border-size-025 solid var(--osui-list-item-border-color);
+	padding-block: variables.$token-space-300;
+	padding-inline: variables.$token-space-600;
 	position: relative;
 	transition: background-color variables.$token-transition-time-100 variables.$token-transition-curve-base;
 
 	&:last-of-type {
-		border-bottom: none;
+		border-block-end: none;
 	}
 
 	// ButtonsEffect.ts still injects a `.scale-animation` span on click and relies on the
@@ -34,7 +35,7 @@
 		background: transparent;
 		display: block;
 		height: 0;
-		left: 50%;
+		inset-inline-start: 50%;
 		opacity: 0;
 		pointer-events: none;
 		position: absolute;
@@ -109,15 +110,15 @@
 
 				&:before {
 					border: variables.$token-border-size-025 solid variables.$token-semantics-primary-base;
-					border-right-width: variables.$token-border-size-0;
-					border-left-width: variables.$token-border-size-075;
+					border-inline-end-width: variables.$token-border-size-0;
+					border-inline-start-width: variables.$token-border-size-075;
 					bottom: 0;
 					content: '';
 					display: block;
-					left: 0;
+					inset-inline-start: 0;
 					pointer-events: none;
 					position: absolute;
-					right: 0;
+					inset-inline-end: 0;
 					top: 0;
 				}
 			}

--- a/src/scss/03-widgets/_popover-odc.scss
+++ b/src/scss/03-widgets/_popover-odc.scss
@@ -12,6 +12,9 @@
 ///
 .is-rtl {
 	[data-popover] > .popover-bottom.align-center {
+		// The base `margin-left: -50%` + `translateX(-50%)` pair lives in the PLATFORM
+		// stylesheet, not in OSUI, so it never became logical. Both halves of the mirror
+		// have to stay physical here.
 		margin-left: initial;
 		margin-right: -50%;
 		transform: translateX(50%);

--- a/src/scss/03-widgets/_radio-button.scss
+++ b/src/scss/03-widgets/_radio-button.scss
@@ -107,7 +107,7 @@
 			width: auto;
 
 			&:not(:first-of-type) {
-				margin-left: variables.$token-scale-500;
+				margin-inline-start: variables.$token-scale-500;
 			}
 		}
 	}
@@ -129,13 +129,14 @@
 	[data-radio-button] {
 		align-items: center;
 		display: flex;
-		margin: variables.$token-scale-300 0;
+		margin-block: variables.$token-scale-300;
+		margin-inline: 0;
 
 		label {
 			cursor: pointer;
 			line-height: 1;
-			margin-bottom: 0;
-			margin-left: variables.$token-scale-200;
+			margin-block-end: 0;
+			margin-inline-start: variables.$token-scale-200;
 		}
 	}
 }
@@ -162,9 +163,9 @@
 			border-radius: var(--border-radius-rounded);
 			content: '';
 			height: variables.$token-scale-300;
-			left: 50%;
-			margin-left: calc(#{variables.$token-scale-300} * -0.5);
-			margin-top: calc(#{variables.$token-scale-300} * -0.5);
+			inset-inline-start: 50%;
+			margin-inline-start: calc(#{variables.$token-scale-300} * -0.5);
+			margin-block-start: calc(#{variables.$token-scale-300} * -0.5);
 			position: absolute;
 			position: absolute;
 			top: 50%;
@@ -188,24 +189,5 @@
 
 	[data-radio-group].not-valid [data-radio-button] .radio-button:checked:before {
 		border-color: variables.$token-semantics-primary-base;
-	}
-}
-
-// IsRTL -------------------------------------------------------------------------
-.is-rtl {
-	[data-radio-group] label {
-		margin-left: variables.$token-scale-0;
-		margin-right: variables.$token-scale-200;
-	}
-
-	.radio-group {
-		&.is-horizontal {
-			[data-radio-button] {
-				&:not(:first-of-type) {
-					margin-left: unset;
-					margin-right: variables.$token-scale-500;
-				}
-			}
-		}
 	}
 }

--- a/src/scss/03-widgets/_switch.scss
+++ b/src/scss/03-widgets/_switch.scss
@@ -43,6 +43,9 @@
 			bottom: 0;
 			box-shadow: var(--osui-switch-thumb-shadow);
 			height: var(--osui-switch-thumb-size);
+			// Physical on purpose: the thumb offset is a `translateX`, which has no logical
+			// form. A logical inset would flip the anchor in RTL while the transform kept
+			// pushing the same way, sliding the thumb outside the track.
 			left: 0;
 			margin-left: 0;
 			top: calc((var(--osui-switch-height) - var(--osui-switch-thumb-size)) / 2);
@@ -134,7 +137,7 @@
 			font-family: monospace;
 			font-size: variables.$token-font-size-300;
 			justify-content: center;
-			left: -1px;
+			inset-inline-start: -1px;
 			top: variables.$token-scale-075;
 		}
 

--- a/src/scss/03-widgets/_table.scss
+++ b/src/scss/03-widgets/_table.scss
@@ -35,13 +35,14 @@
 
 		th {
 			background-color: var(--osui-table-header-background);
-			border-bottom: variables.$token-border-size-025 solid var(--osui-table-border-color);
+			border-block-end: variables.$token-border-size-025 solid var(--osui-table-border-color);
 			color: var(--osui-table-header-color);
 			font-size: variables.$token-font-size-350;
 			font-weight: variables.$token-font-weight-regular;
 			height: variables.$token-scale-1200;
-			padding: variables.$token-scale-0 variables.$token-scale-600;
-			text-align: left;
+			padding-block: variables.$token-scale-0;
+			padding-inline: variables.$token-scale-600;
+			text-align: start;
 
 			&.sortable {
 				cursor: pointer;
@@ -65,11 +66,12 @@
 
 		td {
 			background: var(--osui-table-cell-background);
-			border-bottom: variables.$token-border-size-025 solid var(--osui-table-border-color);
+			border-block-end: variables.$token-border-size-025 solid var(--osui-table-border-color);
 			color: var(--color-text);
 			font-size: variables.$token-font-size-350;
 			height: variables.$token-scale-1600;
-			padding: variables.$token-scale-200 variables.$token-scale-600;
+			padding-block: variables.$token-scale-200;
+			padding-inline: variables.$token-scale-600;
 			transition: background-color variables.$token-transition-time-100 ease; // no token match for ease
 			vertical-align: inherit;
 		}
@@ -98,7 +100,7 @@
 
 	.table-row:last-child {
 		& > td {
-			border-bottom: none;
+			border-block-end: none;
 		}
 	}
 }
@@ -173,22 +175,22 @@
 			}
 
 			tr {
-				border-bottom: variables.$token-border-size-025 solid var(--color-border);
+				border-block-end: variables.$token-border-size-025 solid var(--color-border);
 			}
 
 			td {
-				border-bottom: 0;
+				border-block-end: 0;
 				display: flex;
 				height: auto;
 				position: relative;
-				text-align: left !important;
+				text-align: start !important;
 				width: 100% !important;
 
 				&:before {
 					content: attr(data-header);
 					display: block;
 					font-weight: bold;
-					margin-right: 10px;
+					margin-inline-end: 10px;
 					max-width: 110px;
 					min-width: 110px;
 					word-break: break-word;
@@ -216,9 +218,10 @@
 
 			td {
 				background: var(--osui-table-cell-background);
-				border-bottom: variables.$token-border-size-025 solid var(--osui-table-border-color);
+				border-block-end: variables.$token-border-size-025 solid var(--osui-table-border-color);
 				display: table-cell;
-				padding: variables.$token-scale-200 variables.$token-scale-600;
+				padding-block: variables.$token-scale-200;
+				padding-inline: variables.$token-scale-600;
 				vertical-align: inherit;
 				width: auto !important;
 
@@ -278,32 +281,5 @@
 		box-shadow: 0 0 0 variables.$token-border-size-075 var(--color-focus-outer);
 		position: relative;
 		z-index: var(--layer-global-screen);
-	}
-}
-
-// IsRTL --------------------------------------------------------------------
-///
-.is-rtl {
-	&.phone,
-	&.tablet {
-		.table:not(.table-no-responsive) {
-			td {
-				text-align: right !important;
-			}
-
-			td:before {
-				margin-left: 10px;
-				margin-right: 0px;
-			}
-		}
-	}
-
-	.table-header th {
-		text-align: right;
-	}
-
-	.sortable-icon {
-		margin-left: variables.$token-scale-0;
-		right: variables.$token-scale-200;
 	}
 }

--- a/src/scss/03-widgets/_upload.scss
+++ b/src/scss/03-widgets/_upload.scss
@@ -25,7 +25,7 @@
 	display: flex;
 	font-size: variables.$token-font-size-350;
 	font-weight: variables.$token-font-weight-medium;
-	margin-bottom: 0;
+	margin-block-end: 0;
 	min-height: auto;
 	padding: var(--osui-upload-padding);
 	position: relative;
@@ -37,7 +37,7 @@
 			background-color: transparent;
 			color: variables.$token-semantics-primary-base;
 			height: auto;
-			margin-top: variables.$token-scale-400;
+			margin-block-start: variables.$token-scale-400;
 			opacity: 1;
 			position: relative;
 		}
@@ -53,23 +53,12 @@
 		background-color: transparent;
 		color: var(--osui-upload-icon-color);
 		line-height: 1;
-		margin-right: variables.$token-scale-200;
+		margin-inline-end: variables.$token-scale-200;
 		width: auto;
 	}
 
 	&:focus-visible {
 		border: variables.$token-border-size-025 solid variables.$token-semantics-primary-base;
-	}
-}
-
-// IsRTL --------------------------------------------------------------------
-///
-.is-rtl {
-	[data-upload] {
-		[data-icon] {
-			margin-left: variables.$token-scale-200;
-			margin-right: variables.$token-scale-0;
-		}
 	}
 }
 

--- a/src/scss/04-patterns/01-adaptive/_columns.scss
+++ b/src/scss/04-patterns/01-adaptive/_columns.scss
@@ -46,12 +46,13 @@
 		@each $type, $value in $osui-sizes {
 			&.gutter {
 				&-#{$type} {
-					margin-left: calc(-1 * #{map.get($osui-space-token-vars, $type)} / 2);
-					margin-right: calc(-1 * #{map.get($osui-space-token-vars, $type)} / 2);
+					margin-inline-start: calc(-1 * #{map.get($osui-space-token-vars, $type)} / 2);
+					margin-inline-end: calc(-1 * #{map.get($osui-space-token-vars, $type)} / 2);
 
 					& > .columns-item {
-						margin-bottom: #{map.get($osui-space-token-vars, $type)};
-						padding: variables.$token-scale-0 calc(#{map.get($osui-space-token-vars, $type)} / 2);
+						margin-block-end: #{map.get($osui-space-token-vars, $type)};
+						padding-block: variables.$token-scale-0;
+						padding-inline: calc(#{map.get($osui-space-token-vars, $type)} / 2);
 					}
 
 					.tablet &.tablet-break {
@@ -60,7 +61,7 @@
 						&-middle,
 						&-all {
 							&:only-child > .columns-item:not(:last-child) {
-								margin-bottom: #{map.get($osui-space-token-vars, $type)};
+								margin-block-end: #{map.get($osui-space-token-vars, $type)};
 							}
 						}
 					}
@@ -71,7 +72,7 @@
 						&-middle,
 						&-all {
 							&:only-child > .columns-item:not(:last-child) {
-								margin-bottom: #{map.get($osui-space-token-vars, $type)};
+								margin-block-end: #{map.get($osui-space-token-vars, $type)};
 							}
 						}
 					}
@@ -83,7 +84,7 @@
 
 // Override gutters rule
 .columns:only-child > .columns-item {
-	margin-bottom: variables.$token-scale-0;
+	margin-block-end: variables.$token-scale-0;
 }
 
 // Responsive --------------------------------------------------------------------

--- a/src/scss/04-patterns/01-adaptive/_master-detail.scss
+++ b/src/scss/04-patterns/01-adaptive/_master-detail.scss
@@ -39,7 +39,8 @@
 
 			.list-item {
 				cursor: pointer;
-				padding: variables.$token-scale-300 variables.$token-scale-600;
+				padding-block: variables.$token-scale-300;
+				padding-inline: variables.$token-scale-600;
 				transition: background-color variables.$token-transition-time-100 variables.$token-transition-curve-base;
 
 				&:hover {
@@ -62,12 +63,12 @@
 		}
 
 		&-right {
-			border-left: variables.$token-border-size-025 solid var(--osui-master-detail-border-color);
+			border-inline-start: variables.$token-border-size-025 solid var(--osui-master-detail-border-color);
 			padding: variables.$token-scale-600;
 			width: calc(100% - var(--left-percentage));
 
 			.split-right-close {
-				left: calc(var(--os-safe-area-left) + variables.$token-scale-600);
+				inset-inline-start: calc(var(--os-safe-area-inline-start) + variables.$token-scale-600);
 				position: fixed;
 				top: calc(var(--os-safe-area-right) + (var(--size-header) + var(--token-scale-600, 24px)) / 2);
 				z-index: var(--layer-global-screen);
@@ -104,7 +105,7 @@
 ///
 .layout-native {
 	.split-right-close {
-		left: calc(var(--os-safe-area-left) + variables.$token-scale-600);
+		inset-inline-start: calc(var(--os-safe-area-inline-start) + variables.$token-scale-600);
 	}
 }
 
@@ -151,13 +152,13 @@
 
 			&-right {
 				background-color: var(--osui-master-detail-background);
-				border-left: variables.$token-border-size-0;
+				border-inline-start: variables.$token-border-size-0;
 				height: 100%;
 				left: 0;
-				padding-bottom: calc(var(--os-safe-area-bottom) + variables.$token-scale-600);
-				padding-left: calc(var(--os-safe-area-left) + variables.$token-scale-600);
-				padding-right: calc(var(--os-safe-area-right) + variables.$token-scale-600);
-				padding-top: calc(var(--os-safe-area-right) + var(--size-header) + var(--token-scale-600, 24px));
+				padding-block-end: calc(var(--os-safe-area-bottom) + variables.$token-scale-600);
+				padding-inline-start: calc(var(--os-safe-area-inline-start) + variables.$token-scale-600);
+				padding-inline-end: calc(var(--os-safe-area-inline-end) + variables.$token-scale-600);
+				padding-block-start: calc(var(--os-safe-area-right) + var(--size-header) + var(--token-scale-600, 24px));
 				position: fixed;
 				top: 0;
 				transform: translateX(100%) translateZ(0);
@@ -182,14 +183,14 @@
 
 	.layout-native {
 		.split-right {
-			padding-bottom: calc(var(--os-safe-area-bottom) + variables.$token-scale-400);
-			padding-left: calc(var(--os-safe-area-left) + variables.$token-scale-400);
-			padding-right: calc(var(--os-safe-area-right) + variables.$token-scale-400);
-			padding-top: calc(var(--size-header) + var(--os-safe-area-top));
+			padding-block-end: calc(var(--os-safe-area-bottom) + variables.$token-scale-400);
+			padding-inline-start: calc(var(--os-safe-area-inline-start) + variables.$token-scale-400);
+			padding-inline-end: calc(var(--os-safe-area-inline-end) + variables.$token-scale-400);
+			padding-block-start: calc(var(--size-header) + var(--os-safe-area-top));
 
 			.split-right-close {
 				display: block;
-				left: calc(var(--os-safe-area-left) + variables.$token-scale-400);
+				inset-inline-start: calc(var(--os-safe-area-inline-start) + variables.$token-scale-400);
 			}
 		}
 	}
@@ -197,7 +198,7 @@
 	&.android {
 		.layout-native {
 			.split-right {
-				padding-top: calc(var(--size-header) + #{android-safe-area-top()});
+				padding-block-start: calc(var(--size-header) + #{android-safe-area-top()});
 			}
 		}
 	}
@@ -214,18 +215,9 @@
 .android {
 	.layout-native {
 		.split-right-close {
-			left: variables.$token-scale-400;
+			inset-inline-start: variables.$token-scale-400;
 			top: calc(#{android-safe-area-top()} + 10px);
 		}
-	}
-}
-
-// IsRTL --------------------------------------------------------------------
-///
-.is-rtl {
-	.split-right {
-		border-left: 0;
-		border-right: variables.$token-border-size-025 solid var(--osui-master-detail-border-color);
 	}
 }
 
@@ -242,9 +234,9 @@
 					box-shadow: inset 0 0 0 variables.$token-border-size-075
 						color-mix(in srgb, #{variables.$token-semantics-primary-base} 100%, transparent);
 					content: '';
-					left: 0;
+					inset-inline-start: 0;
 					position: absolute;
-					right: 0;
+					inset-inline-end: 0;
 					top: 0;
 				}
 			}

--- a/src/scss/04-patterns/01-adaptive/_master-detail.scss
+++ b/src/scss/04-patterns/01-adaptive/_master-detail.scss
@@ -68,7 +68,7 @@
 			width: calc(100% - var(--left-percentage));
 
 			.split-right-close {
-				inset-inline-start: calc(var(--os-safe-area-inline-start) + variables.$token-scale-600);
+				left: calc(var(--os-safe-area-left) + variables.$token-scale-600);
 				position: fixed;
 				top: calc(var(--os-safe-area-right) + (var(--size-header) + var(--token-scale-600, 24px)) / 2);
 				z-index: var(--layer-global-screen);
@@ -105,7 +105,7 @@
 ///
 .layout-native {
 	.split-right-close {
-		inset-inline-start: calc(var(--os-safe-area-inline-start) + variables.$token-scale-600);
+		left: calc(var(--os-safe-area-left) + variables.$token-scale-600);
 	}
 }
 
@@ -155,10 +155,10 @@
 				border-inline-start: variables.$token-border-size-0;
 				height: 100%;
 				left: 0;
-				padding-block-end: calc(var(--os-safe-area-bottom) + variables.$token-scale-600);
-				padding-inline-start: calc(var(--os-safe-area-inline-start) + variables.$token-scale-600);
-				padding-inline-end: calc(var(--os-safe-area-inline-end) + variables.$token-scale-600);
-				padding-block-start: calc(var(--os-safe-area-right) + var(--size-header) + var(--token-scale-600, 24px));
+				padding-bottom: calc(var(--os-safe-area-bottom) + variables.$token-scale-600);
+				padding-left: calc(var(--os-safe-area-left) + variables.$token-scale-600);
+				padding-right: calc(var(--os-safe-area-right) + variables.$token-scale-600);
+				padding-top: calc(var(--os-safe-area-right) + var(--size-header) + var(--token-scale-600, 24px));
 				position: fixed;
 				top: 0;
 				transform: translateX(100%) translateZ(0);
@@ -183,14 +183,14 @@
 
 	.layout-native {
 		.split-right {
-			padding-block-end: calc(var(--os-safe-area-bottom) + variables.$token-scale-400);
-			padding-inline-start: calc(var(--os-safe-area-inline-start) + variables.$token-scale-400);
-			padding-inline-end: calc(var(--os-safe-area-inline-end) + variables.$token-scale-400);
-			padding-block-start: calc(var(--size-header) + var(--os-safe-area-top));
+			padding-bottom: calc(var(--os-safe-area-bottom) + variables.$token-scale-400);
+			padding-left: calc(var(--os-safe-area-left) + variables.$token-scale-400);
+			padding-right: calc(var(--os-safe-area-right) + variables.$token-scale-400);
+			padding-top: calc(var(--size-header) + var(--os-safe-area-top));
 
 			.split-right-close {
 				display: block;
-				inset-inline-start: calc(var(--os-safe-area-inline-start) + variables.$token-scale-400);
+				left: calc(var(--os-safe-area-left) + variables.$token-scale-400);
 			}
 		}
 	}

--- a/src/scss/04-patterns/01-adaptive/bottom-sheet/_bottomsheet.scss
+++ b/src/scss/04-patterns/01-adaptive/bottom-sheet/_bottomsheet.scss
@@ -22,11 +22,11 @@
 	--osui-bottom-sheet-transition-function: #{variables.$token-transition-curve-quick};
 
 	background-color: var(--osui-bottom-sheet-background);
-	border-top-left-radius: var(--bottom-sheet-shape);
-	border-top-right-radius: var(--bottom-sheet-shape);
+	border-start-start-radius: var(--bottom-sheet-shape);
+	border-start-end-radius: var(--bottom-sheet-shape);
 	bottom: 0;
 	box-shadow: var(--osui-bottom-sheet-shadow);
-	left: 0;
+	inset-inline-start: 0;
 	max-height: var(--bottom-sheet-max-height);
 	min-height: 50vh;
 	position: fixed;
@@ -62,7 +62,7 @@
 			}
 
 			&__top-bar {
-				padding-top: variables.$token-scale-800;
+				padding-block-start: variables.$token-scale-800;
 			}
 		}
 	}
@@ -84,7 +84,7 @@
 			background-color: var(--osui-bottom-sheet-background);
 			content: '';
 			height: 100%;
-			left: 0;
+			inset-inline-start: 0;
 			position: absolute;
 			top: 100%;
 			width: 100%;
@@ -107,7 +107,7 @@
 	&-overlay {
 		background-color: variables.$token-backdrop;
 		height: 100vh;
-		left: 0;
+		inset-inline-start: 0;
 		opacity: 0;
 		pointer-events: none;
 		position: fixed;
@@ -128,7 +128,7 @@
 		&::after {
 			content: '';
 			height: var(--osui-bottom-sheet-draggable-area);
-			left: 0;
+			inset-inline-start: 0;
 			position: absolute;
 			top: 100%;
 			width: 100%;
@@ -141,7 +141,7 @@
 				box-shadow: variables.$token-elevation-3;
 				content: '';
 				height: 100%;
-				left: 0;
+				inset-inline-start: 0;
 				opacity: 0;
 				position: absolute;
 				transform: translateY(-2px);
@@ -154,7 +154,7 @@
 			}
 
 			&:empty {
-				padding-bottom: unset;
+				padding-block-end: unset;
 			}
 		}
 	}
@@ -163,7 +163,7 @@
 		max-height: var(--bottom-sheet-max-height);
 		overflow-y: scroll;
 		padding: var(--osui-bottom-sheet-padding);
-		padding-bottom: calc(var(--size-bottom-bar) + variables.$token-scale-600 + var(--os-safe-area-bottom));
+		padding-block-end: calc(var(--size-bottom-bar) + variables.$token-scale-600 + var(--os-safe-area-bottom));
 	}
 }
 
@@ -185,8 +185,8 @@
 .landscape {
 	.osui-bottom-sheet__header__top-bar,
 	.osui-bottom-sheet__content {
-		padding-right: calc(variables.$token-scale-400 + var(--os-safe-area-right));
-		padding-left: calc(variables.$token-scale-400 + var(--os-safe-area-left));
+		padding-inline-end: calc(variables.$token-scale-400 + var(--os-safe-area-inline-end));
+		padding-inline-start: calc(variables.$token-scale-400 + var(--os-safe-area-inline-start));
 	}
 }
 

--- a/src/scss/04-patterns/01-adaptive/bottom-sheet/_bottomsheet.scss
+++ b/src/scss/04-patterns/01-adaptive/bottom-sheet/_bottomsheet.scss
@@ -163,7 +163,7 @@
 		max-height: var(--bottom-sheet-max-height);
 		overflow-y: scroll;
 		padding: var(--osui-bottom-sheet-padding);
-		padding-block-end: calc(var(--size-bottom-bar) + variables.$token-scale-600 + var(--os-safe-area-bottom));
+		padding-bottom: calc(var(--size-bottom-bar) + variables.$token-scale-600 + var(--os-safe-area-bottom));
 	}
 }
 
@@ -185,8 +185,8 @@
 .landscape {
 	.osui-bottom-sheet__header__top-bar,
 	.osui-bottom-sheet__content {
-		padding-inline-end: calc(variables.$token-scale-400 + var(--os-safe-area-inline-end));
-		padding-inline-start: calc(variables.$token-scale-400 + var(--os-safe-area-inline-start));
+		padding-right: calc(variables.$token-scale-400 + var(--os-safe-area-right));
+		padding-left: calc(variables.$token-scale-400 + var(--os-safe-area-left));
 	}
 }
 

--- a/src/scss/04-patterns/01-adaptive/gallery/_gallery.scss
+++ b/src/scss/04-patterns/01-adaptive/gallery/_gallery.scss
@@ -13,7 +13,7 @@
 	}
 
 	& > * {
-		margin-top: 0;
+		margin-block-start: 0;
 	}
 
 	& > .list {

--- a/src/scss/04-patterns/02-content/_alert.scss
+++ b/src/scss/04-patterns/02-content/_alert.scss
@@ -76,12 +76,3 @@
 		--osui-alert-accent-color: var(--color-warning);
 	}
 }
-
-// IsRTL -------------------------------------------------------------------------
-///
-.is-rtl {
-	.alert-icon {
-		margin-left: variables.$token-scale-400;
-		margin-right: 0;
-	}
-}

--- a/src/scss/04-patterns/02-content/_blank-slate.scss
+++ b/src/scss/04-patterns/02-content/_blank-slate.scss
@@ -26,13 +26,15 @@
 		}
 
 		& .blank-slate-actions {
-			padding: variables.$token-scale-1200 variables.$token-scale-400;
+			padding-block: variables.$token-scale-1200;
+			padding-inline: variables.$token-scale-400;
 		}
 	}
 
 	&-description {
 		color: var(--osui-blank-slate-description-color);
-		padding: variables.$token-scale-0 variables.$token-scale-400;
+		padding-block: variables.$token-scale-0;
+		padding-inline: variables.$token-scale-400;
 	}
 
 	&-actions {

--- a/src/scss/04-patterns/02-content/_card-background.scss
+++ b/src/scss/04-patterns/02-content/_card-background.scss
@@ -45,7 +45,7 @@
 		&.top-left,
 		&.center-left,
 		&.bottom-left {
-			text-align: left;
+			text-align: start;
 		}
 
 		&.top-center,
@@ -57,7 +57,7 @@
 		&.top-right,
 		&.center-right,
 		&.bottom-right {
-			text-align: right;
+			text-align: end;
 		}
 	}
 
@@ -85,7 +85,7 @@
 			background: linear-gradient(180deg, rgba(0, 0, 0, 0) 0%, rgba(0, 0, 0, 1) 100%);
 			content: '';
 			height: 100%;
-			left: 0;
+			inset-inline-start: 0;
 			opacity: 1;
 			position: absolute;
 			top: 0;

--- a/src/scss/04-patterns/02-content/_card-item.scss
+++ b/src/scss/04-patterns/02-content/_card-item.scss
@@ -17,7 +17,7 @@
 
 	&-left {
 		max-width: 120px;
-		padding-right: variables.$token-scale-400;
+		padding-inline-end: variables.$token-scale-400;
 	}
 
 	&-center {
@@ -25,7 +25,7 @@
 	}
 
 	&-right {
-		padding-left: variables.$token-scale-400;
+		padding-inline-start: variables.$token-scale-400;
 	}
 
 	&-title {
@@ -38,21 +38,5 @@
 		color: var(--osui-card-detail-text-color);
 		overflow: hidden;
 		text-overflow: ellipsis;
-	}
-}
-
-// IsRTL -------------------------------------------------------------------------
-///
-.is-rtl {
-	.card-detail {
-		&-left {
-			padding-left: variables.$token-scale-400;
-			padding-right: 0;
-		}
-
-		&-right {
-			padding-left: 0;
-			padding-right: variables.$token-scale-400;
-		}
 	}
 }

--- a/src/scss/04-patterns/02-content/_card-sectioned.scss
+++ b/src/scss/04-patterns/02-content/_card-sectioned.scss
@@ -9,12 +9,12 @@
 .card {
 	&-sectioned {
 		--card-sectioned-gap: #{variables.$token-scale-600};
-		--card-sectioned-top-padding: #{variables.$token-scale-600} #{variables.$token-scale-0}
-			#{variables.$token-scale-600} #{variables.$token-scale-600};
-		--card-sectioned-image-padding: variables.$token-scale-600 variables.$token-scale-600 variables.$token-scale-600
-			variables.$token-scale-0;
-		--card-sectioned-bottom-padding: #{variables.$token-scale-600} #{variables.$token-scale-600}
-			#{variables.$token-scale-0} #{variables.$token-scale-600};
+		--card-sectioned-top-padding-block: #{variables.$token-scale-600};
+		--card-sectioned-top-padding-inline: #{variables.$token-scale-600} #{variables.$token-scale-0};
+		--card-sectioned-image-padding-block: #{variables.$token-scale-600};
+		--card-sectioned-image-padding-inline: #{variables.$token-scale-0} #{variables.$token-scale-600};
+		--card-sectioned-bottom-padding-block: #{variables.$token-scale-600} #{variables.$token-scale-0};
+		--card-sectioned-bottom-padding-inline: #{variables.$token-scale-600};
 
 		display: flex;
 		gap: var(--card-sectioned-gap);
@@ -24,7 +24,8 @@
 		&-top {
 			display: flex;
 			flex: 1;
-			padding: var(--card-sectioned-top-padding);
+			padding-block: var(--card-sectioned-top-padding-block);
+			padding-inline: var(--card-sectioned-top-padding-inline);
 
 			&:has(.card-content.padding-none) {
 				padding: variables.$token-scale-0;
@@ -35,8 +36,8 @@
 		&.flex-direction-row {
 			.card {
 				&-image {
-					--card-sectioned-image-padding: #{variables.$token-scale-600} #{variables.$token-scale-600}
-						#{variables.$token-scale-600} #{variables.$token-scale-0};
+					--card-sectioned-image-padding-block: #{variables.$token-scale-600};
+					--card-sectioned-image-padding-inline: #{variables.$token-scale-0} #{variables.$token-scale-600};
 
 					&.padding-none {
 						padding: variables.$token-scale-0;
@@ -48,8 +49,8 @@
 		// Vertical: image always renders last, after the title/content/footer block
 		&.flex-direction-column {
 			.card-image {
-				--card-sectioned-image-padding: #{variables.$token-scale-0} #{variables.$token-scale-600}
-					#{variables.$token-scale-600} #{variables.$token-scale-600};
+				--card-sectioned-image-padding-block: #{variables.$token-scale-0} #{variables.$token-scale-600};
+				--card-sectioned-image-padding-inline: #{variables.$token-scale-600};
 
 				order: 1;
 
@@ -59,8 +60,8 @@
 			}
 
 			.card-sectioned-top {
-				--card-sectioned-top-padding: #{variables.$token-scale-600} #{variables.$token-scale-600}
-					#{variables.$token-scale-0} #{variables.$token-scale-600};
+				--card-sectioned-top-padding-block: #{variables.$token-scale-600} #{variables.$token-scale-0};
+				--card-sectioned-top-padding-inline: #{variables.$token-scale-600};
 
 				&:has(.card-content.padding-none) {
 					padding: variables.$token-scale-0;
@@ -82,12 +83,14 @@
 	&-image {
 		flex: 1;
 		order: 1;
-		padding: var(--card-sectioned-image-padding);
+		padding-block: var(--card-sectioned-image-padding-block);
+		padding-inline: var(--card-sectioned-image-padding-inline);
 
 		& img {
 			display: block;
 			height: 100%;
-			margin: 0 auto;
+			margin-block: 0;
+			margin-inline: auto;
 			object-fit: cover;
 			width: 100%;
 		}
@@ -97,7 +100,7 @@
 		color: var(--color-text);
 		font-size: variables.$token-font-size-550;
 		font-weight: variables.$token-font-weight-semi-bold;
-		margin-bottom: variables.$token-scale-600;
+		margin-block-end: variables.$token-scale-600;
 	}
 
 	&-content {
@@ -107,7 +110,7 @@
 	&-bottom {
 		align-items: center;
 		display: flex;
-		margin-top: variables.$token-scale-1000;
+		margin-block-start: variables.$token-scale-1000;
 
 		.btn {
 			width: 100%;
@@ -121,12 +124,12 @@
 		&-sectioned {
 			--card-sectioned-gap: #{variables.$token-scale-400};
 			--card-sectioned-padding: #{variables.$token-scale-400};
-			--card-sectioned-top-padding: #{variables.$token-scale-400} #{variables.$token-scale-0}
-				#{variables.$token-scale-400} #{variables.$token-scale-400};
-			--card-sectioned-image-padding: variables.$token-scale-400 variables.$token-scale-400
-				variables.$token-scale-400 variables.$token-scale-0;
-			--card-sectioned-bottom-padding: #{variables.$token-scale-400} #{variables.$token-scale-400}
-				#{variables.$token-scale-0} #{variables.$token-scale-400};
+			--card-sectioned-top-padding-block: #{variables.$token-scale-400};
+			--card-sectioned-top-padding-inline: #{variables.$token-scale-400} #{variables.$token-scale-0};
+			--card-sectioned-image-padding-block: #{variables.$token-scale-400};
+			--card-sectioned-image-padding-inline: #{variables.$token-scale-0} #{variables.$token-scale-400};
+			--card-sectioned-bottom-padding-block: #{variables.$token-scale-400} #{variables.$token-scale-0};
+			--card-sectioned-bottom-padding-inline: #{variables.$token-scale-400};
 
 			padding: variables.$token-scale-0;
 
@@ -134,8 +137,8 @@
 			&.flex-direction-row {
 				.card {
 					&-image {
-						--card-sectioned-image-padding: #{variables.$token-scale-400} #{variables.$token-scale-400}
-							#{variables.$token-scale-400} #{variables.$token-scale-0};
+						--card-sectioned-image-padding-block: #{variables.$token-scale-400};
+						--card-sectioned-image-padding-inline: #{variables.$token-scale-0} #{variables.$token-scale-400};
 					}
 				}
 			}
@@ -143,13 +146,13 @@
 			// Vertical: image always renders last, after the title/content/footer block
 			&.flex-direction-column {
 				.card-image {
-					--card-sectioned-image-padding: #{variables.$token-scale-0} #{variables.$token-scale-400}
-						#{variables.$token-scale-400} #{variables.$token-scale-400};
+					--card-sectioned-image-padding-block: #{variables.$token-scale-0} #{variables.$token-scale-400};
+					--card-sectioned-image-padding-inline: #{variables.$token-scale-400};
 				}
 
 				.card-sectioned-top {
-					--card-sectioned-top-padding: #{variables.$token-scale-400} #{variables.$token-scale-400}
-						#{variables.$token-scale-0} #{variables.$token-scale-400};
+					--card-sectioned-top-padding-block: #{variables.$token-scale-400} #{variables.$token-scale-0};
+					--card-sectioned-top-padding-inline: #{variables.$token-scale-400};
 				}
 			}
 		}
@@ -170,20 +173,3 @@
 	}
 }
 
-// IsRTL ------------------------------------------------------------------------------
-///
-.is-rtl {
-	.card-sectioned {
-		&.flex-direction-row {
-			.card-image {
-				--card-sectioned-image-padding: #{variables.$token-scale-600} #{variables.$token-scale-0}
-					#{variables.$token-scale-600} #{variables.$token-scale-600};
-			}
-
-			.card-sectioned-top {
-				--card-sectioned-top-padding: #{variables.$token-scale-600} #{variables.$token-scale-600}
-					#{variables.$token-scale-600} #{variables.$token-scale-0};
-			}
-		}
-	}
-}

--- a/src/scss/04-patterns/02-content/_chat-message.scss
+++ b/src/scss/04-patterns/02-content/_chat-message.scss
@@ -25,8 +25,8 @@
 
 		.chat {
 			&-photo {
-				margin-left: variables.$token-space-400;
-				margin-right: variables.$token-scale-0;
+				margin-inline-start: variables.$token-space-400;
+				margin-inline-end: variables.$token-scale-0;
 			}
 
 			&-message {
@@ -37,7 +37,7 @@
 	}
 
 	&-photo {
-		margin-right: variables.$token-space-400;
+		margin-inline-end: variables.$token-space-400;
 
 		img {
 			border-radius: var(--border-radius-rounded);
@@ -62,32 +62,12 @@
 			display: block;
 			font-size: variables.$token-font-size-275;
 			line-height: var(--osui-chat-message-status-line-height);
-			margin-top: variables.$token-space-100;
+			margin-block-start: variables.$token-space-100;
 			width: 100%;
 
 			&.hidden {
 				display: none;
 			}
-		}
-	}
-}
-
-// IsRTL --------------------------------------------------------------------
-///
-.is-rtl {
-	.chat {
-		&.right {
-			.chat {
-				&-photo {
-					margin-left: variables.$token-scale-0;
-					margin-right: variables.$token-space-400;
-				}
-			}
-		}
-
-		&-photo {
-			margin-left: variables.$token-space-400;
-			margin-right: 0;
 		}
 	}
 }

--- a/src/scss/04-patterns/02-content/_floating-content.scss
+++ b/src/scss/04-patterns/02-content/_floating-content.scss
@@ -13,8 +13,8 @@
 
 	&.floating-content-full {
 		&-width {
-			left: 0;
-			right: 0;
+			inset-inline-end: 0;
+			inset-inline-start: 0;
 			width: auto;
 
 			& > .OSInline {
@@ -23,7 +23,7 @@
 		}
 
 		&-height {
-			margin-top: 0;
+			margin-block-start: 0;
 			top: calc(var(--size-header) + variables.$token-space-400 * 2);
 
 			&.absolute-top {
@@ -52,31 +52,31 @@
 
 	&-top {
 		left: 50%;
-		margin-top: 0;
+		margin-block-start: 0;
 		top: calc(var(--size-header) + variables.$token-space-400 * 2);
 		transform: translateX(-50%);
 
 		&-left {
-			left: 0;
-			margin-top: 0;
+			inset-inline-start: 0;
+			margin-block-start: 0;
 			top: calc(var(--size-header) + variables.$token-space-400 * 2);
 		}
 
 		&-right {
-			margin-top: 0;
-			right: 0;
+			inset-inline-end: 0;
+			margin-block-start: 0;
 			top: calc(var(--size-header) + variables.$token-space-400 * 2);
 		}
 	}
 
 	&-left {
-		left: 0;
+		inset-inline-start: 0;
 		top: 50%;
 		transform: translateY(-50%);
 	}
 
 	&-right {
-		right: 0;
+		inset-inline-end: 0;
 		top: 50%;
 		transform: translateY(-50%);
 	}
@@ -113,12 +113,12 @@
 
 		&-left {
 			bottom: 0;
-			left: 0;
+			inset-inline-start: 0;
 		}
 
 		&-right {
 			bottom: 0;
-			right: 0;
+			inset-inline-end: 0;
 		}
 	}
 
@@ -158,7 +158,7 @@
 
 		&.floating-content {
 			&-center {
-				left: calc(50% - variables.$token-space-800);
+				inset-inline-start: calc(50% - variables.$token-space-800);
 				top: calc(50% - variables.$token-space-800);
 			}
 
@@ -169,7 +169,7 @@
 			&-top,
 			&-bottom,
 			&-center {
-				left: calc(50% - variables.$token-space-800);
+				inset-inline-start: calc(50% - variables.$token-space-800);
 			}
 		}
 	}
@@ -214,14 +214,14 @@
 				&-top:not(.absolute-top),
 				&-center:not(.absolute-center),
 				&-bottom:not(.absolute-bottom) {
-					left: calc(50% + ((var(--size-side-menu) / 2)));
+					inset-inline-start: calc(50% + ((var(--size-side-menu) / 2)));
 				}
 
 				&.floating-content-full-width,
 				&-left:not(.absolute-left),
 				&-bottom-left:not(.absolute-left),
 				&-top-left:not(.absolute-left) {
-					left: var(--size-side-menu);
+					inset-inline-start: var(--size-side-menu);
 				}
 			}
 		}
@@ -237,7 +237,7 @@
 			&-left,
 			&-bottom-left {
 				&:not(.absolute-left) {
-					left: var(--size-side-menu);
+					inset-inline-start: var(--size-side-menu);
 				}
 			}
 		}
@@ -246,7 +246,7 @@
 	.layout-native {
 		.aside-visible {
 			.floating-content.floating-content-full-width {
-				left: var(--size-side-menu);
+				inset-inline-start: var(--size-side-menu);
 			}
 		}
 	}
@@ -259,7 +259,7 @@
 			.floating-content.floating-content-full-width {
 				.aside-visible.menu-visible {
 					.floating-content.floating-content-full-width {
-						left: var(--size-side-menu);
+						inset-inline-start: var(--size-side-menu);
 					}
 				}
 			}
@@ -278,8 +278,8 @@
 				}
 
 				&-width {
-					left: 0;
-					right: 0;
+					inset-inline-end: 0;
+					inset-inline-start: 0;
 				}
 			}
 
@@ -303,12 +303,12 @@
 	.floating-content {
 		&-top-left,
 		&-left {
-			left: var(--os-safe-area-left);
+			inset-inline-start: var(--os-safe-area-inline-start);
 		}
 
 		&-top-right,
 		&-right {
-			right: var(--os-safe-area-right);
+			inset-inline-end: var(--os-safe-area-inline-end);
 		}
 
 		&-bottom {
@@ -316,12 +316,12 @@
 
 			&-left {
 				bottom: var(--os-safe-area-bottom);
-				left: var(--os-safe-area-left);
+				inset-inline-start: var(--os-safe-area-inline-start);
 			}
 
 			&-right {
 				bottom: var(--os-safe-area-bottom);
-				right: var(--os-safe-area-right);
+				inset-inline-end: var(--os-safe-area-inline-end);
 			}
 		}
 	}

--- a/src/scss/04-patterns/02-content/_floating-content.scss
+++ b/src/scss/04-patterns/02-content/_floating-content.scss
@@ -303,12 +303,12 @@
 	.floating-content {
 		&-top-left,
 		&-left {
-			inset-inline-start: var(--os-safe-area-inline-start);
+			left: var(--os-safe-area-left);
 		}
 
 		&-top-right,
 		&-right {
-			inset-inline-end: var(--os-safe-area-inline-end);
+			right: var(--os-safe-area-right);
 		}
 
 		&-bottom {
@@ -316,12 +316,12 @@
 
 			&-left {
 				bottom: var(--os-safe-area-bottom);
-				inset-inline-start: var(--os-safe-area-inline-start);
+				left: var(--os-safe-area-left);
 			}
 
 			&-right {
 				bottom: var(--os-safe-area-bottom);
-				inset-inline-end: var(--os-safe-area-inline-end);
+				right: var(--os-safe-area-right);
 			}
 		}
 	}

--- a/src/scss/04-patterns/02-content/_list-item-content.scss
+++ b/src/scss/04-patterns/02-content/_list-item-content.scss
@@ -21,7 +21,7 @@
 
 	&-left {
 		max-width: 120px;
-		padding-right: variables.$token-space-400;
+		padding-inline-end: variables.$token-space-400;
 	}
 
 	&-center {
@@ -30,7 +30,7 @@
 	}
 
 	&-right {
-		padding-left: variables.$token-space-600;
+		padding-inline-start: variables.$token-space-600;
 
 		// Trailing icon renders in a 20px box (Figma CaretRight); `line-height: 1`
 		// keeps the glyph box square instead of inheriting the row's line-height.
@@ -67,11 +67,11 @@
 .layout-native {
 	.list-item-content {
 		&-left {
-			padding-right: variables.$token-space-400;
+			padding-inline-end: variables.$token-space-400;
 		}
 
 		&-right {
-			padding-left: variables.$token-space-600;
+			padding-inline-start: variables.$token-space-600;
 		}
 	}
 }
@@ -79,31 +79,6 @@
 // IsRTL -------------------------------------------------------------------------
 ///
 .is-rtl {
-	.list-item-content {
-		&-left {
-			padding-left: variables.$token-space-400;
-			padding-right: 0;
-		}
-
-		&-right {
-			padding-left: 0;
-			padding-right: variables.$token-space-600;
-		}
-	}
-
-	.layout-native {
-		.list-item-content {
-			&-left {
-				padding-left: variables.$token-space-400;
-				padding-right: 0;
-			}
-
-			&-right {
-				padding-left: 0;
-				padding-right: variables.$token-space-600;
-			}
-		}
-	}
 
 	[data-list-item] {
 		.list-item-float {

--- a/src/scss/04-patterns/02-content/_section.scss
+++ b/src/scss/04-patterns/02-content/_section.scss
@@ -19,12 +19,13 @@
 
 	&-title {
 		background-color: transparent;
-		border-bottom: variables.$token-border-size-025 solid var(--osui-section-title-border-color);
+		border-block-end: variables.$token-border-size-025 solid var(--osui-section-title-border-color);
 		color: var(--osui-section-title-color);
 		font-size: variables.$token-font-size-500;
 		font-weight: variables.$token-font-weight-semi-bold;
 		line-height: var(--osui-section-title-line-height);
-		padding: variables.$token-scale-0 variables.$token-scale-0 variables.$token-space-200 variables.$token-scale-0;
+		padding-block: variables.$token-scale-0 variables.$token-space-200;
+		padding-inline: variables.$token-scale-0;
 		position: relative;
 		text-transform: none;
 		width: 100%;
@@ -33,7 +34,8 @@
 	&-content {
 		color: var(--osui-section-content-color);
 		line-height: var(--osui-section-content-line-height);
-		padding: variables.$token-space-200 variables.$token-scale-0 variables.$token-scale-0;
+		padding-block: variables.$token-space-200 variables.$token-scale-0;
+		padding-inline: variables.$token-scale-0;
 	}
 
 	&-group {
@@ -64,7 +66,8 @@
 .layout-native {
 	.section {
 		&-title {
-			padding: variables.$token-scale-200 variables.$token-scale-400 variables.$token-scale-200 variables.$token-scale-400;
+			padding-block: variables.$token-scale-200;
+			padding-inline: variables.$token-scale-400;
 		}
 
 		&-content {

--- a/src/scss/04-patterns/02-content/_tag.scss
+++ b/src/scss/04-patterns/02-content/_tag.scss
@@ -45,7 +45,8 @@ $osui-tag-lightest-text-colors: (
 	line-height: var(--osui-font-line-height-full);
 	min-height: variables.$token-scale-500;
 	min-width: unset;
-	padding: variables.$token-space-0 variables.$token-space-200;
+	padding-block: variables.$token-space-0;
+	padding-inline: variables.$token-space-200;
 	word-break: normal;
 
 	// Figma Tag spec: Soft shape uses the 4px radius token (border/border-radius/100),
@@ -58,13 +59,15 @@ $osui-tag-lightest-text-colors: (
 		&-small {
 			min-height: variables.$token-scale-400;
 			min-width: variables.$token-scale-400;
-			padding: variables.$token-space-0 variables.$token-space-150;
+			padding-block: variables.$token-space-0;
+			padding-inline: variables.$token-space-150;
 		}
 
 		&-medium {
 			font-size: variables.$token-font-size-350;
 			min-height: variables.$token-scale-700;
-			padding: variables.$token-space-0 variables.$token-space-250;
+			padding-block: variables.$token-space-0;
+			padding-inline: variables.$token-space-250;
 
 			// Figma Tag spec: the Medium size steps the Soft shape up to the 8px
 			// radius token (border/border-radius/200), unlike the 4px default.

--- a/src/scss/04-patterns/02-content/accordion-item/_accordion-item.scss
+++ b/src/scss/04-patterns/02-content/accordion-item/_accordion-item.scss
@@ -100,13 +100,13 @@
 	&__title {
 		align-items: center;
 		color: var(--osui-accordion-item-color);
-		direction: ltr;
 		display: flex;
 		font-size: variables.$token-font-size-400;
 		gap: variables.$token-scale-200;
 		justify-content: space-between;
 		line-height: 1;
-		padding: variables.$token-scale-300 variables.$token-scale-600;
+		padding-block: variables.$token-scale-300;
+		padding-inline: variables.$token-scale-600;
 		width: 100%;
 
 		&:hover {
@@ -136,7 +136,7 @@
 			> a,
 			> button {
 				align-self: center;
-				margin-top: unset;
+				margin-block-start: unset;
 			}
 		}
 
@@ -193,7 +193,8 @@
 		display: block;
 		font-size: variables.$token-font-size-400;
 		overflow: hidden;
-		padding: variables.$token-scale-0 variables.$token-scale-600;
+		padding-block: variables.$token-scale-0;
+		padding-inline: variables.$token-scale-600;
 
 		&--is {
 			&-collapsed {
@@ -209,7 +210,8 @@
 
 			&-expanded {
 				height: auto;
-				padding: variables.$token-scale-0 variables.$token-scale-600 variables.$token-scale-600;
+				padding-block: variables.$token-scale-0 variables.$token-scale-600;
+				padding-inline: variables.$token-scale-600;
 				visibility: visible;
 			}
 
@@ -219,12 +221,12 @@
 		}
 
 		& > div {
-			padding-top: variables.$token-scale-300;
+			padding-block-start: variables.$token-scale-300;
 		}
 
 		/* Add a margin-top when animated label is the first child */
 		[data-block*='AnimatedLabel']:first-child .animated-label {
-			margin-top: variables.$token-scale-200;
+			margin-block-start: variables.$token-scale-200;
 		}
 	}
 
@@ -241,7 +243,7 @@
 
 	// Accordion inside accordion
 	.osui-accordion {
-		margin-top: var(--accordion-active-border-size);
+		margin-block-start: var(--accordion-active-border-size);
 	}
 }
 
@@ -261,15 +263,18 @@
 		}
 
 		&__content {
-			padding: variables.$token-scale-0 variables.$token-scale-400;
+			padding-block: variables.$token-scale-0;
+			padding-inline: variables.$token-scale-400;
 
 			&--is {
 				&-collapsed {
-					padding: variables.$token-scale-0 variables.$token-scale-400;
+					padding-block: variables.$token-scale-0;
+					padding-inline: variables.$token-scale-400;
 				}
 
 				&-expanded {
-					padding: variables.$token-scale-0 variables.$token-scale-400 variables.$token-scale-400;
+					padding-block: variables.$token-scale-0 variables.$token-scale-400;
+					padding-inline: variables.$token-scale-400;
 				}
 			}
 		}
@@ -293,11 +298,3 @@
 	}
 }
 
-// IsRTL -------------------------------------------------------------------------
-///
-.is-rtl {
-	.osui-accordion-item__title__placeholder {
-		direction: rtl;
-		margin-right: variables.$token-scale-200;
-	}
-}

--- a/src/scss/04-patterns/02-content/accordion/_accordion.scss
+++ b/src/scss/04-patterns/02-content/accordion/_accordion.scss
@@ -17,10 +17,10 @@
 	:not(:last-child):not(.list) >,
 	.list :not(:last-child) > {
 		.osui-accordion-item {
-			border-bottom: var(--osui-accordion-item-border-width) solid var(--osui-accordion-item-border-color);
+			border-block-end: var(--osui-accordion-item-border-width) solid var(--osui-accordion-item-border-color);
 
 			&:not(.osui-accordion-item--is-open):hover {
-				border-bottom-color: var(--osui-accordion-item-title-hover-border-color);
+				border-block-end-color: var(--osui-accordion-item-title-hover-border-color);
 			}
 		}
 	}
@@ -29,8 +29,8 @@
 	:first-child:not(.list) >,
 	.list :first-child > {
 		.osui-accordion-item {
-			border-top-left-radius: variables.$token-border-radius-400;
-			border-top-right-radius: variables.$token-border-radius-400;
+			border-start-end-radius: variables.$token-border-radius-400;
+			border-start-start-radius: variables.$token-border-radius-400;
 			overflow: hidden;
 		}
 	}
@@ -39,8 +39,8 @@
 	:last-child:not(.list) >,
 	.list :last-child > {
 		.osui-accordion-item {
-			border-bottom-left-radius: variables.$token-border-radius-400;
-			border-bottom-right-radius: variables.$token-border-radius-400;
+			border-end-end-radius: variables.$token-border-radius-400;
+			border-end-start-radius: variables.$token-border-radius-400;
 			overflow: hidden;
 
 			&:not(.osui-accordion-item--is-open) {

--- a/src/scss/04-patterns/02-content/carousel/_carousel.scss
+++ b/src/scss/04-patterns/02-content/carousel/_carousel.scss
@@ -21,7 +21,6 @@
 	--osui-carousel-pagination-margin: #{variables.$token-scale-1000};
 	// ───────────────────────────────────────────────────────────────────
 
-
 	.splide {
 		&__arrow {
 			background-color: var(--osui-carousel-arrow-background);
@@ -109,7 +108,7 @@
 
 	&--has-pagination {
 		// To fix pagination position so that it appears below Carousel
-		padding-bottom: var(--osui-carousel-pagination-margin);
+		padding-block-end: var(--osui-carousel-pagination-margin);
 
 		// Adjust rule when using List inside
 		&:not(.splide) {
@@ -209,7 +208,8 @@
 		}
 
 		li {
-			margin: variables.$token-scale-0 variables.$token-scale-100;
+			margin-block: variables.$token-scale-0;
+			margin-inline: variables.$token-scale-100;
 		}
 	}
 }

--- a/src/scss/04-patterns/02-content/flip-content/_flipcontent.scss
+++ b/src/scss/04-patterns/02-content/flip-content/_flipcontent.scss
@@ -57,7 +57,7 @@
 		&__front,
 		&__back {
 			backface-visibility: hidden;
-			left: 0;
+			inset-inline-start: 0;
 			top: 0;
 
 			&:empty {

--- a/src/scss/04-patterns/02-content/wizard/_wizard-item.scss
+++ b/src/scss/04-patterns/02-content/wizard/_wizard-item.scss
@@ -89,7 +89,8 @@
 	}
 
 	&-icon-wrapper {
-		margin: variables.$token-space-200 variables.$token-space-0;
+		margin-block: variables.$token-space-200;
+		margin-inline: variables.$token-space-0;
 		position: relative;
 		width: 100%;
 
@@ -105,7 +106,7 @@
 			content: '';
 			height: var(--osui-wizard-connector-size);
 			position: absolute;
-			right: 50%;
+			inset-inline-end: 50%;
 			top: 50%;
 			transform: translateY(-50%);
 			width: 100%;
@@ -124,7 +125,8 @@
 		font-weight: var(--osui-wizard-icon-font-weight);
 		height: var(--osui-wizard-icon-size, #{variables.$token-scale-1000});
 		justify-content: center;
-		margin: 0 auto;
+		margin-block: 0;
+		margin-inline: auto;
 		padding: var(--osui-wizard-icon-padding);
 		position: relative;
 		width: var(--osui-wizard-icon-size, #{variables.$token-scale-1000});
@@ -154,19 +156,6 @@
 		font-size: var(--osui-wizard-font-size);
 		line-height: var(--osui-wizard-label-line-height);
 		text-align: center;
-	}
-}
-
-// IsRTL ---------------------------------------------------------------------------
-///
-.is-rtl {
-	.osui-wizard-item {
-		&-icon-wrapper {
-			&:before {
-				left: calc(50% + var(--osui-wizard-icon-size, #{variables.$token-scale-1000}) / 2);
-				right: auto;
-			}
-		}
 	}
 }
 

--- a/src/scss/04-patterns/02-content/wizard/_wizard.scss
+++ b/src/scss/04-patterns/02-content/wizard/_wizard.scss
@@ -38,29 +38,33 @@
 	&.is-vertical {
 		[data-block*='WizardItem']:last-child {
 			.osui-wizard-item {
-				margin-bottom: variables.$token-scale-0;
+				margin-block-end: variables.$token-scale-0;
 			}
 		}
 
 		.osui-wizard-item {
 			align-items: center;
 			flex-direction: row;
-			margin-bottom: var(--osui-wizard-item-spacing);
+			margin-block-end: var(--osui-wizard-item-spacing);
 
 			&.is-reversed {
 				flex-direction: row-reverse;
 
 				.osui-wizard-item-label {
-					text-align: right;
+					text-align: end;
 				}
 
 				.osui-wizard-item-icon-wrapper {
-					margin: variables.$token-scale-0 variables.$token-scale-0 variables.$token-scale-0 variables.$token-scale-200;
+					margin-block: variables.$token-scale-0;
+					margin-inline-end: variables.$token-scale-0;
+					margin-inline-start: variables.$token-scale-200;
 				}
 			}
 
 			.osui-wizard-item-icon-wrapper {
-				margin: variables.$token-scale-0 variables.$token-scale-200 variables.$token-scale-0 variables.$token-scale-0;
+				margin-block: variables.$token-scale-0;
+				margin-inline-end: variables.$token-scale-200;
+				margin-inline-start: variables.$token-scale-0;
 				width: auto;
 
 				// Same marker-centre-to-marker-centre rule as the horizontal connector, on
@@ -115,34 +119,6 @@
 			.osui-wizard-item-icon-wrapper {
 				&:before {
 					content: none;
-				}
-			}
-		}
-	}
-}
-
-// IsRTL ---------------------------------------------------------------------------
-///
-.is-rtl {
-	.osui-wizard {
-		// Mirror of the LTR connector: same marker-centre anchor, extended the other way.
-		// `right`/`width` are physical, so without this the horizontal connector would
-		// point away from the previous step.
-		.osui-wizard-item-icon-wrapper:before {
-			left: 50%;
-			right: auto;
-		}
-
-		&.is-vertical {
-			.osui-wizard-item {
-				.osui-wizard-item-icon-wrapper {
-					margin: variables.$token-scale-0 variables.$token-scale-0 variables.$token-scale-0 variables.$token-scale-200;
-				}
-
-				&.is-reversed {
-					.osui-wizard-item-icon-wrapper {
-						margin: variables.$token-scale-0 variables.$token-scale-200 variables.$token-scale-0 variables.$token-scale-0;
-					}
 				}
 			}
 		}

--- a/src/scss/04-patterns/03-interaction/_action-sheet.scss
+++ b/src/scss/04-patterns/03-interaction/_action-sheet.scss
@@ -18,12 +18,12 @@
 	// ───────────────────────────────────────────────────────────────────
 
 	bottom: 0;
-	left: 0;
-	margin-top: 0;
-	padding-bottom: calc(var(--os-safe-area-bottom) + variables.$token-scale-400);
-	padding-left: calc(var(--os-safe-area-left) + variables.$token-scale-400);
-	padding-right: calc(var(--os-safe-area-right) + variables.$token-scale-400);
-	padding-top: variables.$token-scale-400;
+	inset-inline-start: 0;
+	margin-block-start: 0;
+	padding-block-end: calc(var(--os-safe-area-bottom) + variables.$token-scale-400);
+	padding-inline-start: calc(var(--os-safe-area-inline-start) + variables.$token-scale-400);
+	padding-inline-end: calc(var(--os-safe-area-inline-end) + variables.$token-scale-400);
+	padding-block-start: variables.$token-scale-400;
 	pointer-events: auto;
 	position: absolute;
 	transform: translateY(100%);
@@ -45,7 +45,7 @@
 		// ───────────────────────────────────────────────────────────────────
 
 		height: 100%;
-		left: 0;
+		inset-inline-start: 0;
 		overflow: hidden;
 		pointer-events: none;
 		position: fixed;
@@ -63,7 +63,7 @@
 			content: '';
 			display: block;
 			height: 100%;
-			left: 0;
+			inset-inline-start: 0;
 			opacity: 0;
 			pointer-events: none;
 			position: absolute;
@@ -129,17 +129,17 @@
 			@include apply-typography(variables.$token-body-action-sm);
 
 			border: none;
-			margin-top: 1px;
+			margin-block-start: 1px;
 			width: 100%;
 		}
 
 		&:first-child .btn {
-			margin-top: 0;
+			margin-block-start: 0;
 		}
 	}
 
 	&-cancel {
-		margin-top: variables.$token-scale-200;
+		margin-block-start: variables.$token-scale-200;
 
 		.btn {
 			--osui-btn-background: var(--osui-action-sheet-background);
@@ -174,11 +174,13 @@
 	.action-sheet {
 		&-buttons,
 		&-cancel {
-			margin: variables.$token-scale-0 auto;
+			margin-block: variables.$token-scale-0;
+			margin-inline: auto;
 		}
 
 		&-cancel {
-			margin: variables.$token-scale-400 auto variables.$token-scale-0;
+			margin-block: variables.$token-scale-400 variables.$token-scale-0;
+			margin-inline: auto;
 		}
 	}
 }

--- a/src/scss/04-patterns/03-interaction/_action-sheet.scss
+++ b/src/scss/04-patterns/03-interaction/_action-sheet.scss
@@ -20,9 +20,9 @@
 	bottom: 0;
 	inset-inline-start: 0;
 	margin-block-start: 0;
-	padding-block-end: calc(var(--os-safe-area-bottom) + variables.$token-scale-400);
-	padding-inline-start: calc(var(--os-safe-area-inline-start) + variables.$token-scale-400);
-	padding-inline-end: calc(var(--os-safe-area-inline-end) + variables.$token-scale-400);
+	padding-bottom: calc(var(--os-safe-area-bottom) + variables.$token-scale-400);
+	padding-left: calc(var(--os-safe-area-left) + variables.$token-scale-400);
+	padding-right: calc(var(--os-safe-area-right) + variables.$token-scale-400);
 	padding-block-start: variables.$token-scale-400;
 	pointer-events: auto;
 	position: absolute;

--- a/src/scss/04-patterns/03-interaction/_floating-actions.scss
+++ b/src/scss/04-patterns/03-interaction/_floating-actions.scss
@@ -214,7 +214,7 @@
 		&.portrait {
 			.layout-native {
 				.floating-actions-wrapper {
-					margin-block-end: var(--os-safe-area-bottom);
+					margin-bottom: var(--os-safe-area-bottom);
 				}
 			}
 		}
@@ -222,7 +222,7 @@
 		&.landscape {
 			.layout-native {
 				.floating-actions-wrapper {
-					margin-inline-end: calc(var(--os-safe-area-inline-end) + variables.$token-scale-400);
+					margin-right: calc(var(--os-safe-area-right) + variables.$token-scale-400);
 				}
 			}
 		}

--- a/src/scss/04-patterns/03-interaction/_floating-actions.scss
+++ b/src/scss/04-patterns/03-interaction/_floating-actions.scss
@@ -32,7 +32,7 @@
 		flex-direction: column;
 		margin: variables.$token-scale-800;
 		position: fixed;
-		right: 0;
+		inset-inline-end: 0;
 		will-change: transform, opacity;
 		z-index: var(--osui-floating-actions-layer);
 
@@ -94,15 +94,15 @@
 		align-items: flex-end;
 		display: flex;
 		flex-direction: column;
-		padding-bottom: variables.$token-scale-200;
-		padding-right: variables.$token-scale-200;
+		padding-block-end: variables.$token-scale-200;
+		padding-inline-end: variables.$token-scale-200;
 	}
 
 	&-actions-item {
 		align-items: center;
 		display: flex;
 		justify-content: flex-end;
-		margin-bottom: variables.$token-scale-400;
+		margin-block-end: variables.$token-scale-400;
 		opacity: 0;
 		transform: translateY(variables.$token-scale-400) translateZ(0);
 		transition:
@@ -127,7 +127,7 @@
 		font-size: variables.$token-font-size-500;
 		height: variables.$token-scale-1000;
 		justify-content: center;
-		margin-left: variables.$token-scale-400;
+		margin-inline-start: variables.$token-scale-400;
 		transform: translateZ(0) scale(0.3);
 		transition: transform variables.$token-transition-time-200 variables.$token-transition-curve-quick;
 		transition-delay: calc(var(--delay) * 40ms); // design-spec: stagger delay
@@ -182,7 +182,7 @@
 		opacity: 0;
 		pointer-events: none;
 		position: fixed;
-		right: 0;
+		inset-inline-end: 0;
 		top: 0;
 		transition: opacity variables.$token-transition-time-200 variables.$token-transition-curve-base;
 		width: 100vw;
@@ -214,7 +214,7 @@
 		&.portrait {
 			.layout-native {
 				.floating-actions-wrapper {
-					margin-bottom: var(--os-safe-area-bottom);
+					margin-block-end: var(--os-safe-area-bottom);
 				}
 			}
 		}
@@ -222,7 +222,7 @@
 		&.landscape {
 			.layout-native {
 				.floating-actions-wrapper {
-					margin-right: calc(var(--os-safe-area-right) + variables.$token-scale-400);
+					margin-inline-end: calc(var(--os-safe-area-inline-end) + variables.$token-scale-400);
 				}
 			}
 		}
@@ -234,23 +234,9 @@
 	&.ios {
 		.floating-actions-wrapper {
 			&.bottom-bar-exists {
-				margin-bottom: 0;
+				margin-block-end: 0;
 			}
 		}
-	}
-}
-
-// IsRTL --------------------------------------------------------------------
-///
-.is-rtl {
-	.floating-actions-item-button {
-		margin-left: variables.$token-scale-0;
-		margin-right: variables.$token-scale-400;
-	}
-
-	.floating-actions-wrapper {
-		left: 0;
-		right: auto;
 	}
 }
 

--- a/src/scss/04-patterns/03-interaction/_input-with-icon.scss
+++ b/src/scss/04-patterns/03-interaction/_input-with-icon.scss
@@ -17,17 +17,17 @@
 
 	&.input-with-icon-right {
 		.input-with-icon-content-icon {
-			left: auto;
-			right: 0;
+			inset-inline-start: auto;
+			inset-inline-end: 0;
 
 			&:not(:empty) + .input-with-icon-input input {
-				padding-left: variables.$token-scale-400;
-				padding-right: variables.$token-scale-1000;
+				padding-inline-start: variables.$token-scale-400;
+				padding-inline-end: variables.$token-scale-1000;
 			}
 
 			&.search-actions {
-				left: 0;
-				right: auto;
+				inset-inline-start: 0;
+				inset-inline-end: auto;
 			}
 		}
 	}
@@ -40,7 +40,7 @@
 	   and the padding pair is already set in that block. */
 	&:not(.input-with-icon-right):has(.input-with-icon-content-icon.search-actions:not(:empty)) {
 		.input-with-icon-input input {
-			padding-right: variables.$token-scale-1000;
+			padding-inline-end: variables.$token-scale-1000;
 		}
 	}
 
@@ -52,7 +52,7 @@
 			display: inline-flex;
 			height: 100%;
 			justify-content: center;
-			left: 0;
+			inset-inline-start: 0;
 			position: absolute;
 			width: variables.$token-scale-1000;
 
@@ -62,12 +62,12 @@
 			}
 
 			&:not(:empty) + .input-with-icon-input input {
-				padding-left: variables.$token-scale-1000;
+				padding-inline-start: variables.$token-scale-1000;
 			}
 
 			&.search-actions {
-				left: auto;
-				right: 0;
+				inset-inline-start: auto;
+				inset-inline-end: 0;
 
 				&:hover {
 					color: var(--osui-input-with-icon-icon-hover-color);
@@ -100,12 +100,12 @@
 .form {
 	.input-with-icon {
 		.input-with-icon-content-icon {
-			padding-bottom: variables.$token-scale-600;
+			padding-block-end: variables.$token-scale-600;
 			z-index: var(--layer-local-tier-1);
 		}
 
 		.form-control[class*='ThemeGrid_Width'].not-valid ~ span.validation-message {
-			left: 0;
+			inset-inline-start: 0;
 		}
 	}
 }

--- a/src/scss/04-patterns/03-interaction/_lightbox-image.scss
+++ b/src/scss/04-patterns/03-interaction/_lightbox-image.scss
@@ -89,8 +89,8 @@
 
 ///
 .pswp__top-bar {
-	padding-inline-start: var(--os-safe-area-inline-start);
-	padding-inline-end: var(--os-safe-area-inline-end);
+	padding-left: var(--os-safe-area-left);
+	padding-right: var(--os-safe-area-right);
 }
 
 // Responsive --------------------------------------------------------------------
@@ -106,12 +106,12 @@
 ///
 .ios {
 	.pswp__top-bar {
-		padding-inline-start: var(--os-safe-area-inline-start);
-		padding-inline-end: var(--os-safe-area-inline-end);
+		padding-left: var(--os-safe-area-left);
+		padding-right: var(--os-safe-area-right);
 		top: var(--os-safe-area-top);
 
 		.pswp__counter {
-			inset-inline-start: var(--os-safe-area-inline-start);
+			left: var(--os-safe-area-left);
 		}
 	}
 }
@@ -119,7 +119,7 @@
 ///
 .phone {
 	.pswp__caption__center {
-		padding-block-end: calc(var(--os-safe-area-bottom) + 10px); // design-spec: 10px caption offset
+		padding-bottom: calc(var(--os-safe-area-bottom) + 10px); // design-spec: 10px caption offset
 	}
 }
 

--- a/src/scss/04-patterns/03-interaction/_lightbox-image.scss
+++ b/src/scss/04-patterns/03-interaction/_lightbox-image.scss
@@ -89,8 +89,8 @@
 
 ///
 .pswp__top-bar {
-	padding-left: var(--os-safe-area-left);
-	padding-right: var(--os-safe-area-right);
+	padding-inline-start: var(--os-safe-area-inline-start);
+	padding-inline-end: var(--os-safe-area-inline-end);
 }
 
 // Responsive --------------------------------------------------------------------
@@ -98,20 +98,20 @@
 .android {
 	.pswp__top-bar {
 		top: #{android-safe-area-top()};
-		padding-left: var(--safe-area-inset-left, 0px);
-		padding-right: var(--safe-area-inset-right, 0px);
+		padding-inline-start: var(--safe-area-inset-left, 0px);
+		padding-inline-end: var(--safe-area-inset-right, 0px);
 	}
 }
 
 ///
 .ios {
 	.pswp__top-bar {
-		padding-left: var(--os-safe-area-left);
-		padding-right: var(--os-safe-area-right);
+		padding-inline-start: var(--os-safe-area-inline-start);
+		padding-inline-end: var(--os-safe-area-inline-end);
 		top: var(--os-safe-area-top);
 
 		.pswp__counter {
-			left: var(--os-safe-area-left);
+			inset-inline-start: var(--os-safe-area-inline-start);
 		}
 	}
 }
@@ -119,7 +119,7 @@
 ///
 .phone {
 	.pswp__caption__center {
-		padding-bottom: calc(var(--os-safe-area-bottom) + 10px); // design-spec: 10px caption offset
+		padding-block-end: calc(var(--os-safe-area-bottom) + 10px); // design-spec: 10px caption offset
 	}
 }
 
@@ -137,10 +137,6 @@
 ///
 .is-rtl {
 	.pswp {
-		&__counter {
-			left: inherit;
-			right: 0;
-		}
 
 		&__top-bar {
 			display: flex;

--- a/src/scss/04-patterns/03-interaction/_rangeslider-odc.scss
+++ b/src/scss/04-patterns/03-interaction/_rangeslider-odc.scss
@@ -2,19 +2,3 @@
 ////
 /// @group Patterns-Range_Slider
 /// Patterns - Interaction - Range Slider (ODC specific RTL fix)
-
-// IsRTL -------------------------------------------------------------------------
-///
-.is-rtl {
-	.osui-range-slider {
-		.noUi {
-			&-horizontal {
-				.noUi-handle {
-					// For ODC RTL: use left instead of right
-					left: var(--range-slider-handle-sliding-position);
-					right: auto;
-				}
-			}
-		}
-	}
-}

--- a/src/scss/04-patterns/03-interaction/_scrollable-area.scss
+++ b/src/scss/04-patterns/03-interaction/_scrollable-area.scss
@@ -108,7 +108,9 @@
 }
 
 // IsRTL -------------------------------------------------------------------------
-///
+/// The LTR counterpart of this spacing is not declared in the OSUI bundle (it comes from
+/// the consuming list/carousel), so there is no logical declaration for RTL to mirror.
+/// Kept physical until that owner is found.
 .is-rtl {
 	.horizontal-scroll {
 		& > :not(:first-child),

--- a/src/scss/04-patterns/03-interaction/_stacked-cards.scss
+++ b/src/scss/04-patterns/03-interaction/_stacked-cards.scss
@@ -23,7 +23,7 @@
 
 	.stackedcards-container {
 		.OSAutoMarginTop {
-			margin-top: variables.$token-scale-0;
+			margin-block-start: variables.$token-scale-0;
 		}
 
 		.list.list-group {
@@ -181,7 +181,7 @@
 		display: flex;
 		height: 100%;
 		justify-content: center;
-		left: 0;
+		inset-inline-start: 0;
 		opacity: 0;
 		top: 0;
 

--- a/src/scss/04-patterns/03-interaction/animated-label/_animated-label.scss
+++ b/src/scss/04-patterns/03-interaction/animated-label/_animated-label.scss
@@ -43,7 +43,7 @@
 			}
 
 			[data-textarea] {
-				padding-bottom: variables.$token-scale-100;
+				padding-block-end: variables.$token-scale-100;
 			}
 		}
 	}
@@ -52,8 +52,9 @@
 		background-color: var(--osui-input-background, var(--color-background-input));
 		color: var(--osui-animated-label-color);
 		font-size: variables.$token-font-size-350;
-		left: variables.$token-scale-300;
-		padding: 0 variables.$token-scale-100;
+		inset-inline-start: variables.$token-scale-300;
+		padding-block: 0;
+		padding-inline: variables.$token-scale-100;
 		pointer-events: none;
 		position: absolute;
 		top: 50%;
@@ -72,7 +73,7 @@
 		}
 
 		.icon {
-			padding-right: variables.$token-scale-400;
+			padding-inline-end: variables.$token-scale-400;
 		}
 
 		// Service Studio Preview
@@ -92,12 +93,12 @@
 			&[data-textarea] {
 				background-color: transparent;
 				border: variables.$token-border-size-0;
-				border-bottom: variables.$token-border-size-025 solid var(--osui-animated-label-border-color);
+				border-block-end: variables.$token-border-size-025 solid var(--osui-animated-label-border-color);
 				padding: variables.$token-scale-0;
 				transition: all variables.$token-transition-time-100 variables.$token-transition-curve-expressive;
 
 				&:focus {
-					border-bottom: variables.$token-border-size-025 solid var(--osui-animated-label-focus-border-color);
+					border-block-end: variables.$token-border-size-025 solid var(--osui-animated-label-focus-border-color);
 
 					&::-webkit-datetime-edit {
 						color: var(--color-text);
@@ -105,11 +106,11 @@
 				}
 
 				&.not-valid {
-					border-bottom: variables.$token-border-size-025 solid variables.$token-semantics-danger-base;
+					border-block-end: variables.$token-border-size-025 solid variables.$token-semantics-danger-base;
 
 					&:focus {
 						border: variables.$token-border-size-0;
-						border-bottom: variables.$token-border-size-025 solid variables.$token-semantics-danger-base;
+						border-block-end: variables.$token-border-size-025 solid variables.$token-semantics-danger-base;
 					}
 				}
 
@@ -132,7 +133,7 @@
 			}
 
 			&[data-textarea] {
-				margin-top: variables.$token-scale-200;
+				margin-block-start: variables.$token-scale-200;
 
 				& + span.validation-message {
 					bottom: 7px;
@@ -152,7 +153,7 @@
 
 	&:has(.input-with-icon-content-icon:not(:empty)) {
 		.animated-label-text {
-			left: variables.$token-scale-1000;
+			inset-inline-start: variables.$token-scale-1000;
 		}
 	}
 
@@ -196,7 +197,7 @@
 
 	&:has(.not-valid) {
 		border-color: var(--osui-animated-label-error-color);
-		margin-bottom: variables.$token-scale-900;
+		margin-block-end: variables.$token-scale-900;
 	}
 
 	&:has(textarea) {
@@ -239,7 +240,8 @@
 				background-color: transparent;
 				border: none;
 				height: 100%;
-				padding: 0 variables.$token-scale-400;
+				padding-block: 0;
+				padding-inline: variables.$token-scale-400;
 				width: 100%;
 
 				&:focus {
@@ -253,7 +255,8 @@
 				background-color: transparent;
 				border: none;
 				margin: 0;
-				padding: variables.$token-scale-400 variables.$token-scale-400 0;
+				padding-block: variables.$token-scale-400 0;
+				padding-inline: variables.$token-scale-400;
 				width: 100%;
 
 				&:focus {
@@ -266,7 +269,7 @@
 
 		.validation-message {
 			bottom: auto;
-			left: 0;
+			inset-inline-start: 0;
 			position: absolute;
 			top: calc(100% + #{variables.$token-scale-100});
 		}
@@ -275,15 +278,15 @@
 			height: variables.$token-scale-1000;
 
 			.input-with-icon-content-icon:not(:empty) + .input-with-icon-input .form-control[data-input] {
-				padding-left: variables.$token-scale-1000;
+				padding-inline-start: variables.$token-scale-1000;
 			}
 
 			&.input-with-icon-right
 				.input-with-icon-content-icon:not(:empty)
 				+ .input-with-icon-input
 				.form-control[data-input] {
-				padding-left: variables.$token-scale-400;
-				padding-right: variables.$token-scale-1000;
+				padding-inline-start: variables.$token-scale-400;
+				padding-inline-end: variables.$token-scale-1000;
 			}
 		}
 	}
@@ -291,7 +294,7 @@
 
 /* Fix for animated labels inside lists */
 .list.list-group > [data-block*='AnimatedLabel']:first-child .animated-label {
-	margin-top: variables.$token-scale-200;
+	margin-block-start: variables.$token-scale-200;
 }
 
 ///
@@ -308,21 +311,7 @@
 	This is an hack to solve the autoFill when Chrome at windows.
 	An event added throught JS was added to proper manage the input behaviour based on this animation.
 */
-@keyframes onAutoFillStart {
-	from {
-	}
 
-	to {
-	}
-}
-
-@keyframes onAutoFillCancel {
-	from {
-	}
-
-	to {
-	}
-}
 // End of Chrome autofill hack -----------------------------------
 
 // Responsive --------------------------------------------------------------------
@@ -363,7 +352,8 @@
 .os-high-contrast {
 	.animated-label-text {
 		font-weight: variables.$token-font-weight-semi-bold;
-		padding: variables.$token-scale-0 variables.$token-scale-200;
+		padding-block: variables.$token-scale-0;
+		padding-inline: variables.$token-scale-200;
 	}
 
 	.animated-label {
@@ -378,7 +368,8 @@
 
 	.animated-label-input {
 		.form-control[data-input] {
-			padding: variables.$token-scale-0 variables.$token-scale-200;
+			padding-block: variables.$token-scale-0;
+			padding-inline: variables.$token-scale-200;
 		}
 	}
 }

--- a/src/scss/04-patterns/03-interaction/balloon/_balloon.scss
+++ b/src/scss/04-patterns/03-interaction/balloon/_balloon.scss
@@ -21,7 +21,9 @@
 	border-radius: var(--osui-balloon-shape);
 	background-color: var(--osui-balloon-background);
 	height: auto;
-	inset-inline-start: var(--osui-floating-position-x);
+	// physical: FloatingUI computes --osui-floating-position-x as a physical
+	// from-the-left coordinate; a logical inset would mirror it in RTL
+	left: var(--osui-floating-position-x);
 	opacity: 0;
 	position: var(--osui-balloon-position);
 	pointer-events: none;

--- a/src/scss/04-patterns/03-interaction/balloon/_balloon.scss
+++ b/src/scss/04-patterns/03-interaction/balloon/_balloon.scss
@@ -21,7 +21,7 @@
 	border-radius: var(--osui-balloon-shape);
 	background-color: var(--osui-balloon-background);
 	height: auto;
-	left: var(--osui-floating-position-x);
+	inset-inline-start: var(--osui-floating-position-x);
 	opacity: 0;
 	position: var(--osui-balloon-position);
 	pointer-events: none;

--- a/src/scss/04-patterns/03-interaction/button-loading/_button-loading.scss
+++ b/src/scss/04-patterns/03-interaction/button-loading/_button-loading.scss
@@ -24,7 +24,7 @@
 				gap: variables.$token-scale-0;
 
 				.osui-btn-loading__spinner-animation {
-					margin-right: variables.$token-scale-0;
+					margin-inline-end: variables.$token-scale-0;
 				}
 
 				& > span[data-expression] {
@@ -63,9 +63,9 @@
 			animation: loadingSpinner variables.$token-transition-time-1000 cubic-bezier(0.7, 1.05, 0.78, 0.78) infinite;
 			border: variables.$token-border-size-050 solid currentColor;
 			border-radius: var(--border-radius-rounded);
-			border-top-color: transparent;
+			border-block-start-color: transparent;
 			height: variables.$token-scale-400;
-			margin-right: variables.$token-scale-200;
+			margin-inline-end: variables.$token-scale-200;
 			width: variables.$token-scale-400;
 			will-change: transform;
 
@@ -77,31 +77,6 @@
 
 		& > span[data-expression] {
 			white-space: nowrap;
-		}
-	}
-}
-
-// IsRTL -------------------------------------------------------------------------
-///
-.is-rtl {
-	.osui-btn-loading {
-		&-show-spinner {
-			&.osui-btn-loading--is-loading {
-				.btn {
-					.osui-btn-loading__spinner-animation {
-						margin-left: variables.$token-scale-0;
-					}
-				}
-			}
-		}
-
-		&--is-loading {
-			.btn {
-				.osui-btn-loading__spinner-animation {
-					margin-left: variables.$token-scale-200;
-					margin-right: variables.$token-scale-0;
-				}
-			}
 		}
 	}
 }
@@ -121,8 +96,8 @@
 		.btn {
 			.osui-btn-loading__spinner-animation {
 				border-width: variables.$token-border-size-075;
-				border-bottom: none;
-				border-top: none;
+				border-block-end: none;
+				border-block-start: none;
 			}
 		}
 	}

--- a/src/scss/04-patterns/03-interaction/dropdown/_dropdown-serverside.scss
+++ b/src/scss/04-patterns/03-interaction/dropdown/_dropdown-serverside.scss
@@ -67,7 +67,7 @@ $balloonMobileTopMargin: 5vh;
 		display: flex;
 		flex: 1;
 		height: inherit;
-		margin-right: variables.$token-scale-400;
+		margin-inline-end: variables.$token-scale-400;
 		overflow: hidden;
 
 		&:after {
@@ -79,7 +79,7 @@ $balloonMobileTopMargin: 5vh;
 			line-height: 1;
 			pointer-events: none;
 			position: absolute;
-			right: variables.$token-scale-400;
+			inset-inline-end: variables.$token-scale-400;
 			top: 50%;
 			transform: translateY(-50%);
 			transition: transform variables.$token-transition-time-200 variables.$token-transition-curve-expressive;
@@ -109,7 +109,8 @@ $balloonMobileTopMargin: 5vh;
 			display: flex;
 			font-size: variables.$token-font-size-350;
 			height: variables.$token-scale-1000;
-			padding: variables.$token-scale-0 variables.$token-scale-400;
+			padding-block: variables.$token-scale-0;
+			padding-inline: variables.$token-scale-400;
 			position: relative;
 			transition: border variables.$token-transition-time-300 variables.$token-transition-curve-expressive;
 			width: 100%;
@@ -159,7 +160,7 @@ $balloonMobileTopMargin: 5vh;
 				color: var(--color-text-disabled);
 				display: flex;
 				height: 100%;
-				left: variables.$token-scale-400;
+				inset-inline-start: variables.$token-scale-400;
 				position: absolute;
 				top: 0;
 			}
@@ -176,7 +177,9 @@ $balloonMobileTopMargin: 5vh;
 				color: inherit;
 				font-size: variables.$token-font-size-350;
 				height: variables.$token-scale-1000;
-				padding: variables.$token-scale-0 variables.$token-scale-200 variables.$token-scale-0 variables.$token-scale-400;
+				padding-block: variables.$token-scale-0;
+				padding-inline-end: variables.$token-scale-200;
+				padding-inline-start: variables.$token-scale-400;
 				width: 100%;
 
 				&:focus,
@@ -192,12 +195,13 @@ $balloonMobileTopMargin: 5vh;
 			align-items: center;
 			display: flex;
 			height: 100%;
-			padding: variables.$token-scale-0 variables.$token-scale-400;
+			padding-block: variables.$token-scale-0;
+			padding-inline: variables.$token-scale-400;
 		}
 
 		// Options placeholder
 		&-content {
-			border-top: variables.$token-border-size-025 solid var(--color-border-input);
+			border-block-start: variables.$token-border-size-025 solid var(--color-border-input);
 			flex: 1;
 			height: auto;
 			max-height: var(--osui-dropdown-ss-balloon-max-height);
@@ -226,14 +230,15 @@ $balloonMobileTopMargin: 5vh;
 		// If Search input do not exist, this modifier will be added!
 		&--has-not-search {
 			.osui-dropdown-serverside__balloon-content {
-				border-top: none;
+				border-block-start: none;
 			}
 		}
 
 		// Footer placeholder
 		&-footer {
-			border-top: variables.$token-border-size-025 solid var(--color-border-input);
-			padding: variables.$token-scale-200 variables.$token-scale-400;
+			border-block-start: variables.$token-border-size-025 solid var(--color-border-input);
+			padding-block: variables.$token-scale-200;
+			padding-inline: variables.$token-scale-400;
 		}
 	}
 
@@ -286,8 +291,8 @@ $balloonMobileTopMargin: 5vh;
 		& + .osui-dropdown-serverside-error-message {
 			color: variables.$token-semantics-danger-base;
 			font-size: variables.$token-font-size-300;
-			margin-left: variables.$token-scale-0;
-			margin-top: variables.$token-scale-075;
+			margin-inline-start: variables.$token-scale-0;
+			margin-block-start: variables.$token-scale-075;
 		}
 	}
 
@@ -307,7 +312,7 @@ $balloonMobileTopMargin: 5vh;
 // Inside Form
 .form {
 	.osui-dropdown-serverside__balloon-search-wrapper input[data-input] {
-		margin-bottom: 0;
+		margin-block-end: 0;
 	}
 
 	.osui-dropdown-serverside__balloon .wcag-hide-text {
@@ -379,7 +384,7 @@ $balloonMobileTopMargin: 5vh;
 					&:after {
 						height: var(--osui-outline-size);
 						/* This negative margin will avoid having sticky element on pushing down the elements */
-						margin-top: calc(-1 * var(--osui-outline-size));
+						margin-block-start: calc(-1 * var(--osui-outline-size));
 						position: sticky;
 						width: 100%;
 						z-index: var(--layer-local-tier-3);
@@ -404,10 +409,10 @@ $balloonMobileTopMargin: 5vh;
 					}
 
 					& > *:before {
-						left: 0;
+						inset-inline-start: 0;
 					}
 					& > *:after {
-						right: 0;
+						inset-inline-end: 0;
 					}
 				}
 			}
@@ -422,37 +427,6 @@ $balloonMobileTopMargin: 5vh;
 		--osui-outline-size: 0;
 
 		box-shadow: inset 0 0 0 variables.$token-border-size-075 var(--color-focus-outer);
-	}
-}
-
-// IsRTL -------------------------------------------------------------------------
-///
-.is-rtl {
-	.osui-dropdown-serverside {
-		&__selected-values {
-			margin-left: variables.$token-scale-400;
-			margin-right: initial;
-
-			&:after {
-				left: variables.$token-scale-400;
-				right: auto;
-			}
-		}
-
-		// Balloon States
-		&__balloon {
-			&-search {
-				&:before {
-					left: auto;
-					right: variables.$token-scale-400;
-				}
-
-				input,
-				.form-control[data-input] {
-					padding: variables.$token-scale-0 variables.$token-scale-400 variables.$token-scale-0 variables.$token-scale-200;
-				}
-			}
-		}
 	}
 }
 
@@ -541,7 +515,7 @@ $balloonMobileTopMargin: 5vh;
 			border: none;
 			border-radius: var(--border-radius-sharp);
 			display: flex;
-			left: 0;
+			inset-inline-start: 0;
 			max-width: 100vw;
 			opacity: 0;
 			overflow: hidden;
@@ -566,7 +540,7 @@ $balloonMobileTopMargin: 5vh;
 				display: flex;
 				flex-direction: column;
 				height: auto;
-				margin-top: $balloonMobileTopMargin;
+				margin-block-start: $balloonMobileTopMargin;
 				// 90vh - maxHeight in order to create a margin top/bottom with 5vh
 				max-height: calc(90vh - $balloonMobileTopMargin - var(--size-header));
 				overflow: hidden;
@@ -589,7 +563,7 @@ $balloonMobileTopMargin: 5vh;
 			// If do not exist a input search inside balloon
 			&--has-not-search {
 				.osui-dropdown-serverside__balloon-container {
-					margin-top: $balloonMobileTopMargin;
+					margin-block-start: $balloonMobileTopMargin;
 					max-height: calc(var(--viewport-height, 100vh) - $balloonMobileTopMargin - var(--size-header));
 				}
 			}
@@ -617,7 +591,7 @@ $balloonMobileTopMargin: 5vh;
 			}
 
 			.osui-dropdown-serverside__balloon-container {
-				margin-top: var(--ballon-top-margin-value);
+				margin-block-start: var(--ballon-top-margin-value);
 				position: relative;
 				transform: translateY(calc(0.5 * var(--ballon-top-margin-value)));
 				transition: all variables.$token-transition-time-300 variables.$token-transition-curve-expressive;

--- a/src/scss/04-patterns/03-interaction/dropdown/_dropdown.scss
+++ b/src/scss/04-patterns/03-interaction/dropdown/_dropdown.scss
@@ -49,7 +49,7 @@
 			border-radius: 100%;
 			display: inline-block;
 			height: variables.$token-scale-600;
-			margin-right: variables.$token-scale-200;
+			margin-inline-end: variables.$token-scale-200;
 			width: variables.$token-scale-600;
 			background-color: variables.$token-bg-neutral-subtle-default;
 			overflow: hidden;
@@ -58,7 +58,7 @@
 		&-icon {
 			color: var(--color-text);
 			font-size: variables.$token-font-size-450;
-			margin-right: variables.$token-scale-200;
+			margin-inline-end: variables.$token-scale-200;
 		}
 	}
 
@@ -66,18 +66,7 @@
 	&-error-message {
 		color: variables.$token-semantics-danger-base;
 		font-size: variables.$token-font-size-300;
-		margin-left: variables.$token-scale-0;
-		margin-top: variables.$token-scale-075;
-	}
-}
-
-// IsRTL -------------------------------------------------------------------------
-.is-rtl {
-	.osui-dropdown {
-		&-option-image,
-		&-option-icon {
-			margin-left: variables.$token-scale-200;
-			margin-right: initial;
-		}
+		margin-inline-start: variables.$token-scale-0;
+		margin-block-start: variables.$token-scale-075;
 	}
 }

--- a/src/scss/04-patterns/03-interaction/dropdown/_dropdownserversideitem.scss
+++ b/src/scss/04-patterns/03-interaction/dropdown/_dropdownserversideitem.scss
@@ -21,7 +21,8 @@
 	flex: 1;
 	min-height: variables.$token-scale-1000;
 	overflow: hidden;
-	padding: variables.$token-scale-200 variables.$token-scale-400;
+	padding-block: variables.$token-scale-200;
+	padding-inline: variables.$token-scale-400;
 	position: relative;
 	transition: background variables.$token-transition-time-300 variables.$token-transition-curve-expressive;
 	width: 100%;
@@ -49,7 +50,7 @@
 			flex-shrink: 0;
 			font-family: var(--osui-icon-font-family);
 			font-size: variables.$token-font-size-400;
-			margin-left: variables.$token-scale-200;
+			margin-inline-start: variables.$token-scale-200;
 		}
 	}
 
@@ -102,9 +103,9 @@
 				bottom: 0;
 				content: '';
 				display: block;
-				left: 0;
+				inset-inline-start: 0;
 				position: absolute;
-				right: 0;
+				inset-inline-end: 0;
 				top: 0;
 			}
 		}

--- a/src/scss/04-patterns/03-interaction/dropdown/provider/_virtualselect.scss
+++ b/src/scss/04-patterns/03-interaction/dropdown/provider/_virtualselect.scss
@@ -266,20 +266,16 @@
 
 			&.has-value {
 				.vscomp-clear-button {
-					inset-inline-start: variables.$token-scale-1000;
+					// physical: counters the vendor lib's `left: 2px` under .text-direction-rtl,
+					// which outranks our logical base (inset-inline-end) in specificity
+					left: variables.$token-scale-1000;
 				}
 			}
 		}
 
-		.vscomp-toggle-button {
-			&:after {
-				inset-inline-start: variables.$token-scale-400;
-				inset-inline-end: auto;
-			}
-		}
-
 		.checkbox-icon {
-			margin-inline-start: variables.$token-scale-200;
+			// physical: counters the vendor lib's `margin-left: 10px` under .text-direction-rtl
+			margin-left: variables.$token-scale-200;
 
 			&.checked {
 				&:after {

--- a/src/scss/04-patterns/03-interaction/dropdown/provider/_virtualselect.scss
+++ b/src/scss/04-patterns/03-interaction/dropdown/provider/_virtualselect.scss
@@ -110,8 +110,9 @@
 
 					&:after {
 						border-color: var(--color-text-inverse);
-						border-inline-start-color: transparent;
-						border-block-start-color: transparent;
+						// physical: these sides shape the check glyph under rotate(45deg) — a checkmark must not mirror in RTL
+						border-left-color: transparent;
+						border-top-color: transparent;
 						height: 80%;
 						opacity: 1;
 						@include CheckBoxCheckIconTransform;
@@ -311,8 +312,9 @@
 
 			&:after {
 				border-color: var(--color-text-inverse);
-				border-inline-start-color: transparent;
-				border-block-start-color: transparent;
+				// physical: these sides shape the check glyph under rotate(45deg) — a checkmark must not mirror in RTL
+				border-left-color: transparent;
+				border-top-color: transparent;
 				height: 80%;
 				opacity: 1;
 				@include CheckBoxCheckIconTransform;

--- a/src/scss/04-patterns/03-interaction/dropdown/provider/_virtualselect.scss
+++ b/src/scss/04-patterns/03-interaction/dropdown/provider/_virtualselect.scss
@@ -110,8 +110,8 @@
 
 					&:after {
 						border-color: var(--color-text-inverse);
-						border-left-color: transparent;
-						border-top-color: transparent;
+						border-inline-start-color: transparent;
+						border-block-start-color: transparent;
 						height: 80%;
 						opacity: 1;
 						@include CheckBoxCheckIconTransform;
@@ -171,18 +171,18 @@
 				border-radius: 0;
 				color: variables.$token-icon-subtlest;
 				height: auto;
-				left: auto;
+				inset-inline-start: auto;
 				margin-inline-start: variables.$token-scale-100;
 				opacity: 0.5;
 				position: relative;
-				right: auto;
+				inset-inline-end: auto;
 				top: auto;
 				transform: none;
 				width: auto;
 
 				.vscomp-clear-icon {
 					height: variables.$token-scale-300;
-					left: variables.$token-scale-0;
+					inset-inline-start: variables.$token-scale-0;
 					position: relative;
 					top: variables.$token-scale-0;
 					width: variables.$token-scale-300;
@@ -210,10 +210,10 @@
 
 		&.has-value {
 			.vscomp-clear-button {
-				margin-top: 0;
+				margin-block-start: 0;
 				top: 50%;
 				transform: translateY(-50%);
-				right: variables.$token-scale-1000;
+				inset-inline-end: variables.$token-scale-1000;
 			}
 		}
 	}
@@ -239,10 +239,10 @@
 		}
 	}
 
-	// RTL Text
 	&.text-direction-rtl {
 		.vscomp-search-container {
-			padding: variables.$token-scale-0 variables.$token-scale-400;
+			padding-block: variables.$token-scale-0;
+			padding-inline: variables.$token-scale-400;
 		}
 
 		&.multiple {
@@ -266,20 +266,20 @@
 
 			&.has-value {
 				.vscomp-clear-button {
-					left: variables.$token-scale-1000;
+					inset-inline-start: variables.$token-scale-1000;
 				}
 			}
 		}
 
 		.vscomp-toggle-button {
 			&:after {
-				left: variables.$token-scale-400;
-				right: auto;
+				inset-inline-start: variables.$token-scale-400;
+				inset-inline-end: auto;
 			}
 		}
 
 		.checkbox-icon {
-			margin-left: variables.$token-scale-200;
+			margin-inline-start: variables.$token-scale-200;
 
 			&.checked {
 				&:after {
@@ -295,7 +295,7 @@
 		border-radius: variables.$token-border-radius-100;
 		border: variables.$token-border-size-025 solid var(--color-border-input);
 		height: variables.$token-scale-400;
-		margin-right: 0px;
+		margin-inline-end: 0px;
 		overflow: visible;
 		transition: background-color variables.$token-transition-time-300 variables.$token-transition-curve-expressive;
 		width: variables.$token-scale-400;
@@ -315,8 +315,8 @@
 
 			&:after {
 				border-color: var(--color-text-inverse);
-				border-left-color: transparent;
-				border-top-color: transparent;
+				border-inline-start-color: transparent;
+				border-block-start-color: transparent;
 				height: 80%;
 				opacity: 1;
 				@include CheckBoxCheckIconTransform;
@@ -342,8 +342,9 @@
 	height: var(--vscomp-toogle-btn-height);
 	line-height: var(--vscomp-toogle-btn-height);
 	min-width: 180px;
-	padding: variables.$token-scale-100 variables.$token-scale-1000 variables.$token-scale-100
-		variables.$token-scale-400;
+	padding-block: variables.$token-scale-100;
+	padding-inline-end: variables.$token-scale-1000;
+	padding-inline-start: variables.$token-scale-400;
 	position: relative;
 	transition: border-color variables.$token-transition-time-100 variables.$token-transition-curve-base;
 	vertical-align: middle;
@@ -358,7 +359,7 @@
 		justify-content: center;
 		line-height: 1;
 		position: absolute;
-		right: variables.$token-scale-400;
+		inset-inline-end: variables.$token-scale-400;
 		top: 50%;
 		transform: translateY(-50%);
 		transform-origin: center;
@@ -424,8 +425,10 @@
 
 // Options container input search wrapper
 .vscomp-search-container {
-	border-bottom: variables.$token-border-size-025 solid var(--color-border);
-	padding: variables.$token-scale-0 variables.$token-scale-200 variables.$token-scale-0 variables.$token-scale-400;
+	border-block-end: variables.$token-border-size-025 solid var(--color-border);
+	padding-block: variables.$token-scale-0;
+	padding-inline-end: variables.$token-scale-200;
+	padding-inline-start: variables.$token-scale-400;
 	position: relative;
 
 	&::before {
@@ -463,7 +466,7 @@
 	// Move "Toggle all" checkbox to the end of the search container
 	.vscomp-toggle-all-button {
 		order: 1;
-		margin-left: variables.$token-scale-200;
+		margin-inline-start: variables.$token-scale-200;
 	}
 }
 
@@ -532,7 +535,7 @@
 			flex-shrink: 0;
 			font-family: var(--osui-icon-font-family);
 			font-size: variables.$token-font-size-400;
-			margin-left: variables.$token-scale-200;
+			margin-inline-start: variables.$token-scale-200;
 		}
 	}
 
@@ -561,15 +564,15 @@
 .vscomp-option-description {
 	color: variables.$token-primitives-neutral-700;
 	font-size: variables.$token-font-size-275;
-	margin-top: 1px;
+	margin-block-start: 1px;
 }
 
 // When using the extensibility property allowNewOption
 .vscomp-new-option-icon {
 	&::before {
 		border: 15px solid variables.$token-semantics-primary-base;
-		border-bottom-color: rgba(0, 0, 0, 0);
-		border-left-color: rgba(0, 0, 0, 0);
+		border-block-end-color: rgba(0, 0, 0, 0);
+		border-inline-start-color: rgba(0, 0, 0, 0);
 	}
 }
 
@@ -615,9 +618,9 @@
 					bottom: 0;
 					content: '';
 					display: block;
-					left: 0;
+					inset-inline-start: 0;
 					position: absolute;
-					right: 0;
+					inset-inline-end: 0;
 					top: 0;
 				}
 			}
@@ -626,8 +629,8 @@
 		&.multiple .vscomp-option {
 			&.selected .checkbox-icon {
 				&:after {
-					border-top: none;
-					border-left: none;
+					border-block-start: none;
+					border-inline-start: none;
 				}
 			}
 		}

--- a/src/scss/04-patterns/03-interaction/notification/_notification.scss
+++ b/src/scss/04-patterns/03-interaction/notification/_notification.scss
@@ -99,11 +99,11 @@
 			}
 
 			&-right {
-				right: calc(var(--os-safe-area-right) + var(--osui-notification-margin));
+				right: calc(var(--os-safe-area-inline-end) + var(--osui-notification-margin));
 				transform: translateX(100%);
 			}
 			&-left {
-				left: calc(var(--os-safe-area-left) + var(--osui-notification-margin));
+				left: calc(var(--os-safe-area-inline-start) + var(--osui-notification-margin));
 				transform: translateX(-100%);
 			}
 		}
@@ -120,11 +120,11 @@
 		}
 
 		&-right {
-			right: calc(var(--os-safe-area-right) + var(--osui-notification-margin));
+			right: calc(var(--os-safe-area-inline-end) + var(--osui-notification-margin));
 			transform: translate(100%, -50%);
 		}
 		&-left {
-			left: calc(var(--os-safe-area-left) + var(--osui-notification-margin));
+			left: calc(var(--os-safe-area-inline-start) + var(--osui-notification-margin));
 			transform: translate(-100%, -50%);
 		}
 
@@ -139,11 +139,11 @@
 			}
 
 			&-right {
-				right: calc(var(--os-safe-area-right) + var(--osui-notification-margin));
+				right: calc(var(--os-safe-area-inline-end) + var(--osui-notification-margin));
 				transform: translateX(100%);
 			}
 			&-left {
-				left: calc(var(--os-safe-area-left) + var(--osui-notification-margin));
+				left: calc(var(--os-safe-area-inline-start) + var(--osui-notification-margin));
 				transform: translateX(-100%);
 			}
 		}
@@ -215,7 +215,7 @@
 .android {
 	.layout-native {
 		.osui-notification--is-open {
-			margin-top: #{android-safe-area-top()};
+			margin-block-start: #{android-safe-area-top()};
 		}
 	}
 }

--- a/src/scss/04-patterns/03-interaction/notification/_notification.scss
+++ b/src/scss/04-patterns/03-interaction/notification/_notification.scss
@@ -99,11 +99,11 @@
 			}
 
 			&-right {
-				right: calc(var(--os-safe-area-inline-end) + var(--osui-notification-margin));
+				right: calc(var(--os-safe-area-right) + var(--osui-notification-margin));
 				transform: translateX(100%);
 			}
 			&-left {
-				left: calc(var(--os-safe-area-inline-start) + var(--osui-notification-margin));
+				left: calc(var(--os-safe-area-left) + var(--osui-notification-margin));
 				transform: translateX(-100%);
 			}
 		}
@@ -120,11 +120,11 @@
 		}
 
 		&-right {
-			right: calc(var(--os-safe-area-inline-end) + var(--osui-notification-margin));
+			right: calc(var(--os-safe-area-right) + var(--osui-notification-margin));
 			transform: translate(100%, -50%);
 		}
 		&-left {
-			left: calc(var(--os-safe-area-inline-start) + var(--osui-notification-margin));
+			left: calc(var(--os-safe-area-left) + var(--osui-notification-margin));
 			transform: translate(-100%, -50%);
 		}
 
@@ -139,11 +139,11 @@
 			}
 
 			&-right {
-				right: calc(var(--os-safe-area-inline-end) + var(--osui-notification-margin));
+				right: calc(var(--os-safe-area-right) + var(--osui-notification-margin));
 				transform: translateX(100%);
 			}
 			&-left {
-				left: calc(var(--os-safe-area-inline-start) + var(--osui-notification-margin));
+				left: calc(var(--os-safe-area-left) + var(--osui-notification-margin));
 				transform: translateX(-100%);
 			}
 		}

--- a/src/scss/04-patterns/03-interaction/overflow-menu/_overflowmenu.scss
+++ b/src/scss/04-patterns/03-interaction/overflow-menu/_overflowmenu.scss
@@ -77,7 +77,8 @@
 
 		// To make extensibility with ExtendedClass easier
 		a:not([class^='padding-']) {
-			padding: variables.$token-scale-200 variables.$token-scale-400;
+			padding-block: variables.$token-scale-200;
+			padding-inline: variables.$token-scale-400;
 		}
 	}
 }

--- a/src/scss/04-patterns/03-interaction/range-slider/_rangeslider.scss
+++ b/src/scss/04-patterns/03-interaction/range-slider/_rangeslider.scss
@@ -25,7 +25,8 @@
 	--range-slider-handle-size-half: calc(var(--range-slider-handle-size) / 2);
 	--range-slider-thickness-half: calc(var(--range-slider-thickness) / 2);
 	--range-slider-handle-sliding-position: calc(var(--range-slider-handle-size-half) * -1);
-	padding: 0 variables.$token-scale-400;
+	padding-block: 0;
+	padding-inline: variables.$token-scale-400;
 
 	&--is-vertical {
 		height: var(--range-slider-size);
@@ -35,7 +36,8 @@
 	&--has-ticks {
 		.noUi {
 			&-target {
-				margin: variables.$token-scale-600 variables.$token-scale-0 variables.$token-scale-1000;
+				margin-block: variables.$token-scale-600 variables.$token-scale-1000;
+				margin-inline: variables.$token-scale-0;
 			}
 		}
 	}
@@ -43,7 +45,8 @@
 	&:not(.osui-range-slider--has-ticks) {
 		.noUi {
 			&-target {
-				margin: variables.$token-scale-600 variables.$token-scale-0;
+				margin-block: variables.$token-scale-600;
+				margin-inline: variables.$token-scale-0;
 			}
 		}
 	}
@@ -89,13 +92,13 @@
 
 			.noUi-handle:before {
 				border-width: variables.$token-border-size-0 variables.$token-border-size-0 variables.$token-border-size-0 variables.$token-border-size-025;
-				left: calc(var(--range-slider-handle-size) / 4);
-				right: auto;
+				inset-inline-start: calc(var(--range-slider-handle-size) / 4);
+				inset-inline-end: auto;
 			}
 
 			.noUi-handle:after {
 				border-width: variables.$token-border-size-0 variables.$token-border-size-025;
-				left: calc(var(--range-slider-handle-size) / 2.5);
+				inset-inline-start: calc(var(--range-slider-handle-size) / 2.5);
 				width: variables.$token-scale-075;
 			}
 
@@ -120,12 +123,13 @@
 
 		&-vertical {
 			height: var(--range-slider-size);
-			margin: variables.$token-scale-600 variables.$token-scale-0;
+			margin-block: variables.$token-scale-600;
+			margin-inline: variables.$token-scale-0;
 			width: var(--range-slider-thickness);
 
 			.noUi-handle {
 				bottom: var(--range-slider-handle-sliding-position);
-				left: calc((var(--range-slider-handle-size-half) + var(--range-slider-thickness-half)) * -1);
+				inset-inline-start: calc((var(--range-slider-handle-size-half) + var(--range-slider-thickness-half)) * -1);
 
 				// Service Studio Preview
 				& {
@@ -139,7 +143,7 @@
 			width: var(--range-slider-size);
 
 			.noUi-handle {
-				right: var(--range-slider-handle-sliding-position);
+				inset-inline-end: var(--range-slider-handle-sliding-position);
 				top: calc((var(--range-slider-handle-size-half) - var(--range-slider-thickness-half)) * -1);
 			}
 
@@ -148,7 +152,7 @@
 			}
 
 			.noUi-pips-margin {
-				margin-bottom: 60px;
+				margin-block-end: 60px;
 			}
 		}
 
@@ -166,8 +170,9 @@
 
 		&-pips-horizontal {
 			height: variables.$token-scale-1000;
-			left: 0;
-			padding: variables.$token-scale-100 0 0;
+			inset-inline-start: 0;
+			padding-block: variables.$token-scale-100 0;
+			padding-inline: 0;
 			top: 100%;
 			width: 100%;
 		}
@@ -175,8 +180,10 @@
 		&-pips-vertical {
 			color: var(--color-text-subtlest);
 			height: 100%;
-			left: 100%;
-			padding: 0 0 0 variables.$token-scale-100;
+			inset-inline-start: 100%;
+			padding-block: 0;
+			padding-inline-end: 0;
+			padding-inline-start: variables.$token-scale-100;
 			top: 0;
 		}
 
@@ -212,7 +219,7 @@
 		&-value-vertical {
 			color: var(--color-text-subtlest);
 			font-size: variables.$token-font-size-300;
-			padding-left: variables.$token-scale-200;
+			padding-inline-start: variables.$token-scale-200;
 		}
 
 		&-tooltip {
@@ -224,24 +231,24 @@
 
 		&-rtl {
 			&.noUi-vertical .noUi-handle {
-				right: unset;
+				inset-inline-end: unset;
 			}
 
 			.noUi-value.noUi-value-vertical {
-				padding-left: variables.$token-scale-0;
-				padding-right: variables.$token-scale-600;
+				padding-inline-start: variables.$token-scale-0;
+				padding-inline-end: variables.$token-scale-600;
 			}
 
 			.noUi-marker.noUi-marker-vertical {
-				margin-right: variables.$token-scale-400;
+				margin-inline-end: variables.$token-scale-400;
 			}
 		}
 
 		&-txt-dir-rtl {
 			&.noUi-horizontal {
 				.noUi-origin {
-					left: inherit;
-					right: inherit;
+					inset-inline-start: inherit;
+					inset-inline-end: inherit;
 				}
 			}
 		}

--- a/src/scss/04-patterns/03-interaction/range-slider/_rangeslider.scss
+++ b/src/scss/04-patterns/03-interaction/range-slider/_rangeslider.scss
@@ -92,13 +92,15 @@
 
 			.noUi-handle:before {
 				border-width: variables.$token-border-size-0 variables.$token-border-size-0 variables.$token-border-size-0 variables.$token-border-size-025;
-				inset-inline-start: calc(var(--range-slider-handle-size) / 4);
-				inset-inline-end: auto;
+				// physical: noUiSlider positions handles physically and does its own
+				// RTL via .noUi-txt-dir-rtl — logical props here would double-flip
+				left: calc(var(--range-slider-handle-size) / 4);
+				right: auto;
 			}
 
 			.noUi-handle:after {
 				border-width: variables.$token-border-size-0 variables.$token-border-size-025;
-				inset-inline-start: calc(var(--range-slider-handle-size) / 2.5);
+				left: calc(var(--range-slider-handle-size) / 2.5); // physical: see note above
 				width: variables.$token-scale-075;
 			}
 
@@ -129,7 +131,8 @@
 
 			.noUi-handle {
 				bottom: var(--range-slider-handle-sliding-position);
-				inset-inline-start: calc((var(--range-slider-handle-size-half) + var(--range-slider-thickness-half)) * -1);
+				// physical: pairs with the vendor's physical handle placement
+				left: calc((var(--range-slider-handle-size-half) + var(--range-slider-thickness-half)) * -1);
 
 				// Service Studio Preview
 				& {
@@ -143,7 +146,8 @@
 			width: var(--range-slider-size);
 
 			.noUi-handle {
-				inset-inline-end: var(--range-slider-handle-sliding-position);
+				// physical: the vendor's .noUi-txt-dir-rtl swaps this to `left` itself
+				right: var(--range-slider-handle-sliding-position);
 				top: calc((var(--range-slider-handle-size-half) - var(--range-slider-thickness-half)) * -1);
 			}
 
@@ -170,7 +174,7 @@
 
 		&-pips-horizontal {
 			height: variables.$token-scale-1000;
-			inset-inline-start: 0;
+			left: 0; // physical: noUiSlider geometry — the vendor mirrors RTL itself
 			padding-block: variables.$token-scale-100 0;
 			padding-inline: 0;
 			top: 100%;
@@ -180,10 +184,9 @@
 		&-pips-vertical {
 			color: var(--color-text-subtlest);
 			height: 100%;
-			inset-inline-start: 100%;
-			padding-block: 0;
-			padding-inline-end: 0;
-			padding-inline-start: variables.$token-scale-100;
+			// physical: noUiSlider geometry — mirrored by the .noUi-rtl rules below
+			left: 100%;
+			padding: 0 0 0 variables.$token-scale-100;
 			top: 0;
 		}
 
@@ -219,7 +222,7 @@
 		&-value-vertical {
 			color: var(--color-text-subtlest);
 			font-size: variables.$token-font-size-300;
-			padding-inline-start: variables.$token-scale-200;
+			padding-left: variables.$token-scale-200; // physical: mirrored by .noUi-rtl below
 		}
 
 		&-tooltip {
@@ -229,26 +232,27 @@
 			padding: variables.$token-scale-100;
 		}
 
+		// physical: hand-written RTL counters for the physical vendor geometry above
 		&-rtl {
 			&.noUi-vertical .noUi-handle {
-				inset-inline-end: unset;
+				right: unset;
 			}
 
 			.noUi-value.noUi-value-vertical {
-				padding-inline-start: variables.$token-scale-0;
-				padding-inline-end: variables.$token-scale-600;
+				padding-left: variables.$token-scale-0;
+				padding-right: variables.$token-scale-600;
 			}
 
 			.noUi-marker.noUi-marker-vertical {
-				margin-inline-end: variables.$token-scale-400;
+				margin-right: variables.$token-scale-400;
 			}
 		}
 
 		&-txt-dir-rtl {
 			&.noUi-horizontal {
 				.noUi-origin {
-					inset-inline-start: inherit;
-					inset-inline-end: inherit;
+					left: inherit;
+					right: inherit;
 				}
 			}
 		}

--- a/src/scss/04-patterns/03-interaction/range-slider/provider/_noUiSlider.scss
+++ b/src/scss/04-patterns/03-interaction/range-slider/provider/_noUiSlider.scss
@@ -4,25 +4,25 @@
  */
 .noUi-target,
 .noUi-target * {
-	-moz-box-sizing: border-box;
-	-moz-user-select: none;
-	-ms-touch-action: none;
-	-ms-user-select: none;
-	-webkit-tap-highlight-color: rgba(0, 0, 0, 0);
 	-webkit-touch-callout: none;
+	-webkit-tap-highlight-color: rgba(0, 0, 0, 0);
 	-webkit-user-select: none;
-	box-sizing: border-box;
+	-ms-touch-action: none;
 	touch-action: none;
+	-ms-user-select: none;
+	-moz-user-select: none;
 	user-select: none;
+	-moz-box-sizing: border-box;
+	box-sizing: border-box;
 }
 .noUi-target {
 	position: relative;
 }
 .noUi-base,
 .noUi-connects {
+	width: 100%;
 	height: 100%;
 	position: relative;
-	width: 100%;
 	z-index: 1;
 }
 /* Wrapper for all connect elements.
@@ -33,24 +33,24 @@
 }
 .noUi-connect,
 .noUi-origin {
+	will-change: transform;
+	position: absolute;
+	z-index: 1;
+	top: 0;
+	right: 0;
+	height: 100%;
+	width: 100%;
 	-ms-transform-origin: 0 0;
 	-webkit-transform-origin: 0 0;
 	-webkit-transform-style: preserve-3d;
-	height: 100%;
-	inset-inline-end: 0;
-	position: absolute;
-	top: 0;
 	transform-origin: 0 0;
 	transform-style: flat;
-	width: 100%;
-	will-change: transform;
-	z-index: 1;
 }
 /* Offset direction
   */
 .noUi-txt-dir-rtl.noUi-horizontal .noUi-origin {
-	inset-inline-end: auto;
-	inset-inline-start: 0;
+	left: 0;
+	right: auto;
 }
 /* Give origins 0 height/width so they don't interfere with clicking the
   * connect elements.
@@ -85,31 +85,31 @@
 	height: 18px;
 }
 .noUi-horizontal .noUi-handle {
-	height: 28px;
-	inset-inline-end: -17px;
-	top: -6px;
 	width: 34px;
+	height: 28px;
+	right: -17px;
+	top: -6px;
 }
 .noUi-vertical {
 	width: 18px;
 }
 .noUi-vertical .noUi-handle {
-	bottom: -17px;
-	height: 34px;
-	inset-inline-end: -6px;
 	width: 28px;
+	height: 34px;
+	right: -6px;
+	bottom: -17px;
 }
 .noUi-txt-dir-rtl.noUi-horizontal .noUi-handle {
-	inset-inline-end: auto;
-	inset-inline-start: -17px;
+	left: -17px;
+	right: auto;
 }
 /* Styling;
   * Giving the connect element a border radius causes issues with using transform: scale
   */
 .noUi-target {
 	background: #fafafa;
-	border: 1px solid #d3d3d3;
 	border-radius: 4px;
+	border: 1px solid #d3d3d3;
 	box-shadow:
 		inset 0 1px 1px #f0f0f0,
 		0 3px 6px -5px #bbb;
@@ -129,9 +129,9 @@
 	cursor: ns-resize;
 }
 .noUi-handle {
-	background: #fff;
 	border: 1px solid #d9d9d9;
 	border-radius: 3px;
+	background: #fff;
 	cursor: default;
 	box-shadow:
 		inset 0 0 1px #fff,
@@ -148,24 +148,24 @@
   */
 .noUi-handle:before,
 .noUi-handle:after {
-	background: #e8e7e6;
 	content: '';
 	display: block;
-	height: 14px;
-	inset-inline-start: 14px;
 	position: absolute;
-	top: 6px;
+	height: 14px;
 	width: 1px;
+	background: #e8e7e6;
+	left: 14px;
+	top: 6px;
 }
 .noUi-handle:after {
-	inset-inline-start: 17px;
+	left: 17px;
 }
 .noUi-vertical .noUi-handle:before,
 .noUi-vertical .noUi-handle:after {
-	height: 1px;
-	inset-inline-start: 6px;
-	top: 14px;
 	width: 14px;
+	height: 1px;
+	left: 6px;
+	top: 14px;
 }
 .noUi-vertical .noUi-handle:after {
 	top: 17px;
@@ -189,16 +189,16 @@
 	box-sizing: border-box;
 }
 .noUi-pips {
-	color: #999;
 	position: absolute;
+	color: #999;
 }
 /* Values;
   *
   */
 .noUi-value {
 	position: absolute;
-	text-align: center;
 	white-space: nowrap;
+	text-align: center;
 }
 .noUi-value-sub {
 	color: #ccc;
@@ -208,8 +208,8 @@
   *
   */
 .noUi-marker {
-	background: #ccc;
 	position: absolute;
+	background: #ccc;
 }
 .noUi-marker-sub {
 	background: #aaa;
@@ -221,11 +221,10 @@
   *
   */
 .noUi-pips-horizontal {
+	padding: 10px 0;
 	height: 80px;
-	inset-inline-start: 0;
-	padding-block: 10px;
-	padding-inline: 0;
 	top: 100%;
+	left: 0;
 	width: 100%;
 }
 .noUi-value-horizontal {
@@ -237,9 +236,9 @@
 	transform: translate(50%, 50%);
 }
 .noUi-marker-horizontal.noUi-marker {
-	height: 5px;
-	margin-inline-start: -1px;
+	margin-left: -1px;
 	width: 2px;
+	height: 5px;
 }
 .noUi-marker-horizontal.noUi-marker-sub {
 	height: 10px;
@@ -251,25 +250,24 @@
   *
   */
 .noUi-pips-vertical {
+	padding: 0 10px;
 	height: 100%;
-	inset-inline-start: 100%;
-	padding-block: 0;
-	padding-inline: 10px;
 	top: 0;
+	left: 100%;
 }
 .noUi-value-vertical {
 	-webkit-transform: translate(0, -50%);
-	padding-inline-start: 25px;
 	transform: translate(0, -50%);
+	padding-left: 25px;
 }
 .noUi-rtl .noUi-value-vertical {
 	-webkit-transform: translate(0, 50%);
 	transform: translate(0, 50%);
 }
 .noUi-marker-vertical.noUi-marker {
-	height: 2px;
-	margin-block-start: -1px;
 	width: 5px;
+	height: 2px;
+	margin-top: -1px;
 }
 .noUi-marker-vertical.noUi-marker-sub {
 	width: 10px;
@@ -278,37 +276,37 @@
 	width: 15px;
 }
 .noUi-tooltip {
-	background: #fff;
+	display: block;
+	position: absolute;
 	border: 1px solid #d9d9d9;
 	border-radius: 3px;
+	background: #fff;
 	color: #000;
-	display: block;
 	padding: 5px;
-	position: absolute;
 	text-align: center;
 	white-space: nowrap;
 }
 .noUi-horizontal .noUi-tooltip {
 	-webkit-transform: translate(-50%, 0);
-	bottom: 120%;
-	left: 50%;
 	transform: translate(-50%, 0);
+	left: 50%;
+	bottom: 120%;
 }
 .noUi-vertical .noUi-tooltip {
 	-webkit-transform: translate(0, -50%);
-	right: 120%;
-	top: 50%;
 	transform: translate(0, -50%);
+	top: 50%;
+	right: 120%;
 }
 .noUi-horizontal .noUi-origin > .noUi-tooltip {
 	-webkit-transform: translate(50%, 0);
-	bottom: 10px;
-	left: auto;
 	transform: translate(50%, 0);
+	left: auto;
+	bottom: 10px;
 }
 .noUi-vertical .noUi-origin > .noUi-tooltip {
 	-webkit-transform: translate(0, -18px);
-	right: 28px;
-	top: auto;
 	transform: translate(0, -18px);
+	top: auto;
+	right: 28px;
 }

--- a/src/scss/04-patterns/03-interaction/range-slider/provider/_noUiSlider.scss
+++ b/src/scss/04-patterns/03-interaction/range-slider/provider/_noUiSlider.scss
@@ -4,25 +4,25 @@
  */
 .noUi-target,
 .noUi-target * {
-	-webkit-touch-callout: none;
-	-webkit-tap-highlight-color: rgba(0, 0, 0, 0);
-	-webkit-user-select: none;
-	-ms-touch-action: none;
-	touch-action: none;
-	-ms-user-select: none;
-	-moz-user-select: none;
-	user-select: none;
 	-moz-box-sizing: border-box;
+	-moz-user-select: none;
+	-ms-touch-action: none;
+	-ms-user-select: none;
+	-webkit-tap-highlight-color: rgba(0, 0, 0, 0);
+	-webkit-touch-callout: none;
+	-webkit-user-select: none;
 	box-sizing: border-box;
+	touch-action: none;
+	user-select: none;
 }
 .noUi-target {
 	position: relative;
 }
 .noUi-base,
 .noUi-connects {
-	width: 100%;
 	height: 100%;
 	position: relative;
+	width: 100%;
 	z-index: 1;
 }
 /* Wrapper for all connect elements.
@@ -33,24 +33,24 @@
 }
 .noUi-connect,
 .noUi-origin {
-	will-change: transform;
-	position: absolute;
-	z-index: 1;
-	top: 0;
-	right: 0;
-	height: 100%;
-	width: 100%;
 	-ms-transform-origin: 0 0;
 	-webkit-transform-origin: 0 0;
 	-webkit-transform-style: preserve-3d;
+	height: 100%;
+	inset-inline-end: 0;
+	position: absolute;
+	top: 0;
 	transform-origin: 0 0;
 	transform-style: flat;
+	width: 100%;
+	will-change: transform;
+	z-index: 1;
 }
 /* Offset direction
   */
 .noUi-txt-dir-rtl.noUi-horizontal .noUi-origin {
-	left: 0;
-	right: auto;
+	inset-inline-end: auto;
+	inset-inline-start: 0;
 }
 /* Give origins 0 height/width so they don't interfere with clicking the
   * connect elements.
@@ -85,31 +85,31 @@
 	height: 18px;
 }
 .noUi-horizontal .noUi-handle {
-	width: 34px;
 	height: 28px;
-	right: -17px;
+	inset-inline-end: -17px;
 	top: -6px;
+	width: 34px;
 }
 .noUi-vertical {
 	width: 18px;
 }
 .noUi-vertical .noUi-handle {
-	width: 28px;
-	height: 34px;
-	right: -6px;
 	bottom: -17px;
+	height: 34px;
+	inset-inline-end: -6px;
+	width: 28px;
 }
 .noUi-txt-dir-rtl.noUi-horizontal .noUi-handle {
-	left: -17px;
-	right: auto;
+	inset-inline-end: auto;
+	inset-inline-start: -17px;
 }
 /* Styling;
   * Giving the connect element a border radius causes issues with using transform: scale
   */
 .noUi-target {
 	background: #fafafa;
-	border-radius: 4px;
 	border: 1px solid #d3d3d3;
+	border-radius: 4px;
 	box-shadow:
 		inset 0 1px 1px #f0f0f0,
 		0 3px 6px -5px #bbb;
@@ -129,9 +129,9 @@
 	cursor: ns-resize;
 }
 .noUi-handle {
+	background: #fff;
 	border: 1px solid #d9d9d9;
 	border-radius: 3px;
-	background: #fff;
 	cursor: default;
 	box-shadow:
 		inset 0 0 1px #fff,
@@ -148,24 +148,24 @@
   */
 .noUi-handle:before,
 .noUi-handle:after {
+	background: #e8e7e6;
 	content: '';
 	display: block;
-	position: absolute;
 	height: 14px;
-	width: 1px;
-	background: #e8e7e6;
-	left: 14px;
+	inset-inline-start: 14px;
+	position: absolute;
 	top: 6px;
+	width: 1px;
 }
 .noUi-handle:after {
-	left: 17px;
+	inset-inline-start: 17px;
 }
 .noUi-vertical .noUi-handle:before,
 .noUi-vertical .noUi-handle:after {
-	width: 14px;
 	height: 1px;
-	left: 6px;
+	inset-inline-start: 6px;
 	top: 14px;
+	width: 14px;
 }
 .noUi-vertical .noUi-handle:after {
 	top: 17px;
@@ -189,16 +189,16 @@
 	box-sizing: border-box;
 }
 .noUi-pips {
-	position: absolute;
 	color: #999;
+	position: absolute;
 }
 /* Values;
   *
   */
 .noUi-value {
 	position: absolute;
-	white-space: nowrap;
 	text-align: center;
+	white-space: nowrap;
 }
 .noUi-value-sub {
 	color: #ccc;
@@ -208,8 +208,8 @@
   *
   */
 .noUi-marker {
-	position: absolute;
 	background: #ccc;
+	position: absolute;
 }
 .noUi-marker-sub {
 	background: #aaa;
@@ -221,10 +221,11 @@
   *
   */
 .noUi-pips-horizontal {
-	padding: 10px 0;
 	height: 80px;
+	inset-inline-start: 0;
+	padding-block: 10px;
+	padding-inline: 0;
 	top: 100%;
-	left: 0;
 	width: 100%;
 }
 .noUi-value-horizontal {
@@ -236,9 +237,9 @@
 	transform: translate(50%, 50%);
 }
 .noUi-marker-horizontal.noUi-marker {
-	margin-left: -1px;
-	width: 2px;
 	height: 5px;
+	margin-inline-start: -1px;
+	width: 2px;
 }
 .noUi-marker-horizontal.noUi-marker-sub {
 	height: 10px;
@@ -250,24 +251,25 @@
   *
   */
 .noUi-pips-vertical {
-	padding: 0 10px;
 	height: 100%;
+	inset-inline-start: 100%;
+	padding-block: 0;
+	padding-inline: 10px;
 	top: 0;
-	left: 100%;
 }
 .noUi-value-vertical {
 	-webkit-transform: translate(0, -50%);
+	padding-inline-start: 25px;
 	transform: translate(0, -50%);
-	padding-left: 25px;
 }
 .noUi-rtl .noUi-value-vertical {
 	-webkit-transform: translate(0, 50%);
 	transform: translate(0, 50%);
 }
 .noUi-marker-vertical.noUi-marker {
-	width: 5px;
 	height: 2px;
-	margin-top: -1px;
+	margin-block-start: -1px;
+	width: 5px;
 }
 .noUi-marker-vertical.noUi-marker-sub {
 	width: 10px;
@@ -276,37 +278,37 @@
 	width: 15px;
 }
 .noUi-tooltip {
-	display: block;
-	position: absolute;
+	background: #fff;
 	border: 1px solid #d9d9d9;
 	border-radius: 3px;
-	background: #fff;
 	color: #000;
+	display: block;
 	padding: 5px;
+	position: absolute;
 	text-align: center;
 	white-space: nowrap;
 }
 .noUi-horizontal .noUi-tooltip {
 	-webkit-transform: translate(-50%, 0);
-	transform: translate(-50%, 0);
-	left: 50%;
 	bottom: 120%;
+	left: 50%;
+	transform: translate(-50%, 0);
 }
 .noUi-vertical .noUi-tooltip {
 	-webkit-transform: translate(0, -50%);
-	transform: translate(0, -50%);
-	top: 50%;
 	right: 120%;
+	top: 50%;
+	transform: translate(0, -50%);
 }
 .noUi-horizontal .noUi-origin > .noUi-tooltip {
 	-webkit-transform: translate(50%, 0);
-	transform: translate(50%, 0);
-	left: auto;
 	bottom: 10px;
+	left: auto;
+	transform: translate(50%, 0);
 }
 .noUi-vertical .noUi-origin > .noUi-tooltip {
 	-webkit-transform: translate(0, -18px);
-	transform: translate(0, -18px);
-	top: auto;
 	right: 28px;
+	top: auto;
+	transform: translate(0, -18px);
 }

--- a/src/scss/04-patterns/03-interaction/search/_search.scss
+++ b/src/scss/04-patterns/03-interaction/search/_search.scss
@@ -27,7 +27,7 @@
 
 	.form-control {
 		&[data-input] {
-			padding-left: variables.$token-scale-1000;
+			padding-inline-start: variables.$token-scale-1000;
 		}
 	}
 }
@@ -35,23 +35,7 @@
 .form {
 	.osui-search {
 		input[data-input] {
-			margin-bottom: variables.$token-scale-0;
-		}
-	}
-}
-
-// IsRTL -------------------------------------------------------------------------
-///
-.is-rtl {
-	.osui-search {
-		&__input:after {
-			left: auto;
-			right: variables.$token-scale-400;
-		}
-
-		.form-control[data-input] {
-			padding-left: variables.$token-scale-400;
-			padding-right: variables.$token-scale-1000;
+			margin-block-end: variables.$token-scale-0;
 		}
 	}
 }
@@ -66,7 +50,7 @@
 				&,
 				&:empty {
 					border: variables.$token-border-size-0;
-					padding-left: variables.$token-scale-1000;
+					padding-inline-start: variables.$token-scale-1000;
 				}
 			}
 		}

--- a/src/scss/04-patterns/03-interaction/time-picker/_timepicker.scss
+++ b/src/scss/04-patterns/03-interaction/time-picker/_timepicker.scss
@@ -68,7 +68,7 @@
 			-servicestudio-z-index: var(--layer-local-tier-1);
 
 			&.time12h {
-				padding-right: variables.$token-scale-1200;
+				padding-inline-end: variables.$token-scale-1200;
 				&:after {
 					background-color: variables.$token-primitives-neutral-700;
 					border-radius: var(--border-radius-rounded);
@@ -78,9 +78,9 @@
 					font-weight: variables.$token-font-weight-semi-bold;
 					height: variables.$token-scale-600;
 					line-height: variables.$token-scale-600;
-					margin-right: 2%;
+					margin-inline-end: 2%;
 					position: absolute;
-					right: 0;
+					inset-inline-end: 0;
 					top: 50%;
 					transform: translateY(-50%);
 					width: 20%;
@@ -146,10 +146,11 @@
 				font-weight: variables.$token-font-weight-medium;
 				height: variables.$token-scale-600;
 				justify-content: center;
-				margin-left: variables.$token-scale-200;
-				margin-right: variables.$token-scale-200;
+				margin-inline-start: variables.$token-scale-200;
+				margin-inline-end: variables.$token-scale-200;
 				min-width: 44px;
-				padding: variables.$token-scale-0 variables.$token-scale-300;
+				padding-block: variables.$token-scale-0;
+				padding-inline: variables.$token-scale-300;
 				position: relative;
 				text-transform: uppercase;
 				width: auto;

--- a/src/scss/04-patterns/03-interaction/tooltip/_tooltip.scss
+++ b/src/scss/04-patterns/03-interaction/tooltip/_tooltip.scss
@@ -44,21 +44,21 @@
 
 		&[class*='top'] {
 			&:after {
-				left: 0;
+				inset-inline-start: 0;
 				top: calc(var(--osui-floating-offset) * 2);
 			}
 		}
 
 		&[class*='left'] {
 			&:after {
-				left: calc(var(--osui-floating-offset) * 2);
+				inset-inline-start: calc(var(--osui-floating-offset) * 2);
 				top: 0;
 			}
 		}
 
 		&[class*='bottom-end'] {
 			&:after {
-				left: 0;
+				inset-inline-start: 0;
 			}
 		}
 
@@ -66,7 +66,7 @@
 		&:after {
 			content: '';
 			position: absolute;
-			left: calc(0px - var(--osui-floating-offset) * 2);
+			inset-inline-start: calc(0px - var(--osui-floating-offset) * 2);
 			top: calc(0px - var(--osui-floating-offset) * 2);
 			width: 100%;
 			height: 100%;
@@ -134,8 +134,8 @@
 
 		&__balloon-arrow {
 			border: 0 solid var(--osui-tooltip-background-color);
-			border-right-width: variables.$token-border-size-025;
-			border-bottom-width: variables.$token-border-size-025;
+			border-inline-end-width: variables.$token-border-size-025;
+			border-block-end-width: variables.$token-border-size-025;
 		}
 	}
 }

--- a/src/scss/04-patterns/03-interaction/tooltip/_tooltip.scss
+++ b/src/scss/04-patterns/03-interaction/tooltip/_tooltip.scss
@@ -134,8 +134,10 @@
 
 		&__balloon-arrow {
 			border: 0 solid var(--osui-tooltip-background-color);
-			border-inline-end-width: variables.$token-border-size-025;
-			border-block-end-width: variables.$token-border-size-025;
+			// physical sides: the arrow is a square under rotate(45deg); which edges
+			// show depends on the rotation, not on text direction
+			border-right-width: variables.$token-border-size-025;
+			border-bottom-width: variables.$token-border-size-025;
 		}
 	}
 }

--- a/src/scss/04-patterns/04-navigation/_bottom-bar-item.scss
+++ b/src/scss/04-patterns/04-navigation/_bottom-bar-item.scss
@@ -18,7 +18,7 @@
 	// ───────────────────────────────────────────────────────────────────
 
 	background-color: var(--osui-bottom-bar-background);
-	border-top: variables.$token-border-size-025 solid var(--osui-bottom-bar-border-color);
+	border-block-start: variables.$token-border-size-025 solid var(--osui-bottom-bar-border-color);
 	height: 100%;
 }
 
@@ -61,7 +61,8 @@
 		height: 100%;
 		justify-content: center;
 		overflow: hidden;
-		padding: 0 variables.$token-scale-200;
+		padding-block: 0;
+		padding-inline: variables.$token-scale-200;
 		position: relative;
 		text-align: center;
 
@@ -85,7 +86,7 @@
 .android {
 	.layout-native {
 		.bottom-bar-wrapper {
-			padding-bottom: var(--safe-area-inset-bottom, 0px);
+			padding-block-end: var(--safe-area-inset-bottom, 0px);
 		}
 	}
 }
@@ -93,7 +94,7 @@
 ///
 .layout-native {
 	.bottom-bar-wrapper {
-		padding-bottom: var(--os-safe-area-bottom);
+		padding-block-end: var(--os-safe-area-bottom);
 	}
 	.bottom-bar {
 		height: 100%;

--- a/src/scss/04-patterns/04-navigation/_bottom-bar-item.scss
+++ b/src/scss/04-patterns/04-navigation/_bottom-bar-item.scss
@@ -94,7 +94,7 @@
 ///
 .layout-native {
 	.bottom-bar-wrapper {
-		padding-block-end: var(--os-safe-area-bottom);
+		padding-bottom: var(--os-safe-area-bottom);
 	}
 	.bottom-bar {
 		height: 100%;

--- a/src/scss/04-patterns/04-navigation/_breadcrumbs.scss
+++ b/src/scss/04-patterns/04-navigation/_breadcrumbs.scss
@@ -51,7 +51,8 @@
 			font-size: variables.$token-font-size-300;
 			justify-content: center;
 			line-height: 1;
-			margin: variables.$token-scale-0 variables.$token-scale-200;
+			margin-block: variables.$token-scale-0;
+			margin-inline: variables.$token-scale-200;
 			width: auto;
 
 			i {

--- a/src/scss/04-patterns/04-navigation/_pagination.scss
+++ b/src/scss/04-patterns/04-navigation/_pagination.scss
@@ -24,7 +24,7 @@
 	align-items: center;
 	display: flex;
 	justify-content: space-between;
-	margin-top: variables.$token-scale-600;
+	margin-block-start: variables.$token-scale-600;
 
 	// pagination-container
 	&-container {
@@ -33,7 +33,7 @@
 		justify-content: center;
 
 		& > .pagination-button:first-child {
-			margin-left: 0;
+			margin-inline-start: 0;
 		}
 
 		.list {
@@ -55,7 +55,7 @@
 		font-weight: var(--osui-pagination-button-font-weight);
 		height: var(--osui-pagination-button-size);
 		justify-content: center;
-		margin-left: variables.$token-scale-100;
+		margin-inline-start: variables.$token-scale-100;
 		padding: var(--osui-pagination-button-padding);
 		transition:
 			background-color variables.$token-transition-time-100 variables.$token-transition-curve-expressive,
@@ -108,7 +108,8 @@
 
 	.form-control[data-input] {
 		height: var(--osui-pagination-button-size);
-		margin: variables.$token-scale-0 variables.$token-scale-100;
+		margin-block: variables.$token-scale-0;
+		margin-inline: variables.$token-scale-100;
 		padding: 0;
 		text-align: center;
 		width: var(--osui-pagination-button-size);
@@ -140,7 +141,7 @@
 		flex-direction: column;
 
 		&-container {
-			margin-top: variables.$token-scale-400;
+			margin-block-start: variables.$token-scale-400;
 		}
 
 		&-button,
@@ -155,8 +156,6 @@
 ///
 .is-rtl {
 	.pagination-button {
-		margin-left: 0;
-		margin-right: variables.$token-scale-100;
 
 		.icon {
 			transform: rotate(180deg);

--- a/src/scss/04-patterns/04-navigation/_timeline.scss
+++ b/src/scss/04-patterns/04-navigation/_timeline.scss
@@ -31,7 +31,7 @@
 		font-size: var(--osui-timeline-font-size);
 		justify-content: space-between;
 		line-height: var(--osui-timeline-line-height);
-		margin-bottom: var(--osui-timeline-gap);
+		margin-block-end: var(--osui-timeline-gap);
 		position: relative;
 
 		.timeline-content {
@@ -43,7 +43,7 @@
 			flex-direction: column;
 			font-weight: var(--osui-timeline-title-font-weight);
 			gap: var(--osui-timeline-content-gap);
-			padding-bottom: var(--osui-timeline-content-spacing);
+			padding-block-end: var(--osui-timeline-content-spacing);
 		}
 	}
 
@@ -56,7 +56,8 @@
 		&-line {
 			background-color: var(--osui-timeline-line-color);
 			flex: 1;
-			margin: variables.$token-space-200 variables.$token-space-0 variables.$token-space-0;
+			margin-block: variables.$token-space-200 variables.$token-space-0;
+			margin-inline: variables.$token-space-0;
 			width: variables.$token-border-size-025;
 		}
 
@@ -68,7 +69,8 @@
 			font-size: variables.$token-font-size-300;
 			height: var(--osui-timeline-icon-size);
 			justify-content: center;
-			margin: variables.$token-space-0 var(--osui-timeline-gutter);
+			margin-block: variables.$token-space-0;
+			margin-inline: var(--osui-timeline-gutter);
 			text-align: center;
 			width: var(--osui-timeline-icon-size);
 

--- a/src/scss/04-patterns/04-navigation/section-index/_sectionindex.scss
+++ b/src/scss/04-patterns/04-navigation/section-index/_sectionindex.scss
@@ -25,7 +25,7 @@
 		background-color: var(--osui-section-index-border-color);
 		bottom: 0;
 		content: '';
-		left: 0;
+		inset-inline-start: 0;
 		position: absolute;
 		top: 0;
 		width: var(--osui-section-index-border-width);
@@ -62,7 +62,9 @@
 		cursor: pointer;
 		display: flex;
 		min-height: variables.$token-scale-1100;
-		padding: variables.$token-scale-200 variables.$token-scale-400 variables.$token-scale-200 variables.$token-scale-600;
+		padding-block: variables.$token-scale-200;
+		padding-inline-end: variables.$token-scale-400;
+		padding-inline-start: variables.$token-scale-600;
 		position: relative;
 		transition:
 			background-color variables.$token-transition-time-100 variables.$token-transition-curve-expressive,
@@ -97,7 +99,7 @@
 			background-color: var(--osui-section-index-active-indicator-color);
 			bottom: 0;
 			content: '';
-			left: var(--osui-section-index-active-indicator-offset);
+			inset-inline-start: var(--osui-section-index-active-indicator-offset);
 			position: absolute;
 			top: 0;
 			width: var(--osui-section-index-active-indicator-width);
@@ -126,39 +128,13 @@
 ///
 .os-high-contrast {
 	.osui-section-index::before {
-		border-left: variables.$token-border-size-025 solid var(--color-focus-outer);
+		border-inline-start: variables.$token-border-size-025 solid var(--color-focus-outer);
 	}
 
 	.osui-section-index-item {
 		&--is-active {
 			&::before {
-				border-left: variables.$token-border-size-075 solid var(--color-focus-outer);
-			}
-		}
-	}
-}
-
-// IsRTL -------------------------------------------------------------------------
-///
-.is-rtl {
-	.osui-section-index {
-		&::before {
-			left: auto;
-			right: 0;
-		}
-	}
-
-	.osui-section-index-item {
-		&,
-		&:visited {
-			padding-left: variables.$token-scale-400;
-			padding-right: variables.$token-scale-600;
-		}
-
-		&--is-active {
-			&::before {
-				left: auto;
-				right: var(--osui-section-index-active-indicator-offset);
+				border-inline-start: variables.$token-border-size-075 solid var(--color-focus-outer);
 			}
 		}
 	}
@@ -169,21 +145,13 @@
 .phone {
 	.osui-section-index {
 		&--is-sticky {
-			left: calc(var(--os-safe-area-right) + variables.$token-scale-400);
-			padding: 0 variables.$token-scale-400 0 0;
+			inset-inline-start: calc(var(--os-safe-area-right) + variables.$token-scale-400);
+			padding-block: 0;
+			padding-inline-end: variables.$token-scale-400;
+			padding-inline-start: 0;
 			position: fixed;
 			top: var(--top-position);
 			z-index: var(--layer-local-tier-1);
-		}
-	}
-
-	.is-rtl {
-		.osui-section-index {
-			&--is-sticky {
-				left: initial;
-				right: calc(var(--os-safe-area-right) + variables.$token-scale-400);
-				padding: 0 0 variables.$token-scale-400 0;
-			}
 		}
 	}
 }

--- a/src/scss/04-patterns/04-navigation/section-index/_sectionindex.scss
+++ b/src/scss/04-patterns/04-navigation/section-index/_sectionindex.scss
@@ -145,13 +145,26 @@
 .phone {
 	.osui-section-index {
 		&--is-sticky {
-			inset-inline-start: calc(var(--os-safe-area-right) + variables.$token-scale-400);
+			left: calc(var(--os-safe-area-right) + variables.$token-scale-400);
 			padding-block: 0;
 			padding-inline-end: variables.$token-scale-400;
 			padding-inline-start: 0;
 			position: fixed;
 			top: var(--top-position);
 			z-index: var(--layer-local-tier-1);
+		}
+	}
+
+	// IsRTL -----------------------------------------------------------------
+	/// Anchored off `env(safe-area-inset-right)`, which is physical and has no logical
+	/// form — so the mirror stays a physical override.
+	.is-rtl {
+		.osui-section-index {
+			&--is-sticky {
+				left: initial;
+				right: calc(var(--os-safe-area-right) + variables.$token-scale-400);
+				padding: 0 0 variables.$token-scale-400 0;
+			}
 		}
 	}
 }

--- a/src/scss/04-patterns/04-navigation/sidebar/_sidebar.scss
+++ b/src/scss/04-patterns/04-navigation/sidebar/_sidebar.scss
@@ -193,8 +193,8 @@
 .ios {
 	.layout-native {
 		.osui-sidebar {
-			padding-block-end: var(--os-safe-area-bottom);
-			padding-block-start: var(--os-safe-area-top);
+			padding-bottom: var(--os-safe-area-bottom);
+			padding-top: var(--os-safe-area-top);
 		}
 	}
 
@@ -202,7 +202,7 @@
 		&.landscape {
 			.layout-native {
 				.osui-sidebar:before {
-					inset-inline-start: calc((var(--os-safe-area-inline-start) + 12px) * -1);
+					left: calc((var(--os-safe-area-left) + 12px) * -1);
 					width: calc(var(--os-safe-area-left) + 12px);
 				}
 			}
@@ -214,7 +214,7 @@
 .landscape {
 	.layout-native {
 		.osui-sidebar {
-			padding-block-end: var(--os-safe-area-bottom);
+			padding-bottom: var(--os-safe-area-bottom);
 		}
 	}
 }

--- a/src/scss/04-patterns/04-navigation/sidebar/_sidebar.scss
+++ b/src/scss/04-patterns/04-navigation/sidebar/_sidebar.scss
@@ -12,8 +12,8 @@
 	--osui-sidebar-background: var(--color-background-surface);
 	--osui-sidebar-color: var(--color-text);
 	--osui-sidebar-shadow: #{variables.$token-elevation-3};
-	--osui-sidebar-padding-x: #{variables.$token-scale-600};
-	--osui-sidebar-padding-y: #{variables.$token-scale-400};
+	--osui-sidebar-padding-inline: #{variables.$token-scale-600};
+	--osui-sidebar-padding-block: #{variables.$token-scale-400};
 	// ───────────────────────────────────────────────────────────────────
 
 	--overlay-opacity: 0;
@@ -56,12 +56,12 @@
 		transform: translateX(102%);
 
 		&:after {
-			left: -24px;
+			inset-inline-start: -24px;
 		}
 
 		&.osui-sidebar--has-overlay {
 			&::before {
-				right: 100%;
+				inset-inline-end: 100%;
 
 				// Service Studio Preview
 				& {
@@ -82,12 +82,12 @@
 		transform: translateX(-102%);
 
 		&:after {
-			right: -24px;
+			inset-inline-end: -24px;
 		}
 
 		&.osui-sidebar--has-overlay {
 			&::before {
-				left: 100%;
+				inset-inline-start: 100%;
 
 				// Service Studio Preview
 				& {
@@ -105,7 +105,8 @@
 
 	&__header,
 	&__content {
-		padding: var(--osui-sidebar-padding-y) var(--osui-sidebar-padding-x);
+		padding-block: var(--osui-sidebar-padding-block);
+		padding-inline: var(--osui-sidebar-padding-inline);
 	}
 
 	&__content {
@@ -180,10 +181,10 @@
 .android {
 	.layout-native {
 		.osui-sidebar {
-			padding-top: #{android-safe-area-top()};
-			padding-right: var(--safe-area-inset-right, 0px);
-			padding-bottom: var(--safe-area-inset-bottom, 0px);
-			padding-left: var(--safe-area-inset-left, 0px);
+			padding-block-start: #{android-safe-area-top()};
+			padding-inline-end: var(--safe-area-inset-right, 0px);
+			padding-block-end: var(--safe-area-inset-bottom, 0px);
+			padding-inline-start: var(--safe-area-inset-left, 0px);
 		}
 	}
 }
@@ -192,8 +193,8 @@
 .ios {
 	.layout-native {
 		.osui-sidebar {
-			padding-bottom: var(--os-safe-area-bottom);
-			padding-top: var(--os-safe-area-top);
+			padding-block-end: var(--os-safe-area-bottom);
+			padding-block-start: var(--os-safe-area-top);
 		}
 	}
 
@@ -201,7 +202,7 @@
 		&.landscape {
 			.layout-native {
 				.osui-sidebar:before {
-					left: calc((var(--os-safe-area-left) + 12px) * -1);
+					inset-inline-start: calc((var(--os-safe-area-inline-start) + 12px) * -1);
 					width: calc(var(--os-safe-area-left) + 12px);
 				}
 			}
@@ -213,7 +214,7 @@
 .landscape {
 	.layout-native {
 		.osui-sidebar {
-			padding-bottom: var(--os-safe-area-bottom);
+			padding-block-end: var(--os-safe-area-bottom);
 		}
 	}
 }
@@ -230,8 +231,8 @@
 	.active-screen {
 		.osui-sidebar {
 			&--is-open {
-				border-left: variables.$token-border-size-050 solid var(--color-focus-outer);
-				border-right: variables.$token-border-size-050 solid var(--color-focus-outer);
+				border-inline-start: variables.$token-border-size-050 solid var(--color-focus-outer);
+				border-inline-end: variables.$token-border-size-050 solid var(--color-focus-outer);
 			}
 		}
 	}

--- a/src/scss/04-patterns/04-navigation/submenu/_submenu.scss
+++ b/src/scss/04-patterns/04-navigation/submenu/_submenu.scss
@@ -54,7 +54,7 @@
 
 		.osui-submenu {
 			&__header {
-				border-bottom: variables.$token-border-size-050 solid var(--osui-submenu-active-border-color);
+				border-block-end: variables.$token-border-size-050 solid var(--osui-submenu-active-border-color);
 
 				&__item {
 					&,
@@ -88,9 +88,9 @@
 						&:after {
 							content: '';
 							height: 100%;
-							left: 0;
+							inset-inline-start: 0;
 							position: absolute;
-							right: 0;
+							inset-inline-end: 0;
 							top: 100%;
 						}
 					}
@@ -101,10 +101,11 @@
 
 	&__header {
 		align-items: center;
-		border-bottom: variables.$token-border-size-050 solid transparent;
-		border-top: variables.$token-border-size-050 solid transparent;
+		border-block-end: variables.$token-border-size-050 solid transparent;
+		border-block-start: variables.$token-border-size-050 solid transparent;
 		display: flex;
-		padding: variables.$token-scale-0 variables.$token-scale-200;
+		padding-block: variables.$token-scale-0;
+		padding-inline: variables.$token-scale-200;
 		transition: all variables.$token-transition-time-150 variables.$token-transition-curve-linear;
 
 		&__item {
@@ -150,7 +151,7 @@
 		box-shadow: var(--osui-submenu-items-shadow);
 		display: flex;
 		flex-direction: column;
-		left: 0;
+		inset-inline-start: 0;
 		max-height: var(--osui-submenu-max-height);
 		min-width: 100px;
 		opacity: 0;
@@ -193,7 +194,8 @@
 			font-size: var(--osui-submenu-item-font-size);
 			line-height: var(--osui-submenu-item-line-height);
 			margin: 0;
-			padding: variables.$token-space-200 variables.$token-space-400;
+			padding-block: variables.$token-space-200;
+			padding-inline: variables.$token-space-400;
 			text-decoration: none;
 			transition: background-color variables.$token-transition-time-150 variables.$token-transition-curve-linear;
 			white-space: nowrap;
@@ -251,7 +253,7 @@
 	&:not(.layout-side) {
 		.app-menu-links {
 			.osui-submenu a {
-				border-bottom: none;
+				border-block-end: none;
 			}
 		}
 	}
@@ -273,7 +275,7 @@
 
 .layout-side .app-menu-links .osui-submenu {
 	a {
-		border-left: none;
+		border-inline-start: none;
 	}
 
 	&.active .osui-submenu__header {
@@ -293,7 +295,8 @@
 
 	.osui-submenu__header {
 		border: none;
-		padding: variables.$token-scale-200 variables.$token-scale-400;
+		padding-block: variables.$token-scale-200;
+		padding-inline: variables.$token-scale-400;
 		width: 100%;
 
 		&__item {
@@ -306,7 +309,8 @@
 		box-shadow: none;
 		display: none;
 		opacity: 1;
-		padding: variables.$token-scale-100 variables.$token-scale-600;
+		padding-block: variables.$token-scale-100;
+		padding-inline: variables.$token-scale-600;
 		pointer-events: auto;
 		position: relative;
 		top: 0;
@@ -314,7 +318,9 @@
 
 		a {
 			border-radius: variables.$token-border-radius-200;
-			padding: variables.$token-scale-200 variables.$token-scale-400 variables.$token-scale-200 variables.$token-scale-600;
+			padding-block: variables.$token-scale-200;
+			padding-inline-end: variables.$token-scale-400;
+			padding-inline-start: variables.$token-scale-600;
 
 			// `:not(:active)` — let the pressed background through
 			&:not(:active):hover {
@@ -378,7 +384,7 @@
 
 		&__header {
 			&:hover {
-				border-bottom: none;
+				border-block-end: none;
 			}
 
 			&__item {
@@ -406,11 +412,13 @@
 	// Pill style for horizontal nav
 	.app-menu-links .osui-submenu__header {
 		align-self: center;
-		border-bottom: none;
+		border-block-end: none;
 		border-radius: variables.$token-border-radius-200;
-		border-top: none;
-		margin: 0 variables.$token-scale-025;
-		padding: variables.$token-scale-200 variables.$token-scale-300;
+		border-block-start: none;
+		margin-block: 0;
+		margin-inline: variables.$token-scale-025;
+		padding-block: variables.$token-scale-200;
+		padding-inline: variables.$token-scale-300;
 		transition: background-color variables.$token-transition-time-150 variables.$token-transition-curve-linear;
 	}
 
@@ -422,17 +430,19 @@
 	}
 
 	.app-menu-links .osui-submenu.active .osui-submenu__header {
-		border-bottom: none;
+		border-block-end: none;
 	}
 
 	// Direct links in header navigation
 	.header-navigation .app-menu-links > a {
 		align-self: center;
-		border-bottom: none;
+		border-block-end: none;
 		border-radius: variables.$token-border-radius-200;
-		border-top: none;
-		margin: 0 variables.$token-scale-025;
-		padding: variables.$token-scale-200 variables.$token-scale-300;
+		border-block-start: none;
+		margin-block: 0;
+		margin-inline: variables.$token-scale-025;
+		padding-block: variables.$token-scale-200;
+		padding-inline: variables.$token-scale-300;
 		transition: background-color variables.$token-transition-time-150 variables.$token-transition-curve-linear;
 
 		&:hover {
@@ -460,8 +470,8 @@
 				&__header {
 					&:hover {
 						background-color: variables.$token-bg-neutral-subtlest-hover;
-						border-bottom: none;
-						border-left: none;
+						border-block-end: none;
+						border-inline-start: none;
 						border-radius: variables.$token-border-radius-200;
 					}
 				}
@@ -528,8 +538,8 @@
 
 		&.active .osui-submenu__header {
 			background-color: transparent;
-			border-bottom: 0;
-			border-left: none;
+			border-block-end: 0;
+			border-inline-start: none;
 		}
 
 		&--is-open .osui-submenu__items {
@@ -543,7 +553,8 @@
 
 		&__header {
 			border: none;
-			padding: variables.$token-scale-200 variables.$token-scale-400;
+			padding-block: variables.$token-scale-200;
+			padding-inline: variables.$token-scale-400;
 
 			&__item {
 				flex: 1;
@@ -571,7 +582,9 @@
 
 			a {
 				border-radius: variables.$token-border-radius-200;
-				padding: variables.$token-scale-200 variables.$token-scale-400 variables.$token-scale-200 variables.$token-scale-600;
+				padding-block: variables.$token-scale-200;
+				padding-inline-end: variables.$token-scale-400;
+				padding-inline-start: variables.$token-scale-600;
 
 				// `:not(:active)` — let the pressed background through
 				&.active:not(:active) {
@@ -627,21 +640,10 @@
 .is-rtl {
 	.layout-side {
 		.osui-submenu {
-			.osui-submenu__header {
-				border-left: 0;
-				border-right: variables.$token-border-size-050 solid transparent;
-			}
 
 			&.active .osui-submenu__header {
 				background-color: transparent;
-				border-left: none;
-				border-right: none;
 			}
-		}
-
-		.app-menu-links .osui-submenu__items a {
-			padding-left: variables.$token-scale-400;
-			padding-right: variables.$token-scale-600;
 		}
 	}
 
@@ -650,19 +652,7 @@
 		.osui-submenu {
 			&.active .osui-submenu__header {
 				background-color: transparent;
-				border-left: none;
-				border-right: none;
 			}
-
-			.osui-submenu__header {
-				border-left: 0;
-				border-right: variables.$token-border-size-050 solid transparent;
-			}
-		}
-
-		.osui-submenu__items a {
-			padding-left: variables.$token-scale-400;
-			padding-right: variables.$token-scale-600;
 		}
 	}
 }
@@ -691,11 +681,11 @@
 ///
 .os-high-contrast {
 	.layout:not(.layout-side) .app-menu-links .osui-submenu a {
-		border-top: none;
-		border-bottom: none;
+		border-block-start: none;
+		border-block-end: none;
 	}
 
 	.osui-submenu__header {
-		border-top: none;
+		border-block-start: none;
 	}
 }

--- a/src/scss/04-patterns/04-navigation/tabs/_tabs.scss
+++ b/src/scss/04-patterns/04-navigation/tabs/_tabs.scss
@@ -40,18 +40,19 @@
 				grid-column: 2;
 
 				.osui-tabs__header-item {
-					padding: variables.$token-space-200 variables.$token-space-200 variables.$token-space-200
-						variables.$token-space-400;
+					padding-block: variables.$token-space-200;
+					padding-inline-end: variables.$token-space-200;
+					padding-inline-start: variables.$token-space-400;
 				}
 
 				& > .osui-tabs__header__indicator {
-					left: 0;
+					inset-inline-start: 0;
 				}
 			}
 
 			.osui-tabs__content {
-				border-right: variables.$token-border-size-025 solid var(--osui-tabs-border-color);
-				margin-right: -1px;
+				border-inline-end: variables.$token-border-size-025 solid var(--osui-tabs-border-color);
+				margin-inline-end: -1px;
 			}
 		}
 
@@ -62,18 +63,19 @@
 			& > .osui-tabs__header {
 				.osui-tabs__header-item {
 					justify-content: flex-start;
-					padding: variables.$token-space-200 variables.$token-space-400 variables.$token-space-200
-						variables.$token-space-200;
+					padding-block: variables.$token-space-200;
+					padding-inline-end: variables.$token-space-400;
+					padding-inline-start: variables.$token-space-200;
 				}
 
 				& > .osui-tabs__header__indicator {
-					right: 0;
+					inset-inline-end: 0;
 				}
 			}
 
 			.osui-tabs__content {
-				border-left: variables.$token-border-size-025 solid var(--osui-tabs-border-color);
-				margin-left: -1px;
+				border-inline-start: variables.$token-border-size-025 solid var(--osui-tabs-border-color);
+				margin-inline-start: -1px;
 			}
 		}
 
@@ -99,7 +101,8 @@
 			width: auto;
 
 			&-item {
-				padding: variables.$token-scale-0 variables.$token-scale-600;
+				padding-block: variables.$token-scale-0;
+				padding-inline: variables.$token-scale-600;
 			}
 		}
 	}
@@ -118,7 +121,8 @@
 
 			.osui-tabs__header-item {
 				justify-content: center;
-				padding: variables.$token-space-200 variables.$token-space-400;
+				padding-block: variables.$token-space-200;
+				padding-inline: variables.$token-space-400;
 			}
 		}
 
@@ -130,8 +134,8 @@
 		}
 
 		.osui-tabs__content {
-			border-top: variables.$token-border-size-025 solid var(--osui-tabs-border-color);
-			margin-top: -1px;
+			border-block-start: variables.$token-border-size-025 solid var(--osui-tabs-border-color);
+			margin-block-start: -1px;
 		}
 	}
 
@@ -278,7 +282,8 @@
 		&-item {
 			height: 100%;
 			overflow-y: var(--tabs-content-item-overflow);
-			padding: variables.$token-scale-600 variables.$token-scale-0;
+			padding-block: variables.$token-scale-600;
+			padding-inline: variables.$token-scale-0;
 			scroll-snap-align: start;
 			scroll-snap-stop: always;
 
@@ -321,42 +326,7 @@
 				.osui-tabs__header {
 					&-item {
 						justify-content: flex-start;
-						padding: variables.$token-space-200 variables.$token-space-400 variables.$token-space-200
-							variables.$token-space-200;
 					}
-
-					& > .osui-tabs__header__indicator {
-						left: unset;
-						right: 0;
-					}
-				}
-
-				.osui-tabs__content {
-					border-left: variables.$token-border-size-025 solid var(--osui-tabs-border-color);
-					margin-left: -1px;
-					border-right: 0;
-				}
-			}
-
-			&.osui-tabs--is-left {
-				.osui-tabs__header {
-					grid-column: 1;
-
-					&-item {
-						padding: variables.$token-space-200 variables.$token-space-200 variables.$token-space-200
-							variables.$token-space-400;
-					}
-
-					& > .osui-tabs__header__indicator {
-						left: 0;
-						right: unset;
-					}
-				}
-
-				.osui-tabs__content {
-					border-right: variables.$token-border-size-025 solid var(--osui-tabs-border-color);
-					margin-right: -1px;
-					border-left: 0;
 				}
 			}
 		}
@@ -418,10 +388,10 @@
 		bottom: 0;
 		content: '';
 		display: block;
-		left: 0;
+		inset-inline-start: 0;
 		pointer-events: none;
 		position: absolute;
-		right: 0;
+		inset-inline-end: 0;
 		top: 0;
 	}
 

--- a/src/scss/04-patterns/05-numbers/_badge.scss
+++ b/src/scss/04-patterns/05-numbers/_badge.scss
@@ -41,7 +41,8 @@ $osui-badge-lightest-text-colors: (
 	justify-content: center;
 	line-height: 1;
 	min-width: variables.$token-scale-500;
-	padding: variables.$token-scale-0 variables.$token-scale-150;
+	padding-block: variables.$token-scale-0;
+	padding-inline: variables.$token-scale-150;
 
 	&.background {
 		&-neutral {
@@ -155,7 +156,8 @@ $osui-badge-lightest-text-colors: (
 		font-size: variables.$token-font-size-300;
 		height: variables.$token-scale-400;
 		min-width: variables.$token-scale-400;
-		padding: variables.$token-scale-0 variables.$token-scale-100;
+		padding-block: variables.$token-scale-0;
+		padding-inline: variables.$token-scale-100;
 	}
 
 	&-medium {

--- a/src/scss/04-patterns/05-numbers/_counter.scss
+++ b/src/scss/04-patterns/05-numbers/_counter.scss
@@ -8,7 +8,8 @@
 ///
 .counter {
 	display: flex;
-	padding: variables.$token-scale-0 variables.$token-scale-600;
+	padding-block: variables.$token-scale-0;
+	padding-inline: variables.$token-scale-600;
 	word-break: keep-all;
 
 	&.background-transparent {

--- a/src/scss/04-patterns/05-numbers/_icon-badge.scss
+++ b/src/scss/04-patterns/05-numbers/_icon-badge.scss
@@ -30,7 +30,8 @@
 		height: variables.$token-scale-400;
 		justify-content: center;
 		min-width: variables.$token-scale-400;
-		padding: variables.$token-scale-0 variables.$token-scale-100;
+		padding-block: variables.$token-scale-0;
+		padding-inline: variables.$token-scale-100;
 		transform: translate(50%, -50%);
 		white-space: nowrap;
 

--- a/src/scss/04-patterns/05-numbers/progress/_progressbar.scss
+++ b/src/scss/04-patterns/05-numbers/progress/_progressbar.scss
@@ -41,10 +41,10 @@
 		&__value {
 			border-radius: calc(var(--shape) / 2);
 			height: var(--thickness);
-			left: 0;
+			inset-inline-end: 0;
+			inset-inline-start: 0;
 			overflow: hidden;
 			position: absolute;
-			right: 0;
 
 			& {
 				-servicestudio-height: var(--thickness, #{variables.$token-scale-200});
@@ -55,7 +55,7 @@
 				border-radius: calc(var(--shape) / 2);
 				content: '';
 				height: 100%;
-				left: 0;
+				inset-inline-start: 0;
 				position: absolute;
 				top: 0;
 
@@ -86,8 +86,9 @@
 		}
 
 		&__content {
-			left: 0;
-			padding: variables.$token-scale-0 variables.$token-scale-200;
+			inset-inline-start: 0;
+			padding-block: variables.$token-scale-0;
+			padding-inline: variables.$token-scale-200;
 			position: absolute;
 			top: 50%;
 			transform: translateY(-50%);
@@ -98,15 +99,6 @@
 				-servicestudio-text-align: center;
 			}
 		}
-	}
-}
-
-// IsRTL -------------------------------------------------------------------------
-///
-.is-rtl {
-	.osui-progress-bar__value:before {
-		left: inherit;
-		right: 0;
 	}
 }
 
@@ -126,8 +118,8 @@
 				&:before,
 				&:after {
 					border: variables.$token-border-size-050 solid var(--color-border-input);
+					inset-inline-start: calc(-1 * variables.$token-border-size-050);
 					top: calc(-1 * variables.$token-border-size-050);
-					left: calc(-1 * variables.$token-border-size-050);
 				}
 			}
 		}

--- a/src/scss/04-patterns/05-numbers/progress/_progresscircle.scss
+++ b/src/scss/04-patterns/05-numbers/progress/_progresscircle.scss
@@ -20,7 +20,8 @@
 	&__container {
 		display: inline-block;
 		height: var(--circle-size);
-		margin: 0 auto;
+		margin-block: 0;
+		margin-inline: auto;
 		position: relative;
 		width: var(--circle-size);
 
@@ -35,7 +36,7 @@
 			cx: 50%;
 			cy: 50%;
 			fill: transparent;
-			left: 0;
+			inset-inline-start: 0;
 			position: absolute;
 			r: var(--radius);
 			stroke-width: var(--thickness);

--- a/src/scss/04-patterns/05-numbers/rating/_rating.scss
+++ b/src/scss/04-patterns/05-numbers/rating/_rating.scss
@@ -32,7 +32,7 @@
 		--rating-size: #{variables.$token-scale-300}; // design-spec: 12px
 
 		.rating-item {
-			padding-right: calc(var(--rating-size) + #{variables.$token-scale-100});
+			padding-inline-end: calc(var(--rating-size) + #{variables.$token-scale-100});
 		}
 	}
 
@@ -84,14 +84,14 @@
 		display: inline-block;
 		height: var(--rating-size);
 		// Padding is used to avoid flicks on hover due to rating-items gap
-		padding-right: calc(var(--rating-size) + #{variables.$token-scale-200});
+		padding-inline-end: calc(var(--rating-size) + #{variables.$token-scale-200});
 		position: relative;
 		width: var(--rating-size);
 
 		&-filled,
 		&-half,
 		&-empty {
-			left: 0;
+			inset-inline-start: 0;
 			line-height: var(--osui-font-line-height-full);
 			position: absolute;
 			top: 0;
@@ -123,7 +123,7 @@
 		}
 
 		&:last-of-type {
-			padding-right: 0;
+			padding-inline-end: 0;
 		}
 
 		img {
@@ -156,7 +156,7 @@
 				box-shadow: 0 0 0 variables.$token-border-size-075
 					color-mix(in srgb, #{variables.$token-semantics-primary-base} 22%, transparent);
 				height: 100%;
-				left: 0;
+				inset-inline-start: 0;
 				opacity: 0;
 				pointer-events: none;
 				position: absolute;
@@ -285,8 +285,6 @@
 .is-rtl {
 	.rating {
 		.rating-item {
-			padding-left: calc(var(--rating-size) + #{variables.$token-scale-200});
-			padding-right: 0;
 			transform: scaleX(-1);
 		}
 	}

--- a/src/scss/04-patterns/05-numbers/rating/_rating.scss
+++ b/src/scss/04-patterns/05-numbers/rating/_rating.scss
@@ -32,7 +32,8 @@
 		--rating-size: #{variables.$token-scale-300}; // design-spec: 12px
 
 		.rating-item {
-			padding-inline-end: calc(var(--rating-size) + #{variables.$token-scale-100});
+			// physical: the item is flipped with scaleX(-1) in RTL, so logical props double-flip
+			padding-right: calc(var(--rating-size) + #{variables.$token-scale-100});
 		}
 	}
 
@@ -84,14 +85,16 @@
 		display: inline-block;
 		height: var(--rating-size);
 		// Padding is used to avoid flicks on hover due to rating-items gap
-		padding-inline-end: calc(var(--rating-size) + #{variables.$token-scale-200});
+		// physical: the item is flipped with scaleX(-1) in RTL (see .is-rtl block), so
+		// logical props inside it double-flip; the .is-rtl block mirrors this by hand
+		padding-right: calc(var(--rating-size) + #{variables.$token-scale-200});
 		position: relative;
 		width: var(--rating-size);
 
 		&-filled,
 		&-half,
 		&-empty {
-			inset-inline-start: 0;
+			left: 0; // physical: inside the scaleX(-1)-flipped item
 			line-height: var(--osui-font-line-height-full);
 			position: absolute;
 			top: 0;
@@ -123,7 +126,7 @@
 		}
 
 		&:last-of-type {
-			padding-inline-end: 0;
+			padding-right: 0; // physical: see the scaleX(-1) note above
 		}
 
 		img {
@@ -156,7 +159,7 @@
 				box-shadow: 0 0 0 variables.$token-border-size-075
 					color-mix(in srgb, #{variables.$token-semantics-primary-base} 22%, transparent);
 				height: 100%;
-				inset-inline-start: 0;
+				left: 0; // physical: full-width overlay on the scaleX(-1)-flipped item
 				opacity: 0;
 				pointer-events: none;
 				position: absolute;
@@ -285,6 +288,11 @@
 .is-rtl {
 	.rating {
 		.rating-item {
+			// The item is mirrored as a whole, so the gap padding is moved to the
+			// physical left by hand — logical properties cannot express this because
+			// scaleX(-1) flips the rendered box after layout.
+			padding-left: calc(var(--rating-size) + #{variables.$token-scale-200});
+			padding-right: 0;
 			transform: scaleX(-1);
 		}
 	}

--- a/src/scss/04-patterns/06-utilities/_list-updating.scss
+++ b/src/scss/04-patterns/06-utilities/_list-updating.scss
@@ -8,7 +8,7 @@
 ///
 .list-updating {
 	height: variables.$token-scale-1000;
-	margin-top: variables.$token-scale-600;
+	margin-block-start: variables.$token-scale-600;
 	position: relative;
 
 	&:before {
@@ -16,13 +16,13 @@
 			spin variables.$token-transition-time-1000 infinite variables.$token-transition-curve-linear,
 			fade variables.$token-transition-time-300 variables.$token-transition-curve-expressive;
 		border: 5px solid var(--color-border-input);
+		border-block-start-color: variables.$token-primitives-neutral-700;
 		border-radius: 50%;
-		border-top-color: variables.$token-primitives-neutral-700;
 		box-sizing: border-box;
 		content: '';
 		height: variables.$token-scale-1000;
-		left: 50%;
-		margin-left: -20px;
+		inset-inline-start: 50%;
+		margin-inline-start: -20px;
 		position: absolute;
 		width: variables.$token-scale-1000;
 

--- a/src/scss/04-patterns/06-utilities/_provider-login-button.scss
+++ b/src/scss/04-patterns/06-utilities/_provider-login-button.scss
@@ -30,13 +30,15 @@
 	}
 	&.btn- {
 		&small {
-			padding: 0 16px;
+			padding-block: 0;
+			padding-inline: 16px;
 			&.btn-provider-login-logo-only {
 				padding: 5px;
 			}
 		}
 		&large {
-			padding: 10px 15px;
+			padding-block: 10px;
+			padding-inline: 15px;
 		}
 	}
 	&.soft {
@@ -53,7 +55,7 @@
 		}
 		&-text {
 			color: var(--osui-provider-login-button-color);
-			margin-left: 10px;
+			margin-inline-start: 10px;
 			white-space: nowrap;
 		}
 	}
@@ -73,7 +75,7 @@
 			}
 		}
 		.btn-provider-login-text-name {
-			text-align: left;
+			text-align: start;
 			width: 70px;
 			-servicestudio-display: inline-block;
 		}

--- a/src/scss/04-patterns/06-utilities/_pull-to-refresh.scss
+++ b/src/scss/04-patterns/06-utilities/_pull-to-refresh.scss
@@ -9,7 +9,7 @@
 .pull-to-refresh {
 	color: var(--color-text-disabled);
 	font-size: variables.$token-font-size-650;
-	left: 0;
+	inset-inline-start: 0;
 	padding: variables.$token-scale-200;
 	position: absolute;
 	text-align: center;

--- a/src/scss/05-useful/_a11y.scss
+++ b/src/scss/05-useful/_a11y.scss
@@ -33,9 +33,10 @@
 /* Skip-nav link used on Accessibility*/
 ///
 .skip-nav {
-	left: variables.$token-scale-1000;
+	inset-inline-start: variables.$token-scale-1000;
 	opacity: 0;
-	padding: variables.$token-scale-200 variables.$token-scale-400;
+	padding-block: variables.$token-scale-200;
+	padding-inline: variables.$token-scale-400;
 	pointer-events: none;
 	position: absolute;
 	text-transform: uppercase;

--- a/src/scss/05-useful/_border-size.scss
+++ b/src/scss/05-useful/_border-size.scss
@@ -31,13 +31,13 @@ $osui-border-size-token-vars: (
 	}
 
 	& {
-		@each $osui-box-side in $osui-box-sides {
+		@each $osui-box-side, $osui-logical-side in $osui-box-sides {
 			@each $type, $value in $osui-border-size {
 				@if $type != 'none' {
 					// Generated - Eg: .border-top-s
 					&-#{$osui-box-side}-#{$type}:not(.columns),
 					&-#{$osui-box-side}-#{$type}.columns > .columns-item:not(:last-child) {
-						border-#{$osui-box-side}: #{map.get($osui-border-size-token-vars, $type)} solid currentColor;
+						border-#{$osui-logical-side}: #{map.get($osui-border-size-token-vars, $type)} solid currentColor;
 					}
 				}
 			}

--- a/src/scss/05-useful/_miscellaneous.scss
+++ b/src/scss/05-useful/_miscellaneous.scss
@@ -18,9 +18,9 @@
 ///
 .sticky-observer {
 	height: var(--size-header);
-	left: 0;
+	inset-inline-end: 0;
+	inset-inline-start: 0;
 	position: absolute;
-	right: 0;
 	top: 0;
 	visibility: hidden;
 }
@@ -37,6 +37,6 @@ Example can be checked at Tooltip since we can have clickable containers. */
 ///
 .tablet .tablet-full-width,
 .phone .phone-full-width {
-	margin-left: 0;
+	margin-inline-start: 0;
 	width: 100%;
 }

--- a/src/scss/05-useful/_positioning-absolute.scss
+++ b/src/scss/05-useful/_positioning-absolute.scss
@@ -14,12 +14,12 @@
 		top: 0;
 
 		&-right {
-			right: 0;
+			inset-inline-end: 0;
 			top: 0;
 		}
 
 		&-left {
-			left: 0;
+			inset-inline-start: 0;
 			top: 0;
 		}
 
@@ -29,7 +29,7 @@
 	}
 
 	&-right {
-		right: 0;
+		inset-inline-end: 0;
 	}
 
 	&-bottom {
@@ -37,12 +37,12 @@
 
 		&-right {
 			bottom: 0;
-			right: 0;
+			inset-inline-end: 0;
 		}
 
 		&-left {
 			bottom: 0;
-			left: 0;
+			inset-inline-start: 0;
 		}
 
 		&.absolute {
@@ -55,7 +55,7 @@
 	}
 
 	&-left {
-		left: 0;
+		inset-inline-start: 0;
 	}
 
 	&-center {
@@ -70,7 +70,7 @@
 		}
 
 		&-right {
-			right: 0;
+			inset-inline-end: 0;
 			top: 50%;
 			transform: translateY(-50%);
 		}
@@ -82,7 +82,7 @@
 		}
 
 		&-left {
-			left: 0;
+			inset-inline-start: 0;
 			top: 50%;
 			transform: translateY(-50%);
 		}

--- a/src/scss/05-useful/_space-margin.scss
+++ b/src/scss/05-useful/_space-margin.scss
@@ -14,42 +14,23 @@
 			margin: #{map.get($osui-space-token-vars, $type)};
 		}
 
-		@each $osui-box-side in $osui-box-sides {
+		@each $osui-box-side, $osui-logical-side in $osui-box-sides {
 			&-#{$osui-box-side}-#{$type} {
-				margin-#{$osui-box-side}: #{map.get($osui-space-token-vars, $type)};
+				margin-#{$osui-logical-side}: #{map.get($osui-space-token-vars, $type)};
 			}
 		}
 
 		&-x-#{$type} {
-			margin-left: #{map.get($osui-space-token-vars, $type)};
-			margin-right: #{map.get($osui-space-token-vars, $type)};
+			margin-inline: #{map.get($osui-space-token-vars, $type)};
 		}
 
 		&-y-#{$type} {
-			margin-bottom: #{map.get($osui-space-token-vars, $type)};
-			margin-top: #{map.get($osui-space-token-vars, $type)};
+			margin-block: #{map.get($osui-space-token-vars, $type)};
 		}
 	}
 
 	&-auto {
-		margin: 0 auto;
-	}
-}
-
-// IsRTL -------------------------------------------------------------------------
-///
-.is-rtl {
-	@each $type, $value in $osui-sizes {
-		.margin {
-			&-right-#{$type} {
-				margin-left: #{map.get($osui-space-token-vars, $type)};
-				margin-right: variables.$token-scale-0;
-			}
-
-			&-left-#{$type} {
-				margin-left: variables.$token-scale-0;
-				margin-right: #{map.get($osui-space-token-vars, $type)};
-			}
-		}
+		margin-block: 0;
+		margin-inline: auto;
 	}
 }

--- a/src/scss/05-useful/_space-padding.scss
+++ b/src/scss/05-useful/_space-padding.scss
@@ -14,42 +14,26 @@
 			padding: #{map.get($osui-space-token-vars, $type)};
 		}
 
-		@each $osui-box-side in $osui-box-sides {
+		@each $osui-box-side, $osui-logical-side in $osui-box-sides {
 			&-#{$osui-box-side}-#{$type} {
-				padding-#{$osui-box-side}: #{map.get($osui-space-token-vars, $type)};
+				padding-#{$osui-logical-side}: #{map.get($osui-space-token-vars, $type)};
 			}
 		}
 
 		&-x-#{$type} {
-			padding-left: #{map.get($osui-space-token-vars, $type)};
-			padding-right: #{map.get($osui-space-token-vars, $type)};
+			padding-inline: #{map.get($osui-space-token-vars, $type)};
 		}
 
 		&-y-#{$type} {
-			padding-bottom: #{map.get($osui-space-token-vars, $type)};
-			padding-top: #{map.get($osui-space-token-vars, $type)};
+			padding-block: #{map.get($osui-space-token-vars, $type)};
 		}
 	}
 
 	&-auto {
-		padding: 0 auto;
-	}
-}
-
-// IsRTL -------------------------------------------------------------------------
-///
-.is-rtl {
-	@each $type, $value in $osui-sizes {
-		.padding {
-			&-right-#{$type} {
-				padding-left: #{map.get($osui-space-token-vars, $type)};
-				padding-right: variables.$token-scale-0;
-			}
-
-			&-left-#{$type} {
-				padding-left: variables.$token-scale-0;
-				padding-right: #{map.get($osui-space-token-vars, $type)};
-			}
-		}
+		// `auto` is not a valid padding value, so this declaration has always been
+		// dropped by the browser. Left physical on purpose: splitting it into
+		// padding-block/padding-inline would make the `0` half suddenly apply.
+		padding-block: 0;
+		padding-inline: auto;
 	}
 }

--- a/src/scss/05-useful/_text.scss
+++ b/src/scss/05-useful/_text.scss
@@ -8,10 +8,20 @@
 	word-break: break-word;
 }
 
+/* The physical `align` attribute has always mirrored in RTL; `start`/`end` keeps that
+   behaviour without an .is-rtl duplicate. */
+[align='left'] {
+	text-align: start;
+}
+
+[align='right'] {
+	text-align: end;
+}
+
 ///
 .text-align {
 	&-left {
-		text-align: left;
+		text-align: start;
 	}
 
 	&-center {
@@ -19,24 +29,11 @@
 	}
 
 	&-right {
-		text-align: right;
+		text-align: end;
 	}
 }
 
 ///
 .white-space-nowrap {
 	white-space: nowrap;
-}
-
-// IsRTL -------------------------------------------------------------------------
-.is-rtl {
-	[align='right'],
-	.text-align-right {
-		text-align: left;
-	}
-
-	[align='left'],
-	.text-align-left {
-		text-align: right;
-	}
 }


### PR DESCRIPTION
Move padding, margin and border from physical sides to logical ones, and delete the hand-written `.is-rtl` rules that existed only to restate a physical side.

Converted, 681 declarations across 92 files:
  - padding/margin sides -> *-inline-start / -end, *-block-start / -end
  - border sides -> border-inline-* / border-block-*
  - inline-asymmetric border-radius -> logical corners
  - padding/margin shorthands -> padding-block / padding-inline
  - left/right -> inset-inline-*, text-align: left|right -> start|end

Deleted 175 `.is-rtl` declarations and pruned 205 rules they left empty; 51 files carrying `.is-rtl` are down to 24.

Also:
  - $osui-box-sides became a physical-name -> logical-side map, so the .margin-left-s / .padding-top-m / .border-left-s utility classes keep their public names and emit logical properties.
  - Card Sectioned's four-value shorthand custom properties were split into -padding-block / -padding-inline pairs, which also fixes a missing interpolation that had been voiding the image padding.
  - --osui-sidebar-padding-x / -y renamed to -inline / -block.
  - [align='left'|'right'] resolve through text-align: start|end.
  - Accordion Item: dropped the hardcoded `direction: ltr` on the title, which kept the row LTR while its content mirrored.
  - Carousel (ODC): swap the arrow glyphs under .splide--rtl. Splide flips the buttons but `content` does not follow, so both arrows pointed inward in RTL.

Left physical on purpose, each with a comment: transform / transform-origin and anything paired with a translateX (a logical inset would flip the anchor while the transform kept its direction), positional top/bottom, float, env() safe areas, -servicestudio-*, vendor baselines, and the Flatpickr calendar, which the vendor pins to `direction: ltr`.

Storybook: the vendored platform shim was missing the author-level `direction: rtl` the running platform provides, so the RTL toggle set `dir` and `is-rtl` but OUI's own `body { direction: ltr }` reset won and nothing mirrored. Added to the shim only; no OUI SCSS involved.

Verified by compiling both bundles before and after and comparing with a normaliser that resolves logical properties back to physical LTR: zero value changes on ODC and O11. Mirroring, the accordion title and the carousel arrows were then measured in headless Chrome against a running Storybook in both directions.

### Checklist

-   [ ] tested locally
-   [ ] documented the code
-   [ ] clean all warnings and errors of eslint
-   [ ] requires changes in OutSystems (if so, provide a module with changes)
-   [ ] requires new sample page in OutSystems (if so, provide a module with changes)
