### PR TITLE
ROU-12714: Update secondary colors for Tag, User Avatar, Badge, and Icon Badge

### DIFF
--- a/src/scss/04-patterns/02-content/_tag.scss
+++ b/src/scss/04-patterns/02-content/_tag.scss
@@ -149,7 +149,7 @@ $osui-tag-lightest-text-colors: (
 
 		&-secondary {
 			background-color: variables.$token-bg-neutral-base-default;
-			--osui-tag-color: var(--color-primary);
+			--osui-tag-color: #{variables.$token-text-primary};
 		}
 
 		&-primary,

--- a/src/scss/04-patterns/02-content/_tag.scss
+++ b/src/scss/04-patterns/02-content/_tag.scss
@@ -148,7 +148,8 @@ $osui-tag-lightest-text-colors: (
 		}
 
 		&-secondary {
-			--osui-tag-color: var(--color-primary);
+			background-color: variables.$token-bg-neutral-base-default;
+			color: variables.$token-text-primary;
 		}
 
 		&-primary,
@@ -185,8 +186,8 @@ $osui-tag-lightest-text-colors: (
 	}
 
 	&.background-secondary-lightest {
-		background-color: variables.$token-bg-neutral-base-default;
-		color: var(--osui-tag-on-light-color);
+		background-color: variables.$token-bg-neutral-subtle-default;
+		color: variables.$token-text-primary;
 	}
 
 	// Extended palette IsLight=true — background comes from the token-backed

--- a/src/scss/04-patterns/02-content/_tag.scss
+++ b/src/scss/04-patterns/02-content/_tag.scss
@@ -149,7 +149,7 @@ $osui-tag-lightest-text-colors: (
 
 		&-secondary {
 			background-color: variables.$token-bg-neutral-base-default;
-			color: variables.$token-text-primary;
+			--osui-tag-color: var(--color-primary);
 		}
 
 		&-primary,
@@ -187,7 +187,8 @@ $osui-tag-lightest-text-colors: (
 
 	&.background-secondary-lightest {
 		background-color: variables.$token-bg-neutral-subtle-default;
-		color: variables.$token-text-primary;
+		--osui-tag-on-light-color: #{variables.$token-text-primary};
+		color: var(--osui-tag-on-light-color);
 	}
 
 	// Extended palette IsLight=true — background comes from the token-backed

--- a/src/scss/04-patterns/02-content/_user-avatar.scss
+++ b/src/scss/04-patterns/02-content/_user-avatar.scss
@@ -121,7 +121,7 @@ $osui-avatar-lightest-text-colors: (
 
 		&-secondary {
 			background-color: variables.$token-bg-neutral-base-default;
-			color: variables.$token-text-primary;
+			--osui-avatar-color: var(--color-primary);
 		}
 
 		&-primary,
@@ -160,7 +160,8 @@ $osui-avatar-lightest-text-colors: (
 
 	&.background-secondary-lightest {
 		background-color: variables.$token-bg-neutral-subtle-default;
-		color: variables.$token-text-primary;
+		--osui-avatar-on-light-color: #{variables.$token-text-primary};
+		color: var(--osui-avatar-on-light-color);
 	}
 
 	// Extended palette IsLight=true — background comes from the token-backed

--- a/src/scss/04-patterns/02-content/_user-avatar.scss
+++ b/src/scss/04-patterns/02-content/_user-avatar.scss
@@ -120,7 +120,8 @@ $osui-avatar-lightest-text-colors: (
 		}
 
 		&-secondary {
-			--osui-avatar-color: var(--color-primary);
+			background-color: variables.$token-bg-neutral-base-default;
+			color: variables.$token-text-primary;
 		}
 
 		&-primary,
@@ -158,8 +159,8 @@ $osui-avatar-lightest-text-colors: (
 	}
 
 	&.background-secondary-lightest {
-		background-color: variables.$token-bg-neutral-base-default;
-		color: var(--osui-avatar-on-light-color);
+		background-color: variables.$token-bg-neutral-subtle-default;
+		color: variables.$token-text-primary;
 	}
 
 	// Extended palette IsLight=true — background comes from the token-backed

--- a/src/scss/04-patterns/02-content/_user-avatar.scss
+++ b/src/scss/04-patterns/02-content/_user-avatar.scss
@@ -121,7 +121,7 @@ $osui-avatar-lightest-text-colors: (
 
 		&-secondary {
 			background-color: variables.$token-bg-neutral-base-default;
-			--osui-avatar-color: var(--color-primary);
+			--osui-avatar-color: #{variables.$token-text-primary};
 		}
 
 		&-primary,

--- a/src/scss/04-patterns/05-numbers/_badge.scss
+++ b/src/scss/04-patterns/05-numbers/_badge.scss
@@ -97,7 +97,7 @@ $osui-badge-lightest-text-colors: (
 
 		&-secondary {
 			background-color: variables.$token-bg-neutral-base-default;
-			color: variables.$token-text-primary;
+			--osui-badge-color: var(--color-primary);
 		}
 
 		&-primary,
@@ -141,7 +141,8 @@ $osui-badge-lightest-text-colors: (
 
 	&.background-secondary-lightest {
 		background-color: #{variables.$token-bg-neutral-subtle-default};
-		color: variables.$token-text-primary;
+		--osui-badge-on-light-color: #{variables.$token-text-primary};
+		color: var(--osui-badge-on-light-color);
 	}
 
 	&.background-transparent-lightest {

--- a/src/scss/04-patterns/05-numbers/_badge.scss
+++ b/src/scss/04-patterns/05-numbers/_badge.scss
@@ -97,7 +97,7 @@ $osui-badge-lightest-text-colors: (
 
 		&-secondary {
 			background-color: variables.$token-bg-neutral-base-default;
-			--osui-badge-color: var(--color-primary);
+			--osui-badge-color: #{variables.$token-text-primary};
 		}
 
 		&-primary,

--- a/src/scss/04-patterns/05-numbers/_badge.scss
+++ b/src/scss/04-patterns/05-numbers/_badge.scss
@@ -96,7 +96,8 @@ $osui-badge-lightest-text-colors: (
 		}
 
 		&-secondary {
-			--osui-badge-color: var(--color-primary);
+			background-color: variables.$token-bg-neutral-base-default;
+			color: variables.$token-text-primary;
 		}
 
 		&-primary,
@@ -139,8 +140,8 @@ $osui-badge-lightest-text-colors: (
 	}
 
 	&.background-secondary-lightest {
-		background-color: #{variables.$token-bg-neutral-base-default};
-		color: var(--osui-badge-on-light-color);
+		background-color: #{variables.$token-bg-neutral-subtle-default};
+		color: variables.$token-text-primary;
 	}
 
 	&.background-transparent-lightest {


### PR DESCRIPTION
This PR is for updating the secondary colors for the Tag, User Avatar, Badge, and Icon Badge widgets to match the [designs in Figma](https://www.figma.com/design/mMqGdwjw4xuQv2shvFVNMB/OutSystems-UI-v3.0.0?node-id=0-6&p=f&m=dev). 

**Note:** The color and background color for the Icon Badge is inherited from the Badge.

[Sample page](https://outsystemsui-dev.outsystemsenterprise.com/TaskSample_DEV_ROU13021/TestScreen1?_ts=639245624416995900)

### Checklist

-   [ ] tested locally
-   [ ] documented the code
-   [ ] clean all warnings and errors of eslint
-   [ ] requires changes in OutSystems (if so, provide a module with changes)
-   [ ] requires new sample page in OutSystems (if so, provide a module with changes)