### PR TITLE
ROU-13001: Add fixed light and dark text theme roles

### DIFF
--- a/src/scss/01-foundations/_root.scss
+++ b/src/scss/01-foundations/_root.scss
@@ -23,6 +23,8 @@
 	--color-text-subtlest: #{variables.$token-text-subtlest};
 	--color-text-disabled: #{variables.$token-text-disabled};
 	--color-text-inverse: #{variables.$token-text-inverse};
+	--color-text-light: #{variables.$token-text-light};
+	--color-text-dark: #{variables.$token-text-dark};
 
 	// ─── Theme layer · borders ───────────────────────────────────────────
 	--color-border: #{variables.$token-border-default};

--- a/src/scss/03-widgets/_btn.scss
+++ b/src/scss/03-widgets/_btn.scss
@@ -29,15 +29,15 @@
 	// Primary variant
 	--osui-btn-primary-background: var(--color-primary);
 	--osui-btn-primary-border-color: var(--color-primary);
-	--osui-btn-primary-color: var(--color-text-inverse);
+	--osui-btn-primary-color: var(--color-text-light);
 	// Success variant
 	--osui-btn-success-background: #{variables.$token-bg-success-base-default};
 	--osui-btn-success-border-color: #{variables.$token-bg-success-base-default};
-	--osui-btn-success-color: var(--color-text-inverse);
+	--osui-btn-success-color: var(--color-text-light);
 	// Error variant
 	--osui-btn-error-background: #{variables.$token-bg-danger-base-default};
 	--osui-btn-error-border-color: #{variables.$token-bg-danger-base-default};
-	--osui-btn-error-color: var(--color-text-inverse);
+	--osui-btn-error-color: var(--color-text-light);
 	// Focus state
 	--osui-btn-focus-shadow-width: #{variables.$token-border-size-050};
 	--osui-btn-focus-shadow-gap: #{variables.$token-scale-050};

--- a/src/scss/04-patterns/02-content/_alert.scss
+++ b/src/scss/04-patterns/02-content/_alert.scss
@@ -52,19 +52,19 @@
 
 	&-info {
 		--osui-alert-background: #{variables.$token-bg-info-base-default};
-		--osui-alert-color: #{variables.$token-text-inverse};
+		--osui-alert-color: var(--color-text-light);
 		--osui-alert-accent-color: var(--color-info);
 	}
 
 	&-success {
 		--osui-alert-background: #{variables.$token-bg-success-base-default};
-		--osui-alert-color: #{variables.$token-text-inverse};
+		--osui-alert-color: var(--color-text-light);
 		--osui-alert-accent-color: var(--color-success);
 	}
 
 	&-error {
 		--osui-alert-background: #{variables.$token-bg-danger-base-default};
-		--osui-alert-color: #{variables.$token-text-inverse};
+		--osui-alert-color: var(--color-text-light);
 		--osui-alert-accent-color: var(--color-error);
 	}
 
@@ -72,7 +72,7 @@
 		--osui-alert-background: #{variables.$token-bg-warning-base-default};
 		// Warning's solid background is a light yellow — keep dark text for contrast,
 		// unlike the other three types which use light text on a darker solid background.
-		--osui-alert-color: var(--color-text);
+		--osui-alert-color: var(--color-text-dark);
 		--osui-alert-accent-color: var(--color-warning);
 	}
 }

--- a/src/scss/04-patterns/02-content/_card-background.scss
+++ b/src/scss/04-patterns/02-content/_card-background.scss
@@ -17,7 +17,7 @@
 	align-items: center;
 	border: var(--osui-card-background-border-width) solid var(--osui-card-background-border-color);
 	border-radius: var(--osui-card-background-border-radius);
-	color: var(--color-text-inverse);
+	color: var(--color-text-light);
 	display: flex;
 	overflow: hidden;
 	padding: variables.$token-scale-600;

--- a/src/scss/04-patterns/02-content/_chat-message.scss
+++ b/src/scss/04-patterns/02-content/_chat-message.scss
@@ -8,11 +8,11 @@
 ///
 .chat {
 	// ─── Component CSS API ─────────────────────────────────────────────
-	--osui-chat-message-background:         #{variables.$token-bg-neutral-subtle-default};
-	--osui-chat-message-border-radius:      #{variables.$token-border-radius-200};
-	--osui-chat-message-sent-background:    var(--color-primary);
-	--osui-chat-message-sent-color:         var(--color-text-inverse);
-	--osui-chat-message-status-color:       #{variables.$token-text-subtlest};
+	--osui-chat-message-background: #{variables.$token-bg-neutral-subtle-default};
+	--osui-chat-message-border-radius: #{variables.$token-border-radius-200};
+	--osui-chat-message-sent-background: var(--color-primary);
+	--osui-chat-message-sent-color: var(--color-text-light);
+	--osui-chat-message-status-color: #{variables.$token-text-subtlest};
 	// Figma says 18px, which sits exactly between the 16px and 20px steps; 16px keeps
 	// the 11px status text at a caption-like 1.45 ratio rather than 1.82.
 	--osui-chat-message-status-line-height: #{variables.$token-font-line-height-400};

--- a/src/scss/04-patterns/02-content/_tag.scss
+++ b/src/scss/04-patterns/02-content/_tag.scss
@@ -29,7 +29,6 @@ $osui-tag-lightest-text-colors: (
 .tag {
 	// ─── Component CSS API ─────────────────────────────────────────────
 	--osui-tag-color: var(--color-text-inverse);
-	--osui-tag-primary-color: var(--color-primary);
 	--osui-tag-on-light-color: var(--color-text);
 	--osui-tag-soft-border-radius: #{variables.$token-border-radius-100};
 	--osui-tag-medium-soft-border-radius: #{variables.$token-border-radius-200};
@@ -79,10 +78,10 @@ $osui-tag-lightest-text-colors: (
 
 	&.background {
 		&-transparent {
-			color: var(--osui-tag-primary-color);
+			--osui-tag-color: var(--color-primary);
 
 			&-lightest {
-				color: variables.$token-text-inverse;
+				--osui-tag-color: var(--color-text-inverse);
 			}
 		}
 
@@ -145,18 +144,18 @@ $osui-tag-lightest-text-colors: (
 		// Warning backgrounds are light enough to need dark text (Figma).
 		&-warning,
 		&-yellow {
-			color: var(--color-text-dark);
+			--osui-tag-color: var(--color-text-dark);
 		}
 
 		&-secondary {
-			color: var(--osui-tag-primary-color);
+			--osui-tag-color: var(--color-primary);
 		}
 
 		&-primary,
 		&-blue,
 		&-green,
 		&-red {
-			color: var(--color-text-light);
+			--osui-tag-color: var(--color-text-light);
 		}
 	}
 

--- a/src/scss/04-patterns/02-content/_tag.scss
+++ b/src/scss/04-patterns/02-content/_tag.scss
@@ -145,7 +145,18 @@ $osui-tag-lightest-text-colors: (
 		// Warning backgrounds are light enough to need dark text (Figma).
 		&-warning,
 		&-yellow {
-			color: var(--osui-tag-on-light-color);
+			color: var(--color-text-dark);
+		}
+
+		&-secondary {
+			color: var(--osui-tag-primary-color);
+		}
+
+		&-primary,
+		&-blue,
+		&-green,
+		&-red {
+			color: var(--color-text-light);
 		}
 	}
 

--- a/src/scss/04-patterns/02-content/_user-avatar.scss
+++ b/src/scss/04-patterns/02-content/_user-avatar.scss
@@ -117,7 +117,18 @@ $osui-avatar-lightest-text-colors: (
 		// Warning backgrounds are light enough to need dark text (Figma).
 		&-warning,
 		&-yellow {
-			color: var(--osui-avatar-on-light-color);
+			color: var(--color-text-dark);
+		}
+
+		&-secondary {
+			color: var(--osui-avatar-primary-color);
+		}
+
+		&-primary,
+		&-blue,
+		&-green,
+		&-red {
+			color: var(--color-text-light);
 		}
 	}
 

--- a/src/scss/04-patterns/02-content/_user-avatar.scss
+++ b/src/scss/04-patterns/02-content/_user-avatar.scss
@@ -29,7 +29,6 @@ $osui-avatar-lightest-text-colors: (
 .avatar {
 	// ─── Component CSS API ─────────────────────────────────────────────
 	--osui-avatar-color: var(--color-text-inverse);
-	--osui-avatar-primary-color: var(--color-primary);
 	--osui-avatar-on-light-color: var(--color-text);
 	--osui-avatar-soft-border-radius: #{variables.$token-border-radius-100};
 	// ───────────────────────────────────────────────────────────────────
@@ -67,10 +66,10 @@ $osui-avatar-lightest-text-colors: (
 
 	&.background {
 		&-transparent {
-			color: var(--osui-avatar-primary-color);
+			--osui-avatar-color: var(--color-primary);
 
 			&-lightest {
-				color: variables.$token-text-inverse;
+				--osui-avatar-color: var(--color-text-inverse);
 			}
 		}
 
@@ -117,18 +116,18 @@ $osui-avatar-lightest-text-colors: (
 		// Warning backgrounds are light enough to need dark text (Figma).
 		&-warning,
 		&-yellow {
-			color: var(--color-text-dark);
+			--osui-avatar-color: var(--color-text-dark);
 		}
 
 		&-secondary {
-			color: var(--osui-avatar-primary-color);
+			--osui-avatar-color: var(--color-primary);
 		}
 
 		&-primary,
 		&-blue,
 		&-green,
 		&-red {
-			color: var(--color-text-light);
+			--osui-avatar-color: var(--color-text-light);
 		}
 	}
 

--- a/src/scss/04-patterns/05-numbers/_badge.scss
+++ b/src/scss/04-patterns/05-numbers/_badge.scss
@@ -29,7 +29,6 @@ $osui-badge-lightest-text-colors: (
 .badge {
 	// ─── Component CSS API ─────────────────────────────────────────────
 	--osui-badge-color: var(--color-text-inverse);
-	--osui-badge-primary-color: #{variables.$token-text-primary};
 	--osui-badge-on-light-color: var(--color-text);
 	// ───────────────────────────────────────────────────────────────────
 
@@ -88,22 +87,22 @@ $osui-badge-lightest-text-colors: (
 		// Warning backgrounds are light enough to need dark text (Figma).
 		&-warning,
 		&-yellow {
-			color: var(--color-text-dark);
+			--osui-badge-color: var(--color-text-dark);
 		}
 
 		&-transparent {
-			color: var(--osui-badge-primary-color);
+			--osui-badge-color: var(--color-primary);
 		}
 
 		&-secondary {
-			color: var(--osui-badge-primary-color);
+			--osui-badge-color: var(--color-primary);
 		}
 
 		&-primary,
 		&-blue,
 		&-green,
 		&-red {
-			color: var(--color-text-light);
+			--osui-badge-color: var(--color-text-light);
 		}
 	}
 
@@ -144,7 +143,7 @@ $osui-badge-lightest-text-colors: (
 	}
 
 	&.background-transparent-lightest {
-		color: variables.$token-text-inverse;
+		--osui-badge-color: var(--color-text-inverse);
 	}
 
 	// Extended palette colors (red, orange, yellow, etc.)

--- a/src/scss/04-patterns/05-numbers/_badge.scss
+++ b/src/scss/04-patterns/05-numbers/_badge.scss
@@ -88,11 +88,22 @@ $osui-badge-lightest-text-colors: (
 		// Warning backgrounds are light enough to need dark text (Figma).
 		&-warning,
 		&-yellow {
-			color: var(--osui-badge-on-light-color);
+			color: var(--color-text-dark);
 		}
 
 		&-transparent {
 			color: var(--osui-badge-primary-color);
+		}
+
+		&-secondary {
+			color: var(--osui-badge-primary-color);
+		}
+
+		&-primary,
+		&-blue,
+		&-green,
+		&-red {
+			color: var(--color-text-light);
 		}
 	}
 

--- a/stories/_helpers/css-api-manifest.ts
+++ b/stories/_helpers/css-api-manifest.ts
@@ -39,9 +39,9 @@ export type CssApiManifest = {
 };
 
 export const CSS_API_MANIFEST: CssApiManifest = {
-	generatedAt: '2026-08-31T07:39:37.679Z',
+	generatedAt: '2026-09-02T09:35:17.634Z',
 	totals: {
-		properties: 546,
+		properties: 543,
 		components: 63,
 		categories: 9,
 	},
@@ -699,10 +699,10 @@ export const CSS_API_MANIFEST: CssApiManifest = {
 							},
 							{
 								name: '--osui-btn-error-color',
-								default: 'var(--color-text-inverse)',
+								default: 'var(--color-text-light)',
 								kind: 'color',
 								chain: 'theme-role',
-								hint: 'var(--color-text-inverse)',
+								hint: 'var(--color-text-light)',
 							},
 							{
 								name: '--osui-btn-focus-shadow-color',
@@ -755,10 +755,10 @@ export const CSS_API_MANIFEST: CssApiManifest = {
 							},
 							{
 								name: '--osui-btn-primary-color',
-								default: 'var(--color-text-inverse)',
+								default: 'var(--color-text-light)',
 								kind: 'color',
 								chain: 'theme-role',
-								hint: 'var(--color-text-inverse)',
+								hint: 'var(--color-text-light)',
 							},
 							{
 								name: '--osui-btn-success-background',
@@ -776,10 +776,10 @@ export const CSS_API_MANIFEST: CssApiManifest = {
 							},
 							{
 								name: '--osui-btn-success-color',
-								default: 'var(--color-text-inverse)',
+								default: 'var(--color-text-light)',
 								kind: 'color',
 								chain: 'theme-role',
-								hint: 'var(--color-text-inverse)',
+								hint: 'var(--color-text-light)',
 							},
 						],
 					},
@@ -2263,10 +2263,10 @@ export const CSS_API_MANIFEST: CssApiManifest = {
 							},
 							{
 								name: '--osui-chat-message-sent-color',
-								default: 'var(--color-text-inverse)',
+								default: 'var(--color-text-light)',
 								kind: 'color',
 								chain: 'theme-role',
-								hint: 'var(--color-text-inverse)',
+								hint: 'var(--color-text-light)',
 							},
 							{
 								name: '--osui-chat-message-status-color',
@@ -2420,13 +2420,6 @@ export const CSS_API_MANIFEST: CssApiManifest = {
 								hint: 'var(--color-text)',
 							},
 							{
-								name: '--osui-tag-primary-color',
-								default: 'var(--color-primary)',
-								kind: 'color',
-								chain: 'theme-role',
-								hint: 'var(--color-primary)',
-							},
-							{
 								name: '--osui-tag-soft-border-radius',
 								default: '#{$token-border-radius-100}',
 								kind: 'border',
@@ -2459,13 +2452,6 @@ export const CSS_API_MANIFEST: CssApiManifest = {
 								kind: 'color',
 								chain: 'theme-role',
 								hint: 'var(--color-text)',
-							},
-							{
-								name: '--osui-avatar-primary-color',
-								default: 'var(--color-primary)',
-								kind: 'color',
-								chain: 'theme-role',
-								hint: 'var(--color-primary)',
 							},
 							{
 								name: '--osui-avatar-soft-border-radius',
@@ -4301,18 +4287,18 @@ export const CSS_API_MANIFEST: CssApiManifest = {
 								hint: 'var(--color-text)',
 							},
 							{
-								name: '--osui-sidebar-padding-x',
-								default: '#{$token-scale-600}',
-								kind: 'spacing',
-								chain: 'token',
-								hint: '#{$token-scale-600}',
-							},
-							{
-								name: '--osui-sidebar-padding-y',
+								name: '--osui-sidebar-padding-block',
 								default: '#{$token-scale-400}',
 								kind: 'spacing',
 								chain: 'token',
 								hint: '#{$token-scale-400}',
+							},
+							{
+								name: '--osui-sidebar-padding-inline',
+								default: '#{$token-scale-600}',
+								kind: 'spacing',
+								chain: 'token',
+								hint: '#{$token-scale-600}',
 							},
 							{
 								name: '--osui-sidebar-shadow',
@@ -4671,13 +4657,6 @@ export const CSS_API_MANIFEST: CssApiManifest = {
 								kind: 'color',
 								chain: 'theme-role',
 								hint: 'var(--color-text)',
-							},
-							{
-								name: '--osui-badge-primary-color',
-								default: '#{$token-text-primary}',
-								kind: 'color',
-								chain: 'token',
-								hint: '#{$token-text-primary}',
 							},
 						],
 					},

--- a/stories/_helpers/theme-roles.ts
+++ b/stories/_helpers/theme-roles.ts
@@ -96,6 +96,8 @@ export const THEME_ROLE_GROUPS: RoleGroup[] = [
 		['--color-text-subtlest', 'Subtlest'],
 		['--color-text-disabled', 'Disabled'],
 		['--color-text-inverse', 'Inverse (on bold bg)'],
+		['--color-text-light', 'Light (always white)'],
+		['--color-text-dark', 'Dark (always near-black)'],
 	]),
 	group({ id: 'border', title: 'Borders', type: 'color' }, [
 		['--color-border', 'Default'],


### PR DESCRIPTION
This PR is for introducing fixed light and dark text theme roles and applying them to components that previously used adaptive inverse or default text.

### What was happening
* Figma defines fixed `text.light` and `text.dark` tokens (always white and near-black), separate from adaptive `text.inverse`.
* Several components used `--color-text-inverse` or `--color-text` where Figma specifies the fixed light or dark tokens.
* Badge, Tag, and User Avatar had no explicit text-color rules for primary/blue/green/red on bold backgrounds, and yellow/warning still used the generic on-light text color.

### What was done
* Added `--color-text-light` and `--color-text-dark` to the theme layer in `_root.scss`, backed by `$token-text-light` and `$token-text-dark`.
* Registered both roles in the Theme Editor (`theme-roles.ts`).
* Badge, Tag, and User Avatar: explicit rules for `background-primary`, `-blue`, `-green`, and `-red` → `var(--color-text-light)`; `background-secondary` → semantic primary text color; `background-yellow` / `-warning` → `var(--color-text-dark)` instead of on-light text.
* Button: primary, success, and error label colors `--color-text-inverse` → `var(--color-text-light)`.
* Alert: info, success, and error → `var(--color-text-light)`; warning → `var(--color-text-dark)` (was `var(--color-text)`).
* Card Background and Chat Message sent bubble: `--color-text-inverse` → `var(--color-text-light)`.

### Test Steps
1. Open sample app
2. Badge / Tag / User Avatar — color Primary, Blue, Green, Red (not lightest): text should be white (`--color-text-light`).
3. Badge / Tag / User Avatar — color Secondary: text should be semantic primary blue, not white.
4. Badge / Tag / User Avatar — color Yellow or Warning: text should be near-black (`--color-text-dark`).
5. Badge / Tag / User Avatar — neutrals and transparent: unchanged from before.
6. Button primary, success, error: label text white.
7. Alert info/success/error: light text; Alert warning: dark text.
8. Card Background and Chat Message sent bubble: light text on bold background.

### Screenshots
(prefer animated gif)

### Checklist
* [ ] tested locally
* [ ] documented the code
* [ ] clean all warnings and errors of eslint
* [ ] requires changes in OutSystems (if so, provide a module with changes)
* [ ] requires new sample page in OutSystems (if so, provide a module with changes)
