### PR TITLE
ROU-13027: Apply new theme styles to timeline

### DIFF
--- a/src/scss/04-patterns/04-navigation/_timeline.scss
+++ b/src/scss/04-patterns/04-navigation/_timeline.scss
@@ -7,26 +7,25 @@
 
 ///
 .timeline {
-	// ─── Component CSS API ─────────────────────────────────────────────
-	--osui-timeline-content-gap: #{variables.$token-space-100};
-	--osui-timeline-content-spacing: #{variables.$token-space-600};
-	--osui-timeline-font-size: #{variables.$token-font-size-350};
-	--osui-timeline-gap: #{variables.$token-space-200};
-	--osui-timeline-gutter: #{variables.$token-space-400};
-	--osui-timeline-icon-color: var(--color-text-inverse);
-	--osui-timeline-icon-size: #{variables.$token-scale-600};
-	--osui-timeline-line-color: var(--color-border);
-	// Figma says 21px; the scale's nearest step is 20px.
-	--osui-timeline-line-height: #{variables.$token-font-line-height-500};
-	--osui-timeline-text-color: var(--color-text-subtlest);
-	--osui-timeline-title-color: var(--color-text);
-	--osui-timeline-title-font-weight: #{variables.$token-font-weight-medium};
-	// ───────────────────────────────────────────────────────────────────
-
-	display: flex;
-	flex-direction: column;
-
+	// CSS API lives on the item: the platform TimelineItem block has no `.timeline` wrapper.
 	&-item {
+		// ─── Component CSS API ─────────────────────────────────────────────
+		--osui-timeline-content-gap: #{variables.$token-space-100};
+		--osui-timeline-content-spacing: #{variables.$token-space-600};
+		--osui-timeline-font-size: #{variables.$token-font-size-350};
+		--osui-timeline-gap: #{variables.$token-space-200};
+		--osui-timeline-gutter: #{variables.$token-space-400};
+		--osui-timeline-icon-color: var(--color-text-inverse);
+		--osui-timeline-icon-size: #{variables.$token-scale-600};
+		--osui-timeline-icon-background-color: #{variables.$token-bg-neutral-bold-default};
+		--osui-timeline-line-color: var(--color-border);
+		// Figma says 21px; the scale's nearest step is 20px.
+		--osui-timeline-line-height: #{variables.$token-font-line-height-500};
+		--osui-timeline-text-color: var(--color-text-subtlest);
+		--osui-timeline-title-color: var(--color-text);
+		--osui-timeline-title-font-weight: #{variables.$token-font-weight-medium};
+		// ───────────────────────────────────────────────────────────────────
+
 		display: flex;
 		font-size: var(--osui-timeline-font-size);
 		justify-content: space-between;
@@ -72,7 +71,8 @@
 			margin-block: variables.$token-space-0;
 			margin-inline: var(--osui-timeline-gutter);
 			text-align: center;
-			width: var(--osui-timeline-icon-size);
+			width: var(--osui-timeline-icon-size, #{variables.$token-scale-600});
+			background-color: var(--osui-timeline-icon-background-color);
 
 			&:empty {
 				height: variables.$token-scale-200; // 8px dot
@@ -93,7 +93,7 @@
 		white-space: nowrap;
 	}
 
-	.timeline-item .timeline-content .timeline-content-inner {
+	&-content-inner {
 		margin: 0;
 		padding: 0;
 	}


### PR DESCRIPTION
This PR is for aligning Timeline with the new theme and fixing CSS API variables that never reached the platform markup.

### What was happening
* The Timeline CSS API was declared on `.timeline`, but the platform TimelineItem block has no `.timeline` wrapper, so `--osui-timeline-*` never inherited onto the icon circle, text, or spacing.
* Unused `display: flex` / `flex-direction: column` on `.timeline` had no effect in the real DOM.

### What was done
* Moved the component CSS API onto `.timeline-item`, the actual root of each TimelineItem block.
* Removed the unused flex layout on `.timeline`.
* Added `--osui-timeline-icon-background-color` and a token fallback on icon width.
* Simplified the `.timeline-content-inner` reset so it no longer depends on a `.timeline` ancestor.

### Test Steps
1. Open a page with TimelineItem blocks and no `.timeline` wrapper.
2. Confirm each icon circle is 24px and uses the theme background, colour, and gutter.
3. Confirm title, description, left, and right text pick up the theme tokens.
4. Confirm the last item hides the connector line.
5. Place an icon in the circle and confirm it still sits inside the 24px box.

### Screenshots
(prefer animated gif)

### Checklist
* [ ] tested locally
* [ ] documented the code
* [ ] clean all warnings and errors of eslint
* [ ] requires changes in OutSystems (if so, provide a module with changes)
* [ ] requires new sample page in OutSystems (if so, provide a module with changes)
