### PR TITLE
ROU-13020: Fixed padding for unselected dropdown

### DIFF
--- a/src/scss/04-patterns/03-interaction/dropdown/provider/_virtualselect.scss
+++ b/src/scss/04-patterns/03-interaction/dropdown/provider/_virtualselect.scss
@@ -340,7 +340,6 @@
 	height: var(--vscomp-toogle-btn-height);
 	line-height: var(--vscomp-toogle-btn-height);
 	min-width: 180px;
-	padding-block: variables.$token-scale-100;
 	padding-inline-end: variables.$token-scale-1000;
 	padding-inline-start: variables.$token-scale-400;
 	position: relative;

--- a/src/scss/04-patterns/03-interaction/dropdown/provider/_virtualselect.scss
+++ b/src/scss/04-patterns/03-interaction/dropdown/provider/_virtualselect.scss
@@ -38,6 +38,16 @@
 				}
 			}
 		}
+
+		.vscomp-wrapper.show-value-as-tags:not(.has-value) .vscomp-toggle-button {
+			padding-block: 0;
+			padding-inline-end: 54px;
+			padding-inline-start: variables.$token-scale-400;
+		}
+
+		.vscomp-wrapper.show-value-as-tags:not(.has-value) .vscomp-value {
+			padding-block-end: 0;
+		}
 	}
 
 	&-ele .vscomp-clear-icon:after,
@@ -95,6 +105,12 @@
 	}
 
 	&:not(.has-value) {
+		.vscomp-toggle-button {
+			padding-block: 0;
+			padding-inline-end: 54px;
+			padding-inline-start: variables.$token-scale-400;
+		}
+
 		.vscomp-value {
 			color: var(--color-text-subtlest);
 			opacity: 1;

--- a/src/scss/04-patterns/03-interaction/dropdown/provider/_virtualselect_lib.scss
+++ b/src/scss/04-patterns/03-interaction/dropdown/provider/_virtualselect_lib.scss
@@ -45,6 +45,7 @@
 	border: 1px solid #ddd;
 	cursor: pointer;
 	display: flex;
+	padding: 7px 30px 7px 10px;
 	position: relative;
 	width: 100%;
 }
@@ -432,7 +433,7 @@
 .vscomp-wrapper.has-clear-button.has-value .vscomp-clear-button {
 	display: flex;
 }
-.vscomp-wrapper.has-clear-button:not(.text-direction-rtl) .vscomp-toggle-button {
+.vscomp-wrapper.has-clear-button .vscomp-toggle-button {
 	padding-right: 54px;
 }
 .vscomp-wrapper.has-no-options .vscomp-options-container,
@@ -490,6 +491,9 @@
 .vscomp-wrapper.has-error ~ .vscomp-error-message {
 	display: flex;
 }
+.vscomp-wrapper.show-value-as-tags .vscomp-toggle-button {
+	padding: 4px 22px 0 10px;
+}
 .vscomp-wrapper.show-value-as-tags .vscomp-value {
 	display: flex;
 	flex-wrap: wrap;
@@ -545,8 +549,12 @@
 .vscomp-wrapper.show-value-as-tags.has-value .vscomp-clear-button {
 	right: 2px;
 }
+.vscomp-wrapper.show-value-as-tags:not(.has-value) .vscomp-toggle-button {
+	padding-bottom: 2px;
+}
 .vscomp-wrapper.show-value-as-tags:not(.has-value) .vscomp-value {
 	align-items: center;
+	padding-bottom: 3px;
 }
 @media (prefers-reduced-motion: reduce) {
 	.vscomp-dropbox-container,
@@ -558,6 +566,9 @@
 }
 .vscomp-wrapper.text-direction-rtl {
 	direction: rtl;
+}
+.vscomp-wrapper.text-direction-rtl .vscomp-toggle-button {
+	padding: 7px 10px 7px 30px;
 }
 .vscomp-wrapper.text-direction-rtl .vscomp-arrow {
 	left: 0;
@@ -609,6 +620,9 @@
 }
 .vscomp-wrapper.text-direction-rtl.keep-always-open .vscomp-clear-button {
 	left: 5px;
+}
+.vscomp-wrapper.text-direction-rtl.show-value-as-tags .vscomp-toggle-button {
+	padding: 4px 10px 0 22px;
 }
 .vscomp-wrapper.text-direction-rtl.show-value-as-tags .vscomp-value-tag {
 	margin: 0 0 4px 4px;

--- a/src/scss/04-patterns/03-interaction/dropdown/provider/_virtualselect_lib.scss
+++ b/src/scss/04-patterns/03-interaction/dropdown/provider/_virtualselect_lib.scss
@@ -45,7 +45,6 @@
 	border: 1px solid #ddd;
 	cursor: pointer;
 	display: flex;
-	padding: 7px 30px 7px 10px;
 	position: relative;
 	width: 100%;
 }
@@ -433,7 +432,7 @@
 .vscomp-wrapper.has-clear-button.has-value .vscomp-clear-button {
 	display: flex;
 }
-.vscomp-wrapper.has-clear-button .vscomp-toggle-button {
+.vscomp-wrapper.has-clear-button:not(.text-direction-rtl) .vscomp-toggle-button {
 	padding-right: 54px;
 }
 .vscomp-wrapper.has-no-options .vscomp-options-container,
@@ -491,9 +490,6 @@
 .vscomp-wrapper.has-error ~ .vscomp-error-message {
 	display: flex;
 }
-.vscomp-wrapper.show-value-as-tags .vscomp-toggle-button {
-	padding: 4px 22px 0 10px;
-}
 .vscomp-wrapper.show-value-as-tags .vscomp-value {
 	display: flex;
 	flex-wrap: wrap;
@@ -549,12 +545,8 @@
 .vscomp-wrapper.show-value-as-tags.has-value .vscomp-clear-button {
 	right: 2px;
 }
-.vscomp-wrapper.show-value-as-tags:not(.has-value) .vscomp-toggle-button {
-	padding-bottom: 2px;
-}
 .vscomp-wrapper.show-value-as-tags:not(.has-value) .vscomp-value {
 	align-items: center;
-	padding-bottom: 3px;
 }
 @media (prefers-reduced-motion: reduce) {
 	.vscomp-dropbox-container,
@@ -566,9 +558,6 @@
 }
 .vscomp-wrapper.text-direction-rtl {
 	direction: rtl;
-}
-.vscomp-wrapper.text-direction-rtl .vscomp-toggle-button {
-	padding: 7px 10px 7px 30px;
 }
 .vscomp-wrapper.text-direction-rtl .vscomp-arrow {
 	left: 0;
@@ -620,9 +609,6 @@
 }
 .vscomp-wrapper.text-direction-rtl.keep-always-open .vscomp-clear-button {
 	left: 5px;
-}
-.vscomp-wrapper.text-direction-rtl.show-value-as-tags .vscomp-toggle-button {
-	padding: 4px 10px 0 22px;
 }
 .vscomp-wrapper.text-direction-rtl.show-value-as-tags .vscomp-value-tag {
 	margin: 0 0 4px 4px;


### PR DESCRIPTION
This PR fixes dropdown toggle padding so unselected VirtualSelect dropdowns align correctly in LTR and RTL.

### What was happening
* The VirtualSelect vendor styles applied hardcoded `padding` on `.vscomp-toggle-button`, which conflicted with OSUI token-based spacing.
* The clear-button LTR rule (`padding-right: 54px`) also applied in RTL, where a separate `padding-left` rule is expected.
* Extra `padding-block` on the OSUI toggle button compounded the misalignment for unselected dropdowns.

### What was done
* Removed vendor hardcoded toggle padding from `_virtualselect_lib.scss` (default, RTL, and show-value-as-tags variants).
* Scoped the clear-button padding rule to LTR only: `.has-clear-button:not(.text-direction-rtl)`.
* Removed `padding-block` from the OSUI toggle button in `_virtualselect.scss`.

### Test Steps
1. Open a screen with a Dropdown (VirtualSelect) without a selected value.
2. Verify toggle height and horizontal padding look correct in LTR.
3. Switch the app to RTL and repeat — clear-button spacing should use `padding-left`, not `padding-right`.
4. Test dropdowns with clear button enabled, with tags mode, and with a selected value.
5. Confirm no visual regression for keep-always-open dropdowns.

### Screenshots
(prefer animated gif)

### Checklist
* [ ] tested locally
* [ ] documented the code
* [ ] clean all warnings and errors of eslint
* [ ] requires changes in OutSystems (if so, provide a module with changes)
* [ ] requires new sample page in OutSystems (if so, provide a module with changes)
