### PR TITLE
ROU-13025: Align Accordion with new theme rules

### DIFF
--- a/src/scss/04-patterns/02-content/accordion-item/_accordion-item.scss
+++ b/src/scss/04-patterns/02-content/accordion-item/_accordion-item.scss
@@ -21,7 +21,7 @@
 	--osui-accordion-item-active-indicator-color: var(--color-primary);
 	--osui-accordion-item-icon-color: #{variables.$token-icon-subtle};
 	--osui-accordion-item-title-hover-background: #{variables.$token-bg-neutral-subtlest-hover};
-	--osui-accordion-item-title-hover-border-color: #{variables.$token-border-default};
+	--osui-accordion-item-title-hover-border-color: var(--osui-accordion-item-border-color);
 	--accordion-active-border-size: #{variables.$token-border-size-050};
 	// ───────────────────────────────────────────────────────────────────
 
@@ -48,13 +48,6 @@
 	&--is {
 		&-open {
 			> .osui-accordion-item__title {
-				font-weight: variables.$token-font-weight-semi-bold;
-
-				&:hover {
-					box-shadow: inset 0 calc(-1 * var(--osui-accordion-item-border-width)) 0 0
-						var(--osui-accordion-item-title-hover-border-color);
-				}
-
 				> .osui-accordion-item__icon {
 					&--caret {
 						transform: rotate(180deg);
@@ -158,20 +151,43 @@
 		width: variables.$token-scale-500;
 
 		&--plus-minus {
+			//Using tokens to set the height and width of the plus/minus icon doesn't make sence,
+			// since it would change the size of the icon if tokens values change.
 			&:after {
 				background-color: var(--osui-accordion-item-icon-color);
 				content: ' ';
-				height: 100%;
+				height: 20px;
 				transition: transform variables.$token-transition-time-300 variables.$token-transition-curve-expressive;
 				width: variables.$token-border-size-050;
 			}
-
+			//Using tokens to set the height and width of the plus/minus icon doesn't make sense,
+			// since it would change the size of the icon if tokens values change.
 			&:before {
 				background-color: var(--osui-accordion-item-icon-color);
 				content: ' ';
 				height: variables.$token-border-size-050;
 				position: absolute;
 				width: variables.$token-scale-500;
+			}
+
+			// Font Awesome bars are visually heavier — round the bar caps and scale the bars only
+			// (not the icon box) so layout size stays on $token-scale-500.
+			// Gated by the ODC icon-library root class (see _icon-library-odc.scss); inert on O11.
+			:root.iconLibrary-phosphor &,
+			body.iconLibrary-phosphor & {
+				&:before,
+				&:after {
+					border-radius: 8px;
+					transform: scale(0.75);
+				}
+			}
+
+			// Open :after needs both transforms — a later rotate-only rule would drop scale(0.75).
+			:root.iconLibrary-phosphor .osui-accordion-item--is-open > .osui-accordion-item__title > &,
+			body.iconLibrary-phosphor .osui-accordion-item--is-open > .osui-accordion-item__title > & {
+				&:after {
+					transform: scale(0.75) rotate(90deg);
+				}
 			}
 		}
 
@@ -221,7 +237,7 @@
 		}
 
 		& > div {
-			padding-block-start: variables.$token-scale-300;
+			padding-block-start: variables.$token-scale-200;
 		}
 
 		/* Add a margin-top when animated label is the first child */
@@ -297,4 +313,3 @@
 		}
 	}
 }
-

--- a/src/scss/04-patterns/02-content/accordion-item/_accordion-item.scss
+++ b/src/scss/04-patterns/02-content/accordion-item/_accordion-item.scss
@@ -22,6 +22,9 @@
 	--osui-accordion-item-icon-color: #{variables.$token-icon-subtle};
 	--osui-accordion-item-title-hover-background: #{variables.$token-bg-neutral-subtlest-hover};
 	--osui-accordion-item-title-hover-border-color: var(--osui-accordion-item-border-color);
+	//Using tokens to set the height and width of the plus/minus icon doesn't make sense,
+	// since it would change the size of the icon if tokens values change.
+	--osui-accordion-item-plus-minus-size: 20px;
 	--accordion-active-border-size: #{variables.$token-border-size-050};
 	// ───────────────────────────────────────────────────────────────────
 
@@ -151,23 +154,20 @@
 		width: variables.$token-scale-500;
 
 		&--plus-minus {
-			//Using tokens to set the height and width of the plus/minus icon doesn't make sence,
-			// since it would change the size of the icon if tokens values change.
 			&:after {
 				background-color: var(--osui-accordion-item-icon-color);
 				content: ' ';
-				height: 20px;
+				height: var(--osui-accordion-item-plus-minus-size);
 				transition: transform variables.$token-transition-time-300 variables.$token-transition-curve-expressive;
 				width: variables.$token-border-size-050;
 			}
-			//Using tokens to set the height and width of the plus/minus icon doesn't make sense,
-			// since it would change the size of the icon if tokens values change.
+
 			&:before {
 				background-color: var(--osui-accordion-item-icon-color);
 				content: ' ';
 				height: variables.$token-border-size-050;
 				position: absolute;
-				width: variables.$token-scale-500;
+				width: var(--osui-accordion-item-plus-minus-size);
 			}
 
 			// Font Awesome bars are visually heavier — round the bar caps and scale the bars only
@@ -177,7 +177,7 @@
 			body.iconLibrary-phosphor & {
 				&:before,
 				&:after {
-					border-radius: 8px;
+					border-radius: variables.$token-border-radius-200;
 					transform: scale(0.75);
 				}
 			}

--- a/stories/_helpers/css-api-manifest.ts
+++ b/stories/_helpers/css-api-manifest.ts
@@ -39,9 +39,9 @@ export type CssApiManifest = {
 };
 
 export const CSS_API_MANIFEST: CssApiManifest = {
-	generatedAt: '2026-09-03T14:04:18.913Z',
+	generatedAt: '2026-09-03T15:34:10.011Z',
 	totals: {
-		properties: 544,
+		properties: 545,
 		components: 63,
 		categories: 9,
 	},
@@ -1952,6 +1952,13 @@ export const CSS_API_MANIFEST: CssApiManifest = {
 								kind: 'color',
 								chain: 'token',
 								hint: '#{$token-icon-subtle}',
+							},
+							{
+								name: '--osui-accordion-item-plus-minus-size',
+								default: '20px',
+								kind: 'spacing',
+								chain: 'literal',
+								hint: '20px',
 							},
 							{
 								name: '--osui-accordion-item-title-hover-background',

--- a/stories/_helpers/css-api-manifest.ts
+++ b/stories/_helpers/css-api-manifest.ts
@@ -39,9 +39,9 @@ export type CssApiManifest = {
 };
 
 export const CSS_API_MANIFEST: CssApiManifest = {
-	generatedAt: '2026-09-02T09:35:17.634Z',
+	generatedAt: '2026-09-03T14:04:18.913Z',
 	totals: {
-		properties: 543,
+		properties: 544,
 		components: 63,
 		categories: 9,
 	},
@@ -1962,10 +1962,10 @@ export const CSS_API_MANIFEST: CssApiManifest = {
 							},
 							{
 								name: '--osui-accordion-item-title-hover-border-color',
-								default: '#{$token-border-default}',
+								default: 'var(--osui-accordion-item-border-color)',
 								kind: 'color',
-								chain: 'token',
-								hint: '#{$token-border-default}',
+								chain: 'theme-role',
+								hint: 'var(--osui-accordion-item-border-color)',
 							},
 						],
 					},


### PR DESCRIPTION
This PR is for aligning Accordion and AccordionItem styles with the new theme rules.

### What was happening
* Accordion item hover showed a darker bottom divider border and an inset bottom border on open title hover.
* Plus/minus icon bars used token-based sizing that did not match the intended visual weight.
* Phosphor icon library plus/minus bars looked heavier than the caret.
* Accordion padding was not in accordance with the design.

### What was done
* Set `--osui-accordion-item-title-hover-border-color` to match the default border color so hover no longer darkens dividers.
* Removed open-title hover inset box-shadow and semi-bold weight.
* Fixed plus/minus bar dimensions with explicit pixel sizing for the vertical bar.
* Added Phosphor-only plus/minus tweaks: 8px bar cap radius and `scale(0.75)`.
* Reduced accordion content top padding from `$token-scale-300` to `$token-scale-200`.
* Regenerated CSS API manifest for accordion item hover border color.

### Test Steps
1. Open Storybook Accordion story with Icon set to PlusMinus.
2. Toggle Icons toolbar between FontAwesome and Phosphor — verify plus/minus appearance in both libraries.
3. Hover closed and open items — confirm background hover works with no extra border emphasis.
4. Expand/collapse items — confirm plus rotates to minus smoothly in Phosphor mode.
5. Validate when opened that the content padding to top is now 8px.

### Checklist
* [ ] tested locally
* [ ] documented the code
* [ ] clean all warnings and errors of eslint
* [ ] requires changes in OutSystems (if so, provide a module with changes)
* [ ] requires new sample page in OutSystems (if so, provide a module with changes)
