### PR TITLE
ROU-13031: Use default line-height on tags

### DIFF
--- a/src/scss/04-patterns/02-content/_tag.scss
+++ b/src/scss/04-patterns/02-content/_tag.scss
@@ -41,7 +41,7 @@ $osui-tag-lightest-text-colors: (
 	font-weight: variables.$token-font-weight-medium;
 	gap: variables.$token-space-200;
 	justify-content: center;
-	line-height: var(--osui-font-line-height-full);
+	line-height: normal;
 	min-height: variables.$token-scale-500;
 	min-width: unset;
 	padding-block: variables.$token-space-0;


### PR DESCRIPTION
This PR is for keeping Tag at its min-height instead of growing from inherited body line-height.

### What was happening
* `.tag` used `line-height: var(--osui-font-line-height-full)`, and the default size rendered taller than the 20px min-height.

### What was done
* Set `line-height: normal` on `.tag` so the line box follows the tag font-size instead of the body leading.
* Height is then controlled by `min-height` (20px default, 16px small, 28px medium).

### Test Steps
1. Open sample app
2. Check the default size (no size class): the tag should be 20px tall, not ~28px.
3. Switch Size to small: the tag should be 16px tall.
4. Switch Size to medium: the tag should be 28px tall.
5. Confirm the label is still readable and vertically centered for each size, including IsLight and shape variants.

### Screenshots
(prefer animated gif)

### Checklist
* [ ] tested locally
* [ ] documented the code
* [ ] clean all warnings and errors of eslint
* [ ] requires changes in OutSystems (if so, provide a module with changes)
* [ ] requires new sample page in OutSystems (if so, provide a module with changes)
