### PR TITLE
ROU-13005: Adding font Inter font-family to defintion of font in the html

### DIFF
--- a/src/scss/01-foundations/_resets.scss
+++ b/src/scss/01-foundations/_resets.scss
@@ -36,20 +36,7 @@
 /* ============================================================================ */
 html {
 	color: var(--color-text);
-	font-family: var(
-		--token-font-family,
-		Inter,
-		-apple-system,
-		system-ui,
-		'Segoe UI',
-		Roboto,
-		Helvetica,
-		Arial,
-		sans-serif,
-		'Apple Color Emoji',
-		'Segoe UI Emoji',
-		'Segoe UI Symbol'
-	);
+	font-family: variables.$token-font-family;
 	-moz-osx-font-smoothing: grayscale;
 	-webkit-font-smoothing: antialiased;
 	overflow: hidden;

--- a/src/scss/01-foundations/_resets.scss
+++ b/src/scss/01-foundations/_resets.scss
@@ -36,8 +36,20 @@
 /* ============================================================================ */
 html {
 	color: var(--color-text);
-	font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif,
-		'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol';
+	font-family: var(
+		--token-font-family,
+		Inter,
+		-apple-system,
+		system-ui,
+		'Segoe UI',
+		Roboto,
+		Helvetica,
+		Arial,
+		sans-serif,
+		'Apple Color Emoji',
+		'Segoe UI Emoji',
+		'Segoe UI Symbol'
+	);
 	-moz-osx-font-smoothing: grayscale;
 	-webkit-font-smoothing: antialiased;
 	overflow: hidden;


### PR DESCRIPTION
This PR is to add the usage of the css variable `--token-font-family`, to the `html` element, allowing the quick override for the developer, but also to add the `Inter` font as the default font family of the theme.

### What was happening
- The theme was not making use of the token to the font-family for the html;
- The default font was not aligned with the design of the new theme;

### What was done
- Replaced the definition of the font-family in the `html`, to first use the css variable `--token-font-family`;
- Added `Inter` as the default font;

### Test Steps
1. Go to sample screen;
2. Validate the font being displayed;

### Checklist
-   [x] tested locally
-   [ ] documented the code
-   [x] clean all warnings and errors of eslint
-   [ ] requires changes in OutSystems (if so, provide a module with changes)
-   [ ] requires new sample page in OutSystems (if so, provide a module with changes)
