### PR TITLE
ROU-13022: Align pagination selected item with Figma

### DIFF
--- a/src/scss/04-patterns/04-navigation/_pagination.scss
+++ b/src/scss/04-patterns/04-navigation/_pagination.scss
@@ -11,11 +11,12 @@
 	--osui-pagination-button-background: transparent;
 	--osui-pagination-button-border-color: transparent;
 	--osui-pagination-button-border-width: #{variables.$token-border-size-025};
-	--osui-pagination-button-font-weight: #{variables.$token-font-weight-medium};
+	--osui-pagination-button-font-weight: #{variables.$token-font-weight-regular};
 	--osui-pagination-button-hover-background: #{variables.$token-bg-neutral-subtlest-hover};
 	--osui-pagination-button-padding: #{variables.$token-scale-0} #{variables.$token-scale-100};
 	--osui-pagination-button-size: #{variables.$token-scale-900};
 	--osui-pagination-button-text-color: var(--color-text);
+	--osui-pagination-active-background: #{variables.$token-bg-neutral-subtlest-default};
 	--osui-pagination-active-border-color: var(--color-border);
 	--osui-pagination-active-color: var(--color-text);
 	--osui-pagination-counter-color: var(--color-text-subtlest);
@@ -68,12 +69,12 @@
 			pointer-events: none;
 		}
 
-		&:focus {
-			border-color: variables.$token-semantics-primary-base;
+		&:focus-visible {
 			box-shadow: 0 0 0 variables.$token-border-size-075 color-mix(in srgb, #{variables.$token-semantics-primary-base} 22%, transparent);
 		}
 
 		&.is--active {
+			background-color: var(--osui-pagination-active-background);
 			border-color: var(--osui-pagination-active-border-color);
 			color: var(--osui-pagination-active-color);
 			cursor: auto;

--- a/stories/_helpers/css-api-manifest.ts
+++ b/stories/_helpers/css-api-manifest.ts
@@ -39,9 +39,9 @@ export type CssApiManifest = {
 };
 
 export const CSS_API_MANIFEST: CssApiManifest = {
-	generatedAt: '2026-09-11T07:43:38.138Z',
+	generatedAt: '2026-09-11T19:45:39.841Z',
 	totals: {
-		properties: 573,
+		properties: 574,
 		components: 67,
 		categories: 9,
 	},
@@ -3709,10 +3709,10 @@ export const CSS_API_MANIFEST: CssApiManifest = {
 							properties: [
 							{
 								name: '--osui-input-with-icon-icon-color',
-								default: '$token-icon-default',
+								default: '#{$token-icon-default}',
 								kind: 'color',
-								chain: 'other',
-								hint: '$token-icon-default',
+								chain: 'token',
+								hint: '#{$token-icon-default}',
 							},
 							{
 								name: '--osui-input-with-icon-icon-hover-color',
@@ -4363,6 +4363,13 @@ export const CSS_API_MANIFEST: CssApiManifest = {
 							selector: '.pagination',
 							properties: [
 							{
+								name: '--osui-pagination-active-background',
+								default: '#{$token-bg-neutral-subtlest-default}',
+								kind: 'color',
+								chain: 'token',
+								hint: '#{$token-bg-neutral-subtlest-default}',
+							},
+							{
 								name: '--osui-pagination-active-border-color',
 								default: 'var(--color-border)',
 								kind: 'color',
@@ -4406,10 +4413,10 @@ export const CSS_API_MANIFEST: CssApiManifest = {
 							},
 							{
 								name: '--osui-pagination-button-font-weight',
-								default: '#{$token-font-weight-medium}',
+								default: '#{$token-font-weight-regular}',
 								kind: 'other',
 								chain: 'token',
-								hint: '#{$token-font-weight-medium}',
+								hint: '#{$token-font-weight-regular}',
 							},
 							{
 								name: '--osui-pagination-button-hover-background',


### PR DESCRIPTION
This PR is for aligning the pagination selected item styles with the [designs](https://www.figma.com/design/mMqGdwjw4xuQv2shvFVNMB/OutSystems-UI-v3.0.0?node-id=5529-23137&t=kur7XXfLkhMmx2wA-4).

[Sample page](https://outsystemsui-dev.outsystemsenterprise.com/TaskSample_DEV_ROU13022/TestScreen1?_ts=639246595350440880)

### Test Steps

1. Validate that the pagination styles match the Figma in both light and dark themes

### Screenshots
<img width="1253" height="100" alt="Screenshot 2026-09-10 at 5 57 18 PM" src="https://github.com/user-attachments/assets/bf0f0bee-657d-4ec8-b127-183feb573a2a" />

<img width="1271" height="93" alt="Screenshot 2026-09-10 at 5 57 29 PM" src="https://github.com/user-attachments/assets/c2875536-c730-4a91-97b3-300f58a836a6" />


### Checklist

-   [ ] tested locally
-   [ ] documented the code
-   [ ] clean all warnings and errors of eslint
-   [ ] requires changes in OutSystems (if so, provide a module with changes)
-   [ ] requires new sample page in OutSystems (if so, provide a module with changes)