### PR TITLE
ROU-13016: Align Alert pattern with Figma

### DIFF
--- a/src/scss/04-patterns/02-content/_alert.scss
+++ b/src/scss/04-patterns/02-content/_alert.scss
@@ -11,21 +11,24 @@
 	--osui-alert-background: transparent;
 	--osui-alert-color: var(--color-text);
 	--osui-alert-accent-color: var(--color-border);
+	--osui-alert-icon-color: currentColor;
 	--osui-alert-border-radius: #{variables.$token-border-radius-300};
 	--osui-alert-padding: #{variables.$token-scale-300} #{variables.$token-scale-400};
 	// ───────────────────────────────────────────────────────────────────
 
 	align-items: flex-start;
 	background-color: var(--osui-alert-background);
+	border: variables.$token-border-size-025 solid var(--osui-alert-accent-color);
 	border-radius: var(--osui-alert-border-radius);
 	color: var(--osui-alert-color);
 	display: flex;
-	gap: variables.$token-scale-200;
+	gap: variables.$token-space-300;
 	padding: var(--osui-alert-padding);
 	transition: background-color variables.$token-transition-time-100 variables.$token-transition-curve-expressive;
 
 	.alert-icon {
 		align-self: flex-start;
+		color: var(--osui-alert-icon-color);
 		display: inline-flex;
 		flex-shrink: 0;
 		font-size: variables.$token-font-size-500;
@@ -46,33 +49,65 @@
 	.alert-message {
 		flex: 1;
 		font-size: variables.$token-font-size-350;
-		font-weight: variables.$token-font-weight-medium;
-		line-height: variables.$token-font-line-height-500;
+		font-weight: variables.$token-font-weight-regular;
+		line-height: variables.$token-font-line-height-600;
 	}
 
 	&-info {
-		--osui-alert-background: #{variables.$token-bg-info-base-default};
-		--osui-alert-color: #{variables.$token-text-inverse};
-		--osui-alert-accent-color: var(--color-info);
+		--osui-alert-background: #{variables.$token-bg-info-subtle-default};
+		--osui-alert-color: var(--color-text);
+		--osui-alert-accent-color: #{variables.$token-border-info};
+		--osui-alert-icon-color: #{variables.$token-icon-info};
+
+		&.vivid {
+			--osui-alert-background: #{variables.$token-bg-info-base-default};
+			--osui-alert-color: #{variables.$token-text-inverse};
+			--osui-alert-accent-color: var(--osui-alert-background);
+			--osui-alert-icon-color: currentColor;
+		}
 	}
 
 	&-success {
-		--osui-alert-background: #{variables.$token-bg-success-base-default};
-		--osui-alert-color: #{variables.$token-text-inverse};
-		--osui-alert-accent-color: var(--color-success);
+		--osui-alert-background: #{variables.$token-bg-success-subtle-default};
+		--osui-alert-color: var(--color-text);
+		--osui-alert-accent-color: #{variables.$token-border-success};
+		--osui-alert-icon-color: #{variables.$token-icon-success};
+
+		&.vivid {
+			--osui-alert-background: #{variables.$token-bg-success-base-default};
+			--osui-alert-color: #{variables.$token-text-inverse};
+			--osui-alert-accent-color: var(--osui-alert-background);
+			--osui-alert-icon-color: currentColor;
+		}
 	}
 
 	&-error {
-		--osui-alert-background: #{variables.$token-bg-danger-base-default};
-		--osui-alert-color: #{variables.$token-text-inverse};
-		--osui-alert-accent-color: var(--color-error);
+		--osui-alert-background: #{variables.$token-bg-danger-subtle-default};
+		--osui-alert-color: var(--color-text);
+		--osui-alert-accent-color: #{variables.$token-border-danger-default};
+		--osui-alert-icon-color: #{variables.$token-icon-danger};
+
+		&.vivid {
+			--osui-alert-background: #{variables.$token-bg-danger-base-default};
+			--osui-alert-color: #{variables.$token-text-inverse};
+			--osui-alert-accent-color: var(--osui-alert-background);
+			--osui-alert-icon-color: currentColor;
+		}
 	}
 
 	&-warning {
-		--osui-alert-background: #{variables.$token-bg-warning-base-default};
-		// Warning's solid background is a light yellow — keep dark text for contrast,
-		// unlike the other three types which use light text on a darker solid background.
+		--osui-alert-background: #{variables.$token-bg-warning-subtle-default};
 		--osui-alert-color: var(--color-text);
-		--osui-alert-accent-color: var(--color-warning);
+		--osui-alert-accent-color: #{variables.$token-border-warning};
+		--osui-alert-icon-color: #{variables.$token-icon-warning};
+
+		&.vivid {
+			--osui-alert-background: #{variables.$token-bg-warning-base-default};
+			// Warning's solid background is a light yellow — keep dark text for contrast,
+			// unlike the other three types which use light text on a darker solid background.
+			--osui-alert-color: var(--color-text);
+			--osui-alert-accent-color: var(--osui-alert-background);
+			--osui-alert-icon-color: currentColor;
+		}
 	}
 }

--- a/src/scss/04-patterns/02-content/_alert.scss
+++ b/src/scss/04-patterns/02-content/_alert.scss
@@ -27,7 +27,7 @@
 	transition: background-color variables.$token-transition-time-100 variables.$token-transition-curve-expressive;
 
 	.alert-icon {
-		align-self: flex-start;
+		align-self: center;
 		color: var(--osui-alert-icon-color);
 		display: inline-flex;
 		flex-shrink: 0;

--- a/stories/Alert.stories.ts
+++ b/stories/Alert.stories.ts
@@ -6,7 +6,7 @@ import { cls, extendedClassArgType } from './_helpers/lowcode';
  * Alert — shipped markup: `.alert.alert-{type}` (role/aria) > empty `.alert-icon`
  * + `.alert-message > span`. The status icon is drawn by `.alert-{type} .alert-icon:after`
  * via `content: var(--osui-icon-{type})` (icon-library var → respects the FA/Phosphor toggle),
- * so NO inner `<i>` is needed.
+ * so NO inner `<i>` is needed. Add `.vivid` (ExtendedClass) for the solid-fill look.
  *
  * Controls mirror the low-code input parameters of the `Alert` block:
  *   AlertType    → `.alert-{success|warning|error|info}` modifier on the root
@@ -16,10 +16,19 @@ import { cls, extendedClassArgType } from './_helpers/lowcode';
 const meta: Meta = { title: 'Patterns/Content/Alert', tags: ['!ui-pending', 'ui-reviewed'] };
 export default meta;
 
-type AlertArgs = { alertType: string; extendedClass: string };
+const ALERT_COPY: Record<string, string> = {
+	success: 'Success! Your changes were saved.',
+	warning: 'Warning — double-check this before continuing.',
+	error: 'Something went wrong. Please try again.',
+	info: 'Heads up — this is an informational alert.',
+};
+
+const ALERT_TYPES = ['info', 'success', 'warning', 'error'] as const;
+
+type AlertArgs = { alertType: string; vivid: boolean; extendedClass: string };
 
 export const Default: StoryObj<AlertArgs> = {
-	args: { alertType: 'success', extendedClass: '' },
+	args: { alertType: 'success', vivid: false, extendedClass: '' },
 	argTypes: {
 		alertType: {
 			name: 'AlertType',
@@ -28,32 +37,32 @@ export const Default: StoryObj<AlertArgs> = {
 			description:
 				'Type of the alert message. Maps to `.alert-{success|info|warning|error}` on the root element.',
 		},
+		vivid: {
+			name: 'Vivid',
+			control: 'boolean',
+			description: 'Solid-fill look. Maps to `.vivid` on the root (typically passed via ExtendedClass).',
+		},
 		extendedClass: extendedClassArgType,
 	},
-	render: ({ alertType, extendedClass }) =>
+	render: ({ alertType, vivid, extendedClass }) =>
 		renderStatic(`
-			<div class="${cls('alert', alertType && `alert-${alertType}`, extendedClass)}" role="alert" aria-live="polite" aria-atomic="true" tabindex="0">
+			<div class="${cls('alert', alertType && `alert-${alertType}`, vivid && 'vivid', extendedClass)}" role="alert" aria-live="polite" aria-atomic="true" tabindex="0">
 				<div class="alert-icon OSInline" aria-hidden="true"></div>
-				<div class="alert-message"><span>${alertType === 'success' ? 'Success! Your changes were saved.' : alertType === 'warning' ? 'Warning — double-check this before continuing.' : alertType === 'error' ? 'Something went wrong. Please try again.' : 'Heads up — this is an informational alert.'}</span></div>
+				<div class="alert-message"><span>${ALERT_COPY[alertType] ?? ALERT_COPY.info}</span></div>
 			</div>`),
 };
 
 export const AllVariants: StoryObj = {
 	render: () =>
 		renderStatic(
-			[
-				{ type: 'info', msg: 'Heads up — this is an informational alert.' },
-				{ type: 'success', msg: 'Success! Your changes were saved.' },
-				{ type: 'warning', msg: 'Warning — double-check this before continuing.' },
-				{ type: 'error', msg: 'Something went wrong. Please try again.' },
-			]
-				.map(
-					({ type, msg }) => `
-			<div class="alert alert-${type}" role="alert" aria-live="polite" aria-atomic="true" tabindex="0" style="margin-bottom:12px;">
+			ALERT_TYPES.flatMap((type) =>
+				[false, true].map(
+					(vivid) => `
+			<div class="${cls('alert', `alert-${type}`, vivid && 'vivid')}" role="alert" aria-live="polite" aria-atomic="true" tabindex="0" style="margin-bottom:12px;">
 				<div class="alert-icon OSInline" aria-hidden="true"></div>
-				<div class="alert-message"><span>${msg}</span></div>
+				<div class="alert-message"><span>${ALERT_COPY[type]}${vivid ? ' (vivid)' : ''}</span></div>
 			</div>`
 				)
-				.join('')
+			).join('')
 		),
 };

--- a/stories/_helpers/css-api-manifest.ts
+++ b/stories/_helpers/css-api-manifest.ts
@@ -39,9 +39,9 @@ export type CssApiManifest = {
 };
 
 export const CSS_API_MANIFEST: CssApiManifest = {
-	generatedAt: '2026-08-31T07:39:37.679Z',
+	generatedAt: '2026-09-01T10:14:07.077Z',
 	totals: {
-		properties: 546,
+		properties: 547,
 		components: 63,
 		categories: 9,
 	},
@@ -2007,6 +2007,13 @@ export const CSS_API_MANIFEST: CssApiManifest = {
 								kind: 'color',
 								chain: 'theme-role',
 								hint: 'var(--color-text)',
+							},
+							{
+								name: '--osui-alert-icon-color',
+								default: 'currentColor',
+								kind: 'color',
+								chain: 'other',
+								hint: 'currentColor',
 							},
 							{
 								name: '--osui-alert-padding',
@@ -4301,18 +4308,18 @@ export const CSS_API_MANIFEST: CssApiManifest = {
 								hint: 'var(--color-text)',
 							},
 							{
-								name: '--osui-sidebar-padding-x',
-								default: '#{$token-scale-600}',
-								kind: 'spacing',
-								chain: 'token',
-								hint: '#{$token-scale-600}',
-							},
-							{
-								name: '--osui-sidebar-padding-y',
+								name: '--osui-sidebar-padding-block',
 								default: '#{$token-scale-400}',
 								kind: 'spacing',
 								chain: 'token',
 								hint: '#{$token-scale-400}',
+							},
+							{
+								name: '--osui-sidebar-padding-inline',
+								default: '#{$token-scale-600}',
+								kind: 'spacing',
+								chain: 'token',
+								hint: '#{$token-scale-600}',
 							},
 							{
 								name: '--osui-sidebar-shadow',


### PR DESCRIPTION
This PR is for aligning the Alert pattern with Figma by switching defaults to subtle fills and adding a vivid modifier.

### What was happening
* Alert types used solid semantic fills by default (inverse text on info, success, and error), with no border and no separate icon color.
* Icon/message spacing and message typography did not match the Figma spec.
* Storybook only showed the solid-fill variants.

### What was done
* Default Alert backgrounds now use subtle semantic fills, an accent border, and a dedicated `--osui-alert-icon-color` CSS API variable.
* Added a `.vivid` modifier so the previous solid-fill look remains available via ExtendedClass.
* Refined alert icon/message spacing and message typography.
* Updated Storybook Alert stories with a Vivid control and rendered all default plus vivid variants.
* Regenerated the CSS API manifest.

### Test Steps
1. Run Storybook and open Patterns / Content / Alert.
2. Check Default for info, success, warning, and error: subtle background, accent border, tinted icon, regular-weight message text.
3. Toggle Vivid on and confirm the solid-fill look (inverse text on info, success, and error; dark text on warning).
4. Open AllVariants and confirm each type appears in both default and vivid.
5. Verify dark theme: both default and vivid alerts still have readable contrast.

### Screenshots
(prefer animated gif)

### Checklist
* [ ] tested locally
* [ ] documented the code
* [ ] clean all warnings and errors of eslint
* [ ] requires changes in OutSystems (if so, provide a module with changes)
* [ ] requires new sample page in OutSystems (if so, provide a module with changes)
